### PR TITLE
Use vector based graphic (SVG) for map rendering

### DIFF
--- a/deebot_client/map.py
+++ b/deebot_client/map.py
@@ -452,7 +452,6 @@ class Map:
 
             # Build the SVG elements
 
-
             # Elements of the SVG Map to vertically flip
             svg_map_group_elements: list[svg.Element] = []
 
@@ -469,17 +468,21 @@ class Map:
             )
 
             # Additional subsets (VirtualWalls and NoMopZones)
-            svg_map_group_elements.extend([
-                _get_svg_subset(subset, image_box)
-                for subset in self._map_data.map_subsets.values()
-            ])
+            svg_map_group_elements.extend(
+                [
+                    _get_svg_subset(subset, image_box)
+                    for subset in self._map_data.map_subsets.values()
+                ]
+            )
 
             # Traces (if any)
             if svg_traces_path := self._get_svg_traces_path():
                 svg_map_group_elements.append(svg_traces_path)
 
             # Bot and Charge stations
-            svg_map_group_elements.extend(_get_svg_positions(self._map_data.positions, image_box))
+            svg_map_group_elements.extend(
+                _get_svg_positions(self._map_data.positions, image_box)
+            )
 
             # Set map viewBox based on background map bounding box.
             svg_map.viewBox = svg.ViewBoxSpec(

--- a/deebot_client/map.py
+++ b/deebot_client/map.py
@@ -87,20 +87,19 @@ _SVG_DEFS = svg.Defs(
         # Charger pin icon (pre-flipped vertically)
         svg.G(
             id=f"position_{PositionType.CHARGER}",
-            transform=[svg.Scale(4, -4)],
             elements=[
                 svg.Path(
                     fill="#ffe605",
                     d=[
-                        svg.M(1, -1.6),
-                        svg.C(1, -1.05, 0, 0, 0, 0),
-                        svg.c(0, 0, -1, -1.05, -1, -1.6),
-                        svg.c(0, -0.55, 0.45, -1, 1, -1),
-                        svg.c(0.55, 0, 1, 0.45, 1, 1),
+                        svg.M(4, 6.4),
+                        svg.C(4, 4.2, 0, 0, 0, 0),
+                        svg.C(0, 0, -4, 4.2, -4, 6.4),
+                        svg.C(-4, 8.6, -2.2, 10.4, 0, 10.4),
+                        svg.C(2.2, 10.4, 4, 8.6, 4, 6.4),
                         svg.Z(),
                     ],
                 ),
-                svg.Circle(fill="white", r=0.7, cy=-1.6, cx=0),
+                svg.Circle(fill="white", r=2.8, cy=6.4, cx=0),
             ],
         ),
     ]
@@ -453,14 +452,6 @@ class Map:
 
             # Build the SVG elements
 
-            svg_positions = _get_svg_positions(self._map_data.positions, image_box)
-
-            svg_subset_elements: list[svg.Element] = [
-                _get_svg_subset(subset, image_box)
-                for subset in self._map_data.map_subsets.values()
-            ]
-
-            svg_traces_path = self._get_svg_traces_path()
 
             # Elements of the SVG Map to vertically flip
             svg_map_group_elements: list[svg.Element] = []
@@ -478,14 +469,17 @@ class Map:
             )
 
             # Additional subsets (VirtualWalls and NoMopZones)
-            svg_map_group_elements.extend(svg_subset_elements)
+            svg_map_group_elements.extend([
+                _get_svg_subset(subset, image_box)
+                for subset in self._map_data.map_subsets.values()
+            ])
 
             # Traces (if any)
-            if svg_traces_path:
+            if svg_traces_path := self._get_svg_traces_path():
                 svg_map_group_elements.append(svg_traces_path)
 
             # Bot and Charge stations
-            svg_map_group_elements.extend(svg_positions)
+            svg_map_group_elements.extend(_get_svg_positions(self._map_data.positions, image_box))
 
             # Set map viewBox based on background map bounding box.
             svg_map.viewBox = svg.ViewBoxSpec(

--- a/deebot_client/map.py
+++ b/deebot_client/map.py
@@ -490,9 +490,8 @@ class Map:
         self._draw_map_pieces(draw)
         del draw
 
-        image_box = image.getbbox()
 
-        if image_box:
+        if image_box := image.getbbox():
             image_box_center = (
                 (image_box[0] + image_box[2]) / 2,
                 (image_box[1] + image_box[3]) / 2,
@@ -578,11 +577,8 @@ class Map:
                 ],
             )
 
-        else:
-            # No map data yet, generate an empty SVG.
-            svg_map = svg.SVG()
 
-        str_svg_map = str(svg_map)
+        str_svg_map = str(svg_map or svg.SVG())
         self._map_data.reset_changed()
         self._last_image = LastImage(str_svg_map, width)
         _LOGGER.debug("[get_svg_map] Finish")

--- a/deebot_client/map.py
+++ b/deebot_client/map.py
@@ -47,8 +47,6 @@ _POSITIONS_SVG_ORDER = {
     PositionType.CHARGER: 1,
 }
 
-_SVG_MAP_MARGIN = 5
-
 _OFFSET = 400
 _TRACE_MAP = "trace_map"
 _COLORS = {
@@ -154,7 +152,7 @@ def _calc_point(
 
 
 def _points_to_svg_path(
-    points: Sequence[tuple[float, float]] | Sequence[tuple[float, float, bool, int]],
+    points: Sequence[tuple[float, float]] | Sequence[tuple[float, float, bool]],
 ) -> list[svg.PathData]:
     # Convert a set of simple point (x, y), or trace points (x, y, connected, type) to
     # SVG path instructions.
@@ -284,11 +282,8 @@ class Map:
             point_data = trace_points[i + 4]
 
             connected = point_data >> 7 & 1 == 0
-            point_type = point_data & 1
 
-            self._map_data.trace_values.append(
-                (position_x, position_y, connected, point_type)
-            )
+            self._map_data.trace_values.append((position_x, position_y, connected))
 
         _LOGGER.debug("[_update_trace_points] finish")
 
@@ -486,10 +481,10 @@ class Map:
 
             # Set map viewBox based on background map bounding box.
             svg_map.viewBox = svg.ViewBoxSpec(
-                image_box[0] - _SVG_MAP_MARGIN,
-                image_box[1] - _SVG_MAP_MARGIN,
-                (image_box[2] - image_box[0]) + _SVG_MAP_MARGIN * 2,
-                image_box[3] - image_box[1] + _SVG_MAP_MARGIN * 2,
+                image_box[0],
+                image_box[1],
+                image_box[2] - image_box[0],
+                image_box[3] - image_box[1],
             )
 
             # Add all elements to the SVG map
@@ -602,7 +597,7 @@ class MapData:
         self._map_subsets: OnChangedDict[int, MapSubsetEvent] = OnChangedDict(on_change)
         self._positions: OnChangedList[Position] = OnChangedList(on_change)
         self._rooms: OnChangedDict[int, Room] = OnChangedDict(on_change)
-        self._trace_values: OnChangedList[tuple[int, int, bool, int]] = OnChangedList(
+        self._trace_values: OnChangedList[tuple[int, int, bool]] = OnChangedList(
             on_change
         )
 
@@ -639,7 +634,7 @@ class MapData:
         return self._rooms
 
     @property
-    def trace_values(self) -> OnChangedList[tuple[int, int, bool, int]]:
+    def trace_values(self) -> OnChangedList[tuple[int, int, bool]]:
         """Return trace values."""
         return self._trace_values
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cachetools>=5.0.0,<6.0
 defusedxml
 numpy>=1.23.2,<2.0
 Pillow>=10.0.1,<11.0
+svg.py>=1.4.2

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -15,9 +15,9 @@ from deebot_client.map import Map, MapData, _calc_point
 from deebot_client.models import Room
 
 _test_calc_point_data = [
-    (0, 10, None, (0, 10)),
-    (10, 100, (100, 0, 200, 50), (200, 50)),
-    (10, 100, (0, 0, 1000, 1000), (400, 402)),
+    (0, 10, None, (0.0, 10.0)),
+    (10, 100, (100, 0, 200, 50), (200.0, 50.0)),
+    (10, 100, (0, 0, 1000, 1000), (400.2, 402.0)),
 ]
 
 
@@ -26,7 +26,7 @@ def test_calc_point(
     x: int,
     y: int,
     image_box: tuple[int, int, int, int] | None,
-    expected: tuple[int, int],
+    expected: tuple[float, float],
 ) -> None:
     result = _calc_point(x, y, image_box)
     assert result == expected


### PR DESCRIPTION
Use vector based graphic (SVG) for map rendering.

**Why?** At least for my environment, the map rendered using only raster graphic results in a very low-res map representation. Vector based graphic allows to produce pretty looking maps with high-res elements for bot, charging station, traces and so on.

For comparison:

Raster based rendering (with a black background due https://github.com/DeebotUniverse/Deebot-4-Home-Assistant/issues/268 )
![image](https://github.com/DeebotUniverse/client.py/assets/972242/caea5a4a-d6b0-4706-a606-cd5facbc6556)


Vector based rendering
![image](https://github.com/DeebotUniverse/client.py/assets/972242/e1e0633e-5f6d-4113-a9dd-e55bb13cc3a9)


TODO:
- [ ] Integrate tests
- [x] Code cleanups