### PR TITLE
Add get_ecovacs_country

### DIFF
--- a/deebot_client/authentication.py
+++ b/deebot_client/authentication.py
@@ -16,6 +16,7 @@ from .logging_filter import get_logger
 from .models import Credentials
 from .util import cancel, create_task, md5
 from .util.continents import get_continent_url_postfix
+from .util.countries import get_ecovacs_country
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Mapping
@@ -56,18 +57,18 @@ def create_rest_config(
     session: ClientSession,
     *,
     device_id: str,
-    country: str,
+    alpha_2_country: str,
     override_rest_url: str | None = None,
 ) -> RestConfiguration:
     """Create configuration."""
-    country = country.upper()
-    continent_postfix = get_continent_url_postfix(country)
+    continent_postfix = get_continent_url_postfix(alpha_2_country)
+    country = get_ecovacs_country(alpha_2_country)
     if override_rest_url:
         portal_url = login_url = auth_code_url = override_rest_url
     else:
         portal_url = f"https://portal{continent_postfix}.ecouser.net"
         country_url = country.lower()
-        tld = "com" if country != COUNTRY_CHINA else country_url
+        tld = "com" if alpha_2_country != COUNTRY_CHINA else country_url
         login_url = f"https://gl-{country_url}-api.ecovacs.{tld}"
         auth_code_url = f"https://gl-{country_url}-openapi.ecovacs.{tld}"
 

--- a/deebot_client/util/continents.py
+++ b/deebot_client/util/continents.py
@@ -4,19 +4,19 @@ from __future__ import annotations
 from deebot_client.const import COUNTRY_CHINA
 
 
-def get_continent(country: str | None) -> str:
+def get_continent(alpha_2_country: str | None) -> str:
     """Return the continent for the given country or ww."""
-    if not country:
+    if not alpha_2_country:
         return "ww"
-    return COUNTRIES_TO_CONTINENTS.get(country.upper(), "ww")
+    return COUNTRIES_TO_CONTINENTS.get(alpha_2_country, "ww")
 
 
-def get_continent_url_postfix(country: str) -> str:
+def get_continent_url_postfix(alpha_2_country: str) -> str:
     """Return the url contintent postfix for the given country."""
-    if country == COUNTRY_CHINA:
+    if alpha_2_country == COUNTRY_CHINA:
         return ""
 
-    return f"-{get_continent(country)}"
+    return f"-{get_continent(alpha_2_country)}"
 
 
 # Copied from https://github.com/mrbungle64/ecovacs-deebot.js/blob/master/countries.json on 11.01.2024
@@ -180,7 +180,7 @@ COUNTRIES_TO_CONTINENTS = {
     "MX": "na",
     "MY": "as",
     "MZ": "ww",
-    "na": "ww",
+    "NA": "ww",
     "NC": "ww",
     "NE": "ww",
     "NF": "ww",
@@ -252,7 +252,6 @@ COUNTRIES_TO_CONTINENTS = {
     "TZ": "ww",
     "UA": "eu",
     "UG": "ww",
-    "UK": "eu",
     "UM": "ww",
     "US": "na",
     "UY": "ww",
@@ -266,7 +265,6 @@ COUNTRIES_TO_CONTINENTS = {
     "VU": "ww",
     "WF": "ww",
     "WS": "ww",
-    "XK": "eu",
     "YE": "as",
     "YT": "ww",
     "ZA": "ww",

--- a/deebot_client/util/countries.py
+++ b/deebot_client/util/countries.py
@@ -1,0 +1,9 @@
+"""Countries util."""
+from __future__ import annotations
+
+_MAP_COUNTRY: dict[str, str] = {"GB": "UK"}
+
+
+def get_ecovacs_country(alpha_2_country: str) -> str:
+    """Get the country used by ecovacs from a ISO 3166 alpha2 country."""
+    return _MAP_COUNTRY.get(alpha_2_country, alpha_2_country)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 mypy==1.8.0
 pre-commit==3.6.0
+pycountry==23.12.11
 pylint==3.0.3
 pytest==7.4.4
 pytest-asyncio==0.23.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def rest_config(
     return create_config_rest(
         session=session,
         device_id=device_id_and_country[0],
-        country=device_id_and_country[1],
+        alpha_2_country=device_id_and_country[1],
     )
 
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -106,7 +106,7 @@ def test_config_override_rest_url(
     config = create_rest_config(
         session=session,
         device_id="123",
-        country=country,
+        alpha_2_country=country,
         override_rest_url=override_rest_url,
     )
     assert config.portal_url == expected_portal_url

--- a/tests/util/test_continents.py
+++ b/tests/util/test_continents.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+import pycountry
 import pytest
 
-from deebot_client.util.continents import get_continent
+from deebot_client.util.continents import COUNTRIES_TO_CONTINENTS, get_continent
 
 
 @pytest.mark.parametrize(
     ("continent", "expected"),
     [
         ("IT", "eu"),
-        ("it", "eu"),
         ("DE", "eu"),
         ("US", "na"),
-        ("invalid", "ww"),
         ("", "ww"),
         ("XX", "ww"),
     ],
 )
 def test_get_continent(continent: str, expected: str) -> None:
     assert get_continent(continent) == expected
+
+
+def test_countries_list_match_pxycountries_one() -> None:
+    expected_contires = {c.alpha_2 for c in pycountry.countries}
+
+    assert set(COUNTRIES_TO_CONTINENTS.keys()) == expected_contires

--- a/tests/util/test_countries.py
+++ b/tests/util/test_countries.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from deebot_client.util.countries import get_ecovacs_country
+
+
+@pytest.mark.parametrize(
+    ("continent", "expected"),
+    [
+        ("IT", "IT"),
+        ("GB", "UK"),
+    ],
+)
+def test_get_ecovacs_country(continent: str, expected: str) -> None:
+    assert get_ecovacs_country(continent) == expected


### PR DESCRIPTION
Ecovacs used `UK` instead of the alpha 2 ISO 3166 code `GB` for United Kingdom -> Add coverter for it
Ref: https://github.com/home-assistant/core/issues/109336

Add tests to make sure all ISO 3166 country codes are supported by the continent mapper