### PR TITLE
Return calibration points together with map

### DIFF
--- a/deebot_client/map.py
+++ b/deebot_client/map.py
@@ -616,9 +616,6 @@ class Map:
             self._last_image = None
             return None
 
-        # Build the SVG elements
-        svg_map = svg.SVG()
-        svg_map.elements = [_SVG_DEFS]
         manipulation = MapManipulation(
             AxisManipulation(
                 map_shift=background.bounding_box[0],
@@ -630,6 +627,10 @@ class Map:
                 _transform=lambda c, v: 2 * c - v,
             ),
         )
+
+        # Build the SVG elements
+        svg_map = svg.SVG(width=manipulation.x.svg_max, height=manipulation.y.svg_max)
+        svg_map.elements = [_SVG_DEFS]
 
         # Set map viewBox based on background map bounding box.
         svg_map.viewBox = svg.ViewBoxSpec(


### PR DESCRIPTION
I would like to take a stab at adding the calibration points to support the Vacuum Map card from this issue:
https://github.com/DeebotUniverse/Deebot-4-Home-Assistant/issues/321

First step is to calculate such points in the client library.

My Python experience is very limited, so let me know if you would like me to refactor it somehow.