### PR TITLE
Extend command: "LifeSpan"

### DIFF
--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -119,6 +119,7 @@ class LifeSpan(str, Enum):
     BRUSH = "brush"
     FILTER = "heap"
     SIDE_BRUSH = "sideBrush"
+    UNIT_CARE = "unitCare"
 
 
 @dataclass(frozen=True)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-mypy==1.6.1
+mypy==1.7.0
 pre-commit==3.5.0
 pylint==3.0.2
 pytest==7.4.3

--- a/tests/commands/json/test_life_span.py
+++ b/tests/commands/json/test_life_span.py
@@ -14,21 +14,37 @@ from . import assert_command, assert_execute_command
     ("command", "json", "expected"),
     [
         (
-            GetLifeSpan({LifeSpan.BRUSH, LifeSpan.FILTER, LifeSpan.SIDE_BRUSH}),
+            GetLifeSpan(
+                {
+                    LifeSpan.BRUSH,
+                    LifeSpan.FILTER,
+                    LifeSpan.SIDE_BRUSH,
+                    LifeSpan.UNIT_CARE,
+                }
+            ),
             get_request_json(
                 get_success_body(
                     [
-                        {"type": "sideBrush", "left": 8977, "total": 9000},
                         {"type": "brush", "left": 17979, "total": 18000},
                         {"type": "heap", "left": 7179, "total": 7200},
+                        {"type": "sideBrush", "left": 8977, "total": 9000},
+                        {"type": "unitCare", "left": 265, "total": 1800},
                     ]
                 )
             ),
             [
-                LifeSpanEvent(LifeSpan.SIDE_BRUSH, 99.74, 8977),
                 LifeSpanEvent(LifeSpan.BRUSH, 99.88, 17979),
                 LifeSpanEvent(LifeSpan.FILTER, 99.71, 7179),
+                LifeSpanEvent(LifeSpan.SIDE_BRUSH, 99.74, 8977),
+                LifeSpanEvent(LifeSpan.UNIT_CARE, 14.72, 265),
             ],
+        ),
+        (
+            GetLifeSpan({LifeSpan.BRUSH}),
+            get_request_json(
+                get_success_body([{"type": "brush", "left": 17979, "total": 18000}])
+            ),
+            [LifeSpanEvent(LifeSpan.BRUSH, 99.88, 17979)],
         ),
         (
             GetLifeSpan([LifeSpan.FILTER]),
@@ -38,11 +54,18 @@ from . import assert_command, assert_execute_command
             [LifeSpanEvent(LifeSpan.FILTER, 99.71, 7179)],
         ),
         (
-            GetLifeSpan({LifeSpan.BRUSH}),
+            GetLifeSpan([LifeSpan.SIDE_BRUSH]),
             get_request_json(
-                get_success_body([{"type": "brush", "left": 17979, "total": 18000}])
+                get_success_body([{"type": "sideBrush", "left": 8977, "total": 9000}])
             ),
-            [LifeSpanEvent(LifeSpan.BRUSH, 99.88, 17979)],
+            [LifeSpanEvent(LifeSpan.SIDE_BRUSH, 99.74, 8977)],
+        ),
+        (
+            GetLifeSpan({LifeSpan.UNIT_CARE}),
+            get_request_json(
+                get_success_body([{"type": "unitCare", "left": 265, "total": 1800}])
+            ),
+            [LifeSpanEvent(LifeSpan.UNIT_CARE, 14.72, 265)],
         ),
     ],
 )


### PR DESCRIPTION
# Extend command: "LifeSpan"

> See more general info and details under **[discussion](https://github.com/DeebotUniverse/client.py/discussions/345)**.

- Tested with **Deebot T10** over HA - [Deebot-4-Home-Assistant](https://github.com/MVladislav/Deebot-4-Home-Assistant/tree/p95mgv) integration
- Added `unitCare` as possible "LifeSpan" option

| Ecovacs Home App            | Home Assistant                                                                |
| :-------------------------- | :---------------------------------------------------------------------------- |
| ![getLifeSpan][getLifeSpan] | ![getLifeSpan_home][getLifeSpan_home] ![getLifeSpan_home2][getLifeSpan_home2] |

[getLifeSpan]: https://github.com/DeebotUniverse/client.py/assets/7400017/13838417-72d1-4b00-9f80-56712d43b021
[getLifeSpan_home]: https://github.com/DeebotUniverse/client.py/assets/7400017/1be371a0-03a6-49bf-917b-d8e88f5e3510
[getLifeSpan_home2]: https://github.com/DeebotUniverse/client.py/assets/7400017/b07e9738-78b7-49b7-a0b3-806657e5b28d