### PR TITLE
Add new command: "clean log v2"

### DIFF
--- a/deebot_client/authentication.py
+++ b/deebot_client/authentication.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin
 
 from aiohttp import ClientResponseError, hdrs
 
-from .const import REALM
+from .const import PATH_USERS_USER, REALM
 from .exceptions import ApiError, AuthenticationError, InvalidAuthenticationError
 from .logging_filter import get_logger
 from .models import Configuration, Credentials
@@ -27,7 +27,6 @@ _USER_LOGIN_URL_FORMAT = (
 _GLOBAL_AUTHCODE_URL_FORMAT = (
     "https://gl-{country}-openapi.ecovacs.{tld}/v1/global/auth/getAuthCode"
 )
-_PATH_USERS_USER = "users/user.do"
 _META = {
     "lang": "EN",
     "appCode": "global_e",
@@ -40,7 +39,7 @@ MAX_RETRIES = 3
 
 def _get_portal_url(config: Configuration, path: str) -> str:
     subdomain = f"portal-{config.continent}" if config.country != "cn" else "portal"
-    return urljoin(f"https://{subdomain}.ecouser.net/api/", path)
+    return urljoin(f"https://{subdomain}.ecouser.net/", path)
 
 
 class _AuthClient:
@@ -195,7 +194,7 @@ class _AuthClient:
         }
 
         for i in range(3):
-            resp = await self.post(_PATH_USERS_USER, data)
+            resp = await self.post(PATH_USERS_USER, data)
             if resp["result"] == "ok":
                 return resp
             if resp["result"] == "fail" and resp["error"] == "set token error.":
@@ -203,9 +202,9 @@ class _AuthClient:
                 _LOGGER.warning("loginByItToken set token error, attempt %d/3", i + 2)
                 continue
 
-            _LOGGER.error("call to %s failed with %s", _PATH_USERS_USER, resp)
+            _LOGGER.error("call to %s failed with %s", PATH_USERS_USER, resp)
             raise AuthenticationError(
-                f"failure {resp['error']} ({resp['errno']}) for call {_PATH_USERS_USER}"
+                f"failure {resp['error']} ({resp['errno']}) for call {PATH_USERS_USER}"
             )
 
         raise AuthenticationError("failed to login with token")

--- a/deebot_client/commands/json/__init__.py
+++ b/deebot_client/commands/json/__init__.py
@@ -9,6 +9,7 @@ from .charge_state import GetChargeState
 from .clean import Clean, CleanArea, GetCleanInfo
 from .clean_count import GetCleanCount, SetCleanCount
 from .clean_logs import GetCleanLogs
+from .clean_logs_v2 import GetCleanLogsV2
 from .clean_preference import GetCleanPreference, SetCleanPreference
 from .common import JsonCommand
 from .continuous_cleaning import GetContinuousCleaning, SetContinuousCleaning
@@ -50,6 +51,7 @@ __all__ = [
     "CleanArea",
     "GetCleanInfo",
     "GetCleanLogs",
+    "GetCleanLogsV2",
     "GetContinuousCleaning",
     "SetContinuousCleaning",
     "GetError",
@@ -107,6 +109,7 @@ _COMMANDS: list[type[JsonCommand]] = [
     GetCleanInfo,
 
     GetCleanLogs,
+    GetCleanLogsV2,
 
     GetContinuousCleaning,
     SetContinuousCleaning,

--- a/deebot_client/commands/json/clean_logs_v2.py
+++ b/deebot_client/commands/json/clean_logs_v2.py
@@ -1,0 +1,94 @@
+"""clean log commands."""
+import json
+from typing import Any
+
+from deebot_client.authentication import Authenticator
+from deebot_client.command import CommandResult
+from deebot_client.const import PATH_API_DLN_LOG_LIST, REQUEST_HEADERS
+from deebot_client.event_bus import EventBus
+from deebot_client.events import CleanJobStatus, CleanLogEntry, CleanLogEvent
+from deebot_client.logging_filter import get_logger
+from deebot_client.models import DeviceInfo
+
+from .common import JsonCommand
+
+_LOGGER = get_logger(__name__)
+
+
+class GetCleanLogsV2(JsonCommand):
+    """Get clean logs command."""
+
+    _targets_bot: bool = False
+    name = "clean"
+
+    def __init__(self, count: int = 0) -> None:
+        super().__init__({"count": count})
+
+    async def _execute_api_request(
+        self, authenticator: Authenticator, device_info: DeviceInfo
+    ) -> dict[str, Any]:
+        credentials = await authenticator.authenticate()
+
+        query_params = {
+            "did": device_info.did,
+            "res": device_info.resource,
+            "version": "v2",
+            "logType": self.name,
+            "channel": "google_play",
+            "size": "10",
+            "auth": json.dumps(
+                {
+                    "with": "users",
+                    "userid": credentials.user_id,
+                    "realm": "ecouser.net",
+                    "token": credentials.token,
+                    "resource": device_info.resource,
+                }
+            ),
+            # "country": "DE",
+            # "lang": "EN",
+            # "defaultLang": "zh_cn",
+            # "before": "1698540667000",
+            # "et1": "1698540667778",
+        }
+
+        return await authenticator.post_authenticated(
+            PATH_API_DLN_LOG_LIST,
+            json={},
+            query_params=query_params,
+            headers=REQUEST_HEADERS,
+        )
+
+    def _handle_response(
+        self, event_bus: EventBus, response: dict[str, Any]
+    ) -> CommandResult:
+        """Handle response from a command.
+
+        :return: A message response
+        """
+        # Ecovacs API is changing their API, this request may not work properly
+        if (
+            response["code"] == 0
+            and (resp_logs := response.get("data"))
+            and len(resp_logs) >= 0
+        ):
+            logs: list[CleanLogEntry] = []
+            for log in resp_logs:
+                try:
+                    logs.append(
+                        CleanLogEntry(
+                            timestamp=log["ts"],
+                            image_url=log["imageUrl"],
+                            type=log["type"],
+                            area=log["area"],
+                            stop_reason=CleanJobStatus(int(log.get("stopReason", -2))),
+                            duration=log["last"],
+                        )
+                    )
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.warning("Skipping log entry: %s", log, exc_info=True)
+
+            event_bus.notify(CleanLogEvent(logs))
+            return CommandResult.success()
+
+        return CommandResult.analyse()

--- a/deebot_client/const.py
+++ b/deebot_client/const.py
@@ -4,10 +4,14 @@ from enum import StrEnum
 from typing import Self
 
 REALM = "ecouser.net"
-PATH_API_APPSVR_APP = "appsvr/app.do"
-PATH_API_PIM_PRODUCT_IOT_MAP = "pim/product/getProductIotMap"
-PATH_API_IOT_DEVMANAGER = "iot/devmanager.do"
-PATH_API_LG_LOG = "lg/log.do"
+_API_PREFIX = "api/"
+PATH_USERS_USER = f"{_API_PREFIX}users/user.do"
+PATH_API_APPSVR_APP = f"{_API_PREFIX}appsvr/app.do"
+PATH_API_PIM_PRODUCT_IOT_MAP = f"{_API_PREFIX}pim/product/getProductIotMap"
+PATH_API_IOT_DEVMANAGER = f"{_API_PREFIX}iot/devmanager.do"
+PATH_API_LG_LOG = f"{_API_PREFIX}lg/log.do"
+_API_PREFIX_2 = "app/dln/api/"
+PATH_API_DLN_LOG_LIST = f"{_API_PREFIX_2}log/clean_result/list"
 REQUEST_HEADERS = {
     "User-Agent": "Dalvik/2.1.0 (Linux; U; Android 5.1.1; A5010 Build/LMY48Z)",
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-mypy==1.6.1
+mypy==1.7.0
 pre-commit==3.5.0
 pylint==3.0.2
 pytest==7.4.3

--- a/tests/commands/json/test_clean_log_v2.py
+++ b/tests/commands/json/test_clean_log_v2.py
@@ -1,0 +1,149 @@
+import logging
+from typing import Any
+
+import pytest
+
+from deebot_client.commands.json import GetCleanLogsV2
+from deebot_client.events import CleanJobStatus, CleanLogEntry, CleanLogEvent
+
+from . import assert_command
+
+
+async def test_GetCleanLogs(caplog: pytest.LogCaptureFixture) -> None:
+    json = {
+        "code": 0,
+        "data": [
+            {
+                "ts": 1656265100,
+                "last": 139,
+                "area": 2,
+                "id": "acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                "imageUrl": "https://portal-eu.ecouser.net/api/lg/image/acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                "type": "spotArea",
+                "aiavoid": 0,
+                "aitypes": [],
+                "stopReason": 1,
+                "aiopen": 1,
+                "powerMopType": 1,
+            },
+            {
+                "ts": 1655564615,
+                "last": 366,
+                "area": 0,
+                "id": "acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                "imageUrl": "https://portal-eu.ecouser.net/api/lg/image/acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                "type": "auto",
+                "aiavoid": 0,
+                "aitypes": [],
+                "aiopen": 1,
+                "powerMopType": 1,
+            },
+            {
+                "ts": 1655564399,
+                "last": 61,
+                "area": 0,
+                "id": "acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                "imageUrl": "https://portal-eu.ecouser.net/api/lg/image/acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                "type": "spotArea",
+                "aiavoid": 0,
+                "aitypes": [],
+                "stopReason": 2,
+                "aiopen": 1,
+                "powerMopType": 1,
+            },
+            {
+                "ts": 1655564222,
+                "last": 73,
+                "area": 0,
+                "id": "acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                "imageUrl": "https://portal-eu.ecouser.net/api/lg/image/acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                "type": "spotArea",
+                "aiavoid": 0,
+                "aitypes": [],
+                "stopReason": 3,
+                "aiopen": 1,
+                "powerMopType": 1,
+            },
+            {"ts": 1655564616, "invalid": "event"},
+        ],
+        "message": "success",
+    }
+
+    expected = CleanLogEvent(
+        [
+            CleanLogEntry(
+                timestamp=1656265100,
+                image_url="https://portal-eu.ecouser.net/api/lg/image/acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                type="spotArea",
+                area=2,
+                stop_reason=CleanJobStatus.FINISHED,
+                duration=139,
+            ),
+            CleanLogEntry(
+                timestamp=1655564615,
+                image_url="https://portal-eu.ecouser.net/api/lg/image/acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                type="auto",
+                area=0,
+                stop_reason=CleanJobStatus.NO_STATUS,
+                duration=366,
+            ),
+            CleanLogEntry(
+                timestamp=1655564399,
+                image_url="https://portal-eu.ecouser.net/api/lg/image/acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                type="spotArea",
+                area=0,
+                stop_reason=CleanJobStatus.MANUAL_STOPPED,
+                duration=61,
+            ),
+            CleanLogEntry(
+                timestamp=1655564222,
+                image_url="https://portal-eu.ecouser.net/api/lg/image/acb2e78e-8f25-454a-a0ac-***@***@iCmB",
+                type="spotArea",
+                area=0,
+                stop_reason=CleanJobStatus.FINISHED_WITH_WARNINGS,
+                duration=73,
+            ),
+        ]
+    )
+
+    await assert_command(GetCleanLogsV2(), json, expected)
+
+    assert (
+        "deebot_client.commands.json.clean_logs_v2",
+        logging.WARNING,
+        "Skipping log entry: {'ts': 1655564616, 'invalid': 'event'}",
+    ) in caplog.record_tuples
+
+
+@pytest.mark.parametrize(
+    "json",
+    [{"code": 0}, {"code": 1}],
+)
+async def test_GetCleanLogs_analyse_logged(
+    json: dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    await assert_command(
+        GetCleanLogsV2(),
+        json,
+        None,
+    )
+
+    assert (
+        "deebot_client.command",
+        logging.DEBUG,
+        f"ANALYSE: Could not handle command: clean with {json}",
+    ) in caplog.record_tuples
+
+
+async def test_GetCleanLogs_handle_fails(caplog: pytest.LogCaptureFixture) -> None:
+    await assert_command(
+        GetCleanLogsV2(),
+        {},
+        None,
+    )
+
+    assert (
+        "deebot_client.command",
+        logging.WARNING,
+        f"Could not parse response for {GetCleanLogsV2.name}: {{}}",
+    ) in caplog.record_tuples


### PR DESCRIPTION
# Add new command: "clean log v2"

> See more general info and details under **[discussion](https://github.com/DeebotUniverse/client.py/discussions/345)**.

- Tested with **Deebot T10** over HA - [Deebot-4-Home-Assistant](https://github.com/MVladislav/Deebot-4-Home-Assistant/tree/p95mgv) integration
- Info
  - added api for `app/dln/api/log/clean_result/list`
  - authentication is updated for use of different api prefix
  - possible this will not fully work with official api, as the request send by POST and should be a GET, i tested it with the offline bumper version

| Ecovacs Home App              | Home Assistant                                                                      |
| :---------------------------- | :---------------------------------------------------------------------------------- |
| ![clean_log_v2][clean_log_v2] | ![clean_log_v2_home][clean_log_v2_home] ![clean_log_v2_home_2][clean_log_v2_home_2] |

[clean_log_v2_home_2]: https://github.com/DeebotUniverse/client.py/assets/7400017/ef1b4c1f-8cee-4f5d-973d-e6133c4523fd
[clean_log_v2_home]: https://github.com/DeebotUniverse/client.py/assets/7400017/94cb4102-a665-4daf-986f-96df01a5949b
[clean_log_v2]: https://github.com/DeebotUniverse/client.py/assets/7400017/c9b8a5b5-0a47-40ae-a666-106df48bcded