### PR TITLE
Update pillow to fix CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ aiomqtt>=1.0.0,<2.0
 cachetools>=5.0.0,<6.0
 defusedxml
 numpy>=1.23.2,<2.0
-Pillow>=10.0.0,<11.0
+Pillow>=10.0.1,<11.0


### PR DESCRIPTION
Updates `Pillow` to 10.0.1
Changelog: <https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst#1001-2023-09-15>

Addresses [CVE-2023-4863](https://github.com/advisories/GHSA-j7hp-h8jx-5ppr)

Credits: @frenck

