### PR TITLE
reportStats content can be coordinates (float)

### DIFF
--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -120,7 +120,7 @@ class ReportStatsEvent(StatsEvent):
 
     cleaning_id: str
     status: CleanJobStatus
-    rooms: Optional[List[int]]
+    content: Optional[List[int]]
 
 
 @dataclass(frozen=True)

--- a/deebot_client/messages/stats.py
+++ b/deebot_client/messages/stats.py
@@ -30,7 +30,7 @@ class ReportStats(Message):
             type=data.get("type"),
             cleaning_id=data["cid"],
             status=status,
-            rooms=[int(x) for x in data.get("content", "").split(",") if x],
+            content=[int(float(x)) for x in data.get("content", "").split(",") if x],
         )
         event_bus.notify(stats_event)
         return HandlingResult.success()


### PR DESCRIPTION
Library fix for https://github.com/DeebotUniverse/Deebot-4-Home-Assistant/issues/62

### Breaking change:

- Renamed the attribute `rooms` to `content` in the `ReportStatsEvent`. Content can be of different format, please refer to the `type` attribute