### PR TITLE
Add support for additional commands

### DIFF
--- a/deebot_client/commands/__init__.py
+++ b/deebot_client/commands/__init__.py
@@ -9,7 +9,7 @@ from .charge_state import GetChargeState
 from .clean import Clean, CleanArea, GetCleanInfo
 from .clean_count import GetCleanCount, SetCleanCount
 from .clean_logs import GetCleanLogs
-from .clean_preference import SetCleanPreference, GetCleanPreference
+from .clean_preference import GetCleanPreference, SetCleanPreference
 from .common import CommandWithHandling, CommandWithMqttP2PHandling, SetCommand
 from .continuous_cleaning import GetContinuousCleaning, SetContinuousCleaning
 from .error import GetError

--- a/deebot_client/commands/__init__.py
+++ b/deebot_client/commands/__init__.py
@@ -7,7 +7,9 @@ from .carpet import GetCarpetAutoFanBoost, SetCarpetAutoFanBoost
 from .charge import Charge
 from .charge_state import GetChargeState
 from .clean import Clean, CleanArea, GetCleanInfo
+from .clean_count import GetCleanCount, SetCleanCount
 from .clean_logs import GetCleanLogs
+from .clean_preference import SetCleanPreference, GetCleanPreference
 from .common import CommandWithHandling, CommandWithMqttP2PHandling, SetCommand
 from .continuous_cleaning import GetContinuousCleaning, SetContinuousCleaning
 from .error import GetError
@@ -40,6 +42,12 @@ _COMMANDS: list[type[CommandWithHandling]] = [
 
     GetCarpetAutoFanBoost,
     SetCarpetAutoFanBoost,
+
+    GetCleanCount,
+    SetCleanCount,
+
+    GetCleanPreference,
+    SetCleanPreference,
 
     Charge,
 

--- a/deebot_client/commands/__init__.py
+++ b/deebot_client/commands/__init__.py
@@ -26,6 +26,7 @@ from .play_sound import PlaySound
 from .pos import GetPos
 from .relocation import SetRelocationState
 from .stats import GetStats, GetTotalStats
+from .true_detect import GetTrueDetect, SetTrueDetect
 from .volume import GetVolume, SetVolume
 from .water_info import GetWaterInfo, SetWaterInfo
 
@@ -79,6 +80,9 @@ _COMMANDS: list[type[CommandWithHandling]] = [
 
     GetStats,
     GetTotalStats,
+
+    GetTrueDetect,
+    SetTrueDetect,
 
     GetVolume,
     SetVolume,

--- a/deebot_client/commands/clean_count.py
+++ b/deebot_client/commands/clean_count.py
@@ -20,9 +20,7 @@ class GetCleanCount(_NoArgsCommand):
         :return: A message response
         """
 
-        event_bus.notify(
-            CleanCountEvent(count=data["count"])
-        )
+        event_bus.notify(CleanCountEvent(count=data["count"]))
         return HandlingResult.success()
 
 

--- a/deebot_client/commands/clean_count.py
+++ b/deebot_client/commands/clean_count.py
@@ -1,3 +1,5 @@
+"""Clean count command module."""
+
 from collections.abc import Mapping
 from typing import Any
 

--- a/deebot_client/commands/clean_count.py
+++ b/deebot_client/commands/clean_count.py
@@ -1,0 +1,36 @@
+from collections.abc import Mapping
+from typing import Any
+
+from ..events import CleanCountEvent
+from ..message import HandlingResult
+from .common import EventBus, SetCommand, _NoArgsCommand
+
+
+class GetCleanCount(_NoArgsCommand):
+    """Get clean count command."""
+
+    name = "getCleanCount"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        """Handle message->body->data and notify the correct event subscribers.
+
+        :return: A message response
+        """
+
+        event_bus.notify(
+            CleanCountEvent(count=data["count"])
+        )
+        return HandlingResult.success()
+
+
+class SetCleanCount(SetCommand):
+    """Set clean count command."""
+
+    name = "setCleanCount"
+    get_command = GetCleanCount
+
+    def __init__(self, count: int, **kwargs: Mapping[str, Any]) -> None:
+        super().__init__({"count": count}, **kwargs)

--- a/deebot_client/commands/clean_preference.py
+++ b/deebot_client/commands/clean_preference.py
@@ -1,4 +1,4 @@
-"""Multimap state command module."""
+"""Clean preference command module."""
 
 from ..events import CleanPreferenceEvent
 from .common import SetEnableCommand, _GetEnableCommand

--- a/deebot_client/commands/clean_preference.py
+++ b/deebot_client/commands/clean_preference.py
@@ -1,0 +1,18 @@
+"""Multimap state command module."""
+
+from ..events import CleanPreferenceEvent
+from .common import SetEnableCommand, _GetEnableCommand
+
+
+class GetCleanPreference(_GetEnableCommand):
+    """Get clean preference command."""
+
+    name = "getCleanPreference"
+    event_type = CleanPreferenceEvent
+
+
+class SetCleanPreference(SetEnableCommand):
+    """Set clean preference command."""
+
+    name = "setCleanPreference"
+    get_command = GetCleanPreference

--- a/deebot_client/commands/true_detect.py
+++ b/deebot_client/commands/true_detect.py
@@ -1,0 +1,18 @@
+"""Multimap state command module."""
+
+from ..events import TrueDetectEvent
+from .common import SetEnableCommand, _GetEnableCommand
+
+
+class GetTrueDetect(_GetEnableCommand):
+    """Get multimap state command."""
+
+    name = "getTrueDetect"
+    event_type = TrueDetectEvent
+
+
+class SetTrueDetect(SetEnableCommand):
+    """Set multimap state command."""
+
+    name = "setTrueDetect"
+    get_command = GetTrueDetect

--- a/deebot_client/commands/true_detect.py
+++ b/deebot_client/commands/true_detect.py
@@ -1,4 +1,4 @@
-"""Multimap state command module."""
+"""True detect command module."""
 
 from ..events import TrueDetectEvent
 from .common import SetEnableCommand, _GetEnableCommand

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -175,6 +175,7 @@ class CarpetAutoFanBoostEvent(EnableEvent):
 class MultimapStateEvent(EnableEvent):
     """Multimap state event."""
 
+
 @dataclass(frozen=True)
 class TrueDetectEvent(EnableEvent):
     """TrueDetect state event."""

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -59,6 +59,13 @@ class CleanLogEvent(Event):
 
 
 @dataclass(frozen=True)
+class CleanCountEvent(Event):
+    """Clean count event representation."""
+
+    count: int
+
+
+@dataclass(frozen=True)
 class CustomCommandEvent(Event):
     """Custom command event representation."""
 
@@ -172,10 +179,15 @@ class CarpetAutoFanBoostEvent(EnableEvent):
 
 
 @dataclass(frozen=True)
+class CleanPreferenceEvent(EnableEvent):
+    """CleanPreference event."""
+
+
+@dataclass(frozen=True)
 class MultimapStateEvent(EnableEvent):
     """Multimap state event."""
 
 
 @dataclass(frozen=True)
 class TrueDetectEvent(EnableEvent):
-    """TrueDetect state event."""
+    """TrueDetect event."""

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -174,3 +174,7 @@ class CarpetAutoFanBoostEvent(EnableEvent):
 @dataclass(frozen=True)
 class MultimapStateEvent(EnableEvent):
     """Multimap state event."""
+
+@dataclass(frozen=True)
+class TrueDetectEvent(EnableEvent):
+    """TrueDetect state event."""

--- a/deebot_client/events/const.py
+++ b/deebot_client/events/const.py
@@ -8,8 +8,10 @@ from ..commands import (
     GetCachedMapInfo,
     GetCarpetAutoFanBoost,
     GetChargeState,
+    GetCleanCount,
     GetCleanInfo,
     GetCleanLogs,
+    GetCleanPreference,
     GetContinuousCleaning,
     GetError,
     GetFanSpeed,
@@ -22,13 +24,15 @@ from ..commands import (
     GetTotalStats,
     GetTrueDetect,
     GetVolume,
-    GetWaterInfo, GetCleanPreference, GetCleanCount,
+    GetWaterInfo,
 )
 from . import (
     AdvancedModeEvent,
     BatteryEvent,
     CarpetAutoFanBoostEvent,
+    CleanCountEvent,
     CleanLogEvent,
+    CleanPreferenceEvent,
     ContinuousCleaningEvent,
     CustomCommandEvent,
     ErrorEvent,
@@ -44,7 +48,7 @@ from . import (
     TotalStatsEvent,
     TrueDetectEvent,
     VolumeEvent,
-    WaterInfoEvent, CleanPreferenceEvent, CleanCountEvent,
+    WaterInfoEvent,
 )
 from .map import (
     MajorMapEvent,

--- a/deebot_client/events/const.py
+++ b/deebot_client/events/const.py
@@ -22,7 +22,7 @@ from ..commands import (
     GetTotalStats,
     GetTrueDetect,
     GetVolume,
-    GetWaterInfo,
+    GetWaterInfo, GetCleanPreference, GetCleanCount,
 )
 from . import (
     AdvancedModeEvent,
@@ -44,7 +44,7 @@ from . import (
     TotalStatsEvent,
     TrueDetectEvent,
     VolumeEvent,
-    WaterInfoEvent,
+    WaterInfoEvent, CleanPreferenceEvent, CleanCountEvent,
 )
 from .map import (
     MajorMapEvent,
@@ -59,6 +59,8 @@ EVENT_DTO_REFRESH_COMMANDS: Mapping[type[Event], list[Command]] = {
     BatteryEvent: [GetBattery()],
     CarpetAutoFanBoostEvent: [GetCarpetAutoFanBoost()],
     CleanLogEvent: [GetCleanLogs()],
+    CleanCountEvent: [GetCleanCount()],
+    CleanPreferenceEvent: [GetCleanPreference()],
     ContinuousCleaningEvent: [GetContinuousCleaning()],
     CustomCommandEvent: [],
     ErrorEvent: [GetError()],

--- a/deebot_client/events/const.py
+++ b/deebot_client/events/const.py
@@ -20,6 +20,7 @@ from ..commands import (
     GetPos,
     GetStats,
     GetTotalStats,
+    GetTrueDetect,
     GetVolume,
     GetWaterInfo,
 )
@@ -41,6 +42,7 @@ from . import (
     StatsEvent,
     StatusEvent,
     TotalStatsEvent,
+    TrueDetectEvent,
     VolumeEvent,
     WaterInfoEvent,
 )
@@ -74,6 +76,7 @@ EVENT_DTO_REFRESH_COMMANDS: Mapping[type[Event], list[Command]] = {
     StatsEvent: [GetStats()],
     StatusEvent: [GetChargeState(), GetCleanInfo()],
     TotalStatsEvent: [GetTotalStats()],
+    TrueDetectEvent: [GetTrueDetect()],
     VolumeEvent: [GetVolume()],
     WaterInfoEvent: [GetWaterInfo()],
 }

--- a/tests/commands/test_clean_count.py
+++ b/tests/commands/test_clean_count.py
@@ -1,0 +1,17 @@
+import pytest
+
+from deebot_client.commands import GetCleanCount, SetCleanCount
+from deebot_client.events import CleanCountEvent
+from tests.commands import assert_command_requested, assert_set_command
+from tests.helpers import get_request_json
+
+
+def test_GetFanSpeed_requested() -> None:
+    json = get_request_json({"count": 2})
+    assert_command_requested(GetCleanCount(), json, CleanCountEvent(2))
+
+
+@pytest.mark.parametrize("count", [1, 2, 3])
+def test_set_multimap_state(count: int) -> None:
+    args = {"count": count}
+    assert_set_command(SetCleanCount(count), args, CleanCountEvent(count))

--- a/tests/commands/test_clean_preference.py
+++ b/tests/commands/test_clean_preference.py
@@ -1,0 +1,18 @@
+import pytest
+
+from deebot_client.commands import GetCleanPreference, SetCleanPreference
+from deebot_client.events import CleanPreferenceEvent
+from tests.commands import assert_command_requested, assert_set_command
+from tests.helpers import get_request_json
+
+
+@pytest.mark.parametrize("value", [False, True])
+def test_get_clean_preference(value: bool) -> None:
+    json = get_request_json({"enable": 1 if value else 0})
+    assert_command_requested(GetCleanPreference(), json, CleanPreferenceEvent(value))
+
+
+@pytest.mark.parametrize("value", [False, True])
+def test_set_clean_preference(value: bool) -> None:
+    args = {"enable": 1 if value else 0}
+    assert_set_command(SetCleanPreference(value), args, CleanPreferenceEvent(value))

--- a/tests/commands/test_true_detect.py
+++ b/tests/commands/test_true_detect.py
@@ -1,0 +1,18 @@
+import pytest
+
+from deebot_client.commands import GetTrueDetect, SetTrueDetect
+from deebot_client.events import TrueDetectEvent
+from tests.commands import assert_command_requested, assert_set_command
+from tests.helpers import get_request_json
+
+
+@pytest.mark.parametrize("value", [False, True])
+def test_get_true_detect(value: bool) -> None:
+    json = get_request_json({"enable": 1 if value else 0})
+    assert_command_requested(GetTrueDetect(), json, TrueDetectEvent(value))
+
+
+@pytest.mark.parametrize("value", [False, True])
+def test_set_true_detect(value: bool) -> None:
+    args = {"enable": 1 if value else 0}
+    assert_set_command(SetTrueDetect(value), args, TrueDetectEvent(value))


### PR DESCRIPTION
Adds support for the following commands:

- (get|set)TrueDetect: Enable/Disable "True Detect Obstacle Avoidance" technology
- (get|set)CleanCount: Set the number of times to clean the area. From testing any integer works - it's possible to clean areas more than twice!
- (get|set)CleanPreference: Enable/Disable "Auto cleaning" mode