### PR TITLE
Add xml commands "GetChargeState"

### DIFF
--- a/deebot_client/commands/xml/__init__.py
+++ b/deebot_client/commands/xml/__init__.py
@@ -6,12 +6,14 @@ from typing import TYPE_CHECKING
 
 from deebot_client.command import Command, CommandMqttP2P
 
+from .charge_state import GetChargeState
 from .error import GetError
 
 if TYPE_CHECKING:
     from .common import XmlCommand
 
 __all__ = [
+    "GetChargeState",
     "GetError",
 ]
 

--- a/deebot_client/commands/xml/charge_state.py
+++ b/deebot_client/commands/xml/charge_state.py
@@ -1,0 +1,52 @@
+"""Charge State command."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deebot_client.events import StateEvent
+from deebot_client.message import HandlingResult
+from deebot_client.models import State
+
+from .common import XmlCommandWithMessageHandling
+
+if TYPE_CHECKING:
+    from xml.etree.ElementTree import Element
+    from deebot_client.event_bus import EventBus
+
+
+class GetChargeState(XmlCommandWithMessageHandling):
+    """GetChargeState command."""
+
+    name = "GetChargeState"
+
+
+    @classmethod
+    def _handle_xml(cls, event_bus: EventBus, xml: Element) -> HandlingResult:
+        """Handle xml message and notify the correct event subscribers.
+
+        :return: A message response
+        """
+
+        status: State | None = None
+
+        ret = ret if (ret := xml.attrib["ret"]) else ""
+        if ret != "ok":
+            return HandlingResult.analyse()
+
+        if charge := xml.find("charge"):
+            type_ = charge.attrib["type"].lower()
+            match(type_):
+                case "slotcharging" | "slot_charging" | "wirecharging":
+                    status = State.DOCKED
+                case "idle":
+                    status = State.IDLE
+                case "going":
+                    status = State.RETURNING
+                case _:
+                    status = State.ERROR
+
+        if status:
+            event_bus.notify(StateEvent(status))
+            return HandlingResult.success()
+
+        return HandlingResult.analyse()

--- a/deebot_client/commands/xml/charge_state.py
+++ b/deebot_client/commands/xml/charge_state.py
@@ -29,11 +29,10 @@ class GetChargeState(XmlCommandWithMessageHandling):
         """
         status: State | None = None
 
-        ret = ret if (ret := xml.attrib["ret"]) else ""
-        if ret != "ok":
+        if xml.attrib.get("ret") != "ok":
             return HandlingResult.analyse()
 
-        if charge := xml.find("charge"):
+        if (charge := xml.find("charge")) is not None:
             type_ = charge.attrib["type"].lower()
             match type_:
                 case "slotcharging" | "slot_charging" | "wirecharging":

--- a/deebot_client/commands/xml/charge_state.py
+++ b/deebot_client/commands/xml/charge_state.py
@@ -1,4 +1,5 @@
 """Charge State command."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -11,6 +12,7 @@ from .common import XmlCommandWithMessageHandling
 
 if TYPE_CHECKING:
     from xml.etree.ElementTree import Element
+
     from deebot_client.event_bus import EventBus
 
 
@@ -19,14 +21,12 @@ class GetChargeState(XmlCommandWithMessageHandling):
 
     name = "GetChargeState"
 
-
     @classmethod
     def _handle_xml(cls, event_bus: EventBus, xml: Element) -> HandlingResult:
         """Handle xml message and notify the correct event subscribers.
 
         :return: A message response
         """
-
         status: State | None = None
 
         ret = ret if (ret := xml.attrib["ret"]) else ""
@@ -35,7 +35,7 @@ class GetChargeState(XmlCommandWithMessageHandling):
 
         if charge := xml.find("charge"):
             type_ = charge.attrib["type"].lower()
-            match(type_):
+            match type_:
                 case "slotcharging" | "slot_charging" | "wirecharging":
                     status = State.DOCKED
                 case "idle":

--- a/tests/commands/xml/test_charge_state.py
+++ b/tests/commands/xml/test_charge_state.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         ("Going", StateEvent(State.RETURNING)),
         ("unknown state returned", StateEvent(State.ERROR)),
     ],
+    ids=["slot_charging", "idle", "going", "unknown"],
 )
 async def test_get_charge_state(state: str, expected_event: Event) -> None:
     json = get_request_xml(f"<ctl ret='ok'><charge type='{state}' g='0'/></ctl>")

--- a/tests/commands/xml/test_charge_state.py
+++ b/tests/commands/xml/test_charge_state.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deebot_client.commands.xml import GetChargeState
+from deebot_client.events import StateEvent
+from deebot_client.models import State
+from tests.commands import assert_command
+
+from . import get_request_xml
+
+if TYPE_CHECKING:
+    from deebot_client.events.base import Event
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_event"),
+    [
+        ("SlotCharging", StateEvent(State.DOCKED)),
+        ("Idle", StateEvent(State.IDLE)),
+        ("Going", StateEvent(State.RETURNING)),
+        ("unknown state returned", StateEvent(State.ERROR)),
+    ],
+)
+async def test_get_charge_state(state: str, expected_event: Event) -> None:
+    json = get_request_xml(f"<ctl ret='ok'><charge type='{state}' g='0'/></ctl>")
+    await assert_command(GetChargeState(), json, expected_event)

--- a/tests/commands/xml/test_charge_state.py
+++ b/tests/commands/xml/test_charge_state.py
@@ -4,8 +4,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from deebot_client.command import CommandResult
 from deebot_client.commands.xml import GetChargeState
 from deebot_client.events import StateEvent
+from deebot_client.message import HandlingState
 from deebot_client.models import State
 from tests.commands import assert_command
 
@@ -28,3 +30,18 @@ if TYPE_CHECKING:
 async def test_get_charge_state(state: str, expected_event: Event) -> None:
     json = get_request_xml(f"<ctl ret='ok'><charge type='{state}' g='0'/></ctl>")
     await assert_command(GetChargeState(), json, expected_event)
+
+
+@pytest.mark.parametrize(
+    "xml",
+    ["<ctl ret='error'/>", "<ctl ret='ok'></ctl>"],
+    ids=["error", "no_state"],
+)
+async def test_get_charge_state_error(xml: str) -> None:
+    json = get_request_xml(xml)
+    await assert_command(
+        GetChargeState(),
+        json,
+        None,
+        command_result=CommandResult(HandlingState.ANALYSE_LOGGED),
+    )


### PR DESCRIPTION
This adds the GetChargeState command (for ls1ok3). I tested them locally and it seems to work.

@edenhaus maybe you can guide me to add support for ls1ok3. I have a Burp file to control my robot. It is easy for me to modify the HTTP requests and to check what is working and whats the response of the robot/API. But it takes a lot of time for me to implement the commands in python.

![image](https://github.com/DeebotUniverse/client.py/assets/4031504/0ff60c83-a08d-4fbe-a86f-ca621cf97dd3)


Some examples:

- [GetBatteryInfo.txt](https://github.com/DeebotUniverse/client.py/files/14605851/GetBatteryInfo.txt)
- [GetChargeState.txt](https://github.com/DeebotUniverse/client.py/files/14605852/GetChargeState.txt)
- [GetCleanLogs.txt](https://github.com/DeebotUniverse/client.py/files/14605853/GetCleanLogs.txt)
- [GetCleanSpeed.txt](https://github.com/DeebotUniverse/client.py/files/14605854/GetCleanSpeed.txt)
- [GetCleanState.txt](https://github.com/DeebotUniverse/client.py/files/14605855/GetCleanState.txt)
- [GetCleanSum.txt](https://github.com/DeebotUniverse/client.py/files/14605856/GetCleanSum.txt)
- [GetLifeSpan.txt](https://github.com/DeebotUniverse/client.py/files/14605857/GetLifeSpan.txt)
- [GetMapM.txt](https://github.com/DeebotUniverse/client.py/files/14605858/GetMapM.txt)
- [GetMapSet.txt](https://github.com/DeebotUniverse/client.py/files/14605859/GetMapSet.txt)
- [GetPos.txt](https://github.com/DeebotUniverse/client.py/files/14605860/GetPos.txt)
- [GetSleepStatus.txt](https://github.com/DeebotUniverse/client.py/files/14605861/GetSleepStatus.txt)
- [GetTime.txt](https://github.com/DeebotUniverse/client.py/files/14605862/GetTime.txt)
- [GetVersion.txt](https://github.com/DeebotUniverse/client.py/files/14605863/GetVersion.txt)
- [GetWaterBoxInfo.txt](https://github.com/DeebotUniverse/client.py/files/14605864/GetWaterBoxInfo.txt)
- [PlaySound.txt](https://github.com/DeebotUniverse/client.py/files/14605865/PlaySound.txt)
- [Charge.txt](https://github.com/DeebotUniverse/client.py/files/14607684/Charge.txt)
- [Clean.txt](https://github.com/DeebotUniverse/client.py/files/14607685/Clean.txt)


Commands and mapping seem to be related to:
- commands: https://github.com/mrbungle64/ecovacs-deebot.js/blob/master/library/non950type/command.js
- mapping: https://github.com/mrbungle64/ecovacs-deebot.js/blob/master/library/non950type/dictionary.js