### PR TITLE
Add support for X2 Omni

### DIFF
--- a/deebot_client/hardware/deebot/e6ofmn.py
+++ b/deebot_client/hardware/deebot/e6ofmn.py
@@ -1,0 +1,227 @@
+"""Deebot X2 Omni Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityLifeSpan,
+    CapabilityMap,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStats,
+    VacuumCapabilities,
+)
+from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.carpet import (
+    GetCarpetAutoFanBoost,
+    SetCarpetAutoFanBoost,
+)
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.clean import Clean, CleanArea, GetCleanInfo
+from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
+from deebot_client.commands.json.clean_logs import GetCleanLogs
+from deebot_client.commands.json.clean_preference import (
+    GetCleanPreference,
+    SetCleanPreference,
+)
+from deebot_client.commands.json.continuous_cleaning import (
+    GetContinuousCleaning,
+    SetContinuousCleaning,
+)
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import GetCachedMapInfo, GetMajorMap, GetMapTrace
+from deebot_client.commands.json.multimap_state import (
+    GetMultimapState,
+    SetMultimapState,
+)
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
+from deebot_client.commands.json.relocation import SetRelocationState
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.sweep_mode import GetSweepMode, SetSweepMode
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.voice_assistant_state import (
+    GetVoiceAssistantState,
+    SetVoiceAssistantState,
+)
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.commands.json.work_mode import GetWorkMode, SetWorkMode
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AdvancedModeEvent,
+    AvailabilityEvent,
+    BatteryEvent,
+    CachedMapInfoEvent,
+    CarpetAutoFanBoostEvent,
+    CleanCountEvent,
+    CleanLogEvent,
+    CleanPreferenceEvent,
+    ContinuousCleaningEvent,
+    CustomCommandEvent,
+    ErrorEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    LifeSpan,
+    LifeSpanEvent,
+    MajorMapEvent,
+    MapChangedEvent,
+    MapTraceEvent,
+    MultimapStateEvent,
+    NetworkInfoEvent,
+    PositionsEvent,
+    ReportStatsEvent,
+    RoomsEvent,
+    StateEvent,
+    StatsEvent,
+    SweepModeEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VoiceAssistantStateEvent,
+    VolumeEvent,
+    WaterAmount,
+    WaterInfoEvent,
+    WorkMode,
+    WorkModeEvent,
+)
+from deebot_client.models import StaticDeviceInfo
+from deebot_client.util import short_name
+
+from . import DEVICES
+
+DEVICES[short_name(__name__)] = StaticDeviceInfo(
+    DataType.JSON,
+    VacuumCapabilities(
+        availability=CapabilityEvent(
+            AvailabilityEvent, [GetBattery(is_available_check=True)]
+        ),
+        battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+        charge=CapabilityExecute(Charge),
+        clean=CapabilityClean(
+            action=CapabilityCleanAction(command=Clean, area=CleanArea),
+            continuous=CapabilitySetEnable(
+                ContinuousCleaningEvent,
+                [GetContinuousCleaning()],
+                SetContinuousCleaning,
+            ),
+            count=CapabilitySet(CleanCountEvent, [GetCleanCount()], SetCleanCount),
+            log=CapabilityEvent(CleanLogEvent, [GetCleanLogs()]),
+            preference=CapabilitySetEnable(
+                CleanPreferenceEvent, [GetCleanPreference()], SetCleanPreference
+            ),
+            work_mode=CapabilitySetTypes(
+                event=WorkModeEvent,
+                get=[GetWorkMode()],
+                set=SetWorkMode,
+                types=(
+                    WorkMode.MOP,
+                    WorkMode.MOP_AFTER_VACUUM,
+                    WorkMode.VACUUM,
+                    WorkMode.VACUUM_AND_MOP,
+                ),
+            ),
+        ),
+        custom=CapabilityCustomCommand(
+            event=CustomCommandEvent, get=[], set=CustomCommand
+        ),
+        error=CapabilityEvent(ErrorEvent, [GetError()]),
+        fan_speed=CapabilitySetTypes(
+            event=FanSpeedEvent,
+            get=[GetFanSpeed()],
+            set=SetFanSpeed,
+            types=(
+                FanSpeedLevel.QUIET,
+                FanSpeedLevel.NORMAL,
+                FanSpeedLevel.MAX,
+                FanSpeedLevel.MAX_PLUS,
+            ),
+        ),
+        life_span=CapabilityLifeSpan(
+			types=(
+                LifeSpan.BRUSH,
+                LifeSpan.FILTER,
+                LifeSpan.SIDE_BRUSH,
+                LifeSpan.UNIT_CARE,
+                LifeSpan.ROUND_MOP,
+            ),
+            event=LifeSpanEvent,
+            get=[
+                GetLifeSpan(
+                    [
+                        LifeSpan.BRUSH,
+                        LifeSpan.FILTER,
+                        LifeSpan.SIDE_BRUSH,
+                        LifeSpan.UNIT_CARE,
+                        LifeSpan.ROUND_MOP,
+                    ]
+                )
+            ],
+            reset=ResetLifeSpan,
+        ),
+        map=CapabilityMap(
+            cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo()]),
+            changed=CapabilityEvent(MapChangedEvent, []),
+            major=CapabilityEvent(MajorMapEvent, [GetMajorMap()]),
+            multi_state=CapabilitySetEnable(
+                MultimapStateEvent, [GetMultimapState()], SetMultimapState
+            ),
+            position=CapabilityEvent(PositionsEvent, [GetPos()]),
+            relocation=CapabilityExecute(SetRelocationState),
+            rooms=CapabilityEvent(RoomsEvent, [GetCachedMapInfo()]),
+            trace=CapabilityEvent(MapTraceEvent, [GetMapTrace()]),
+        ),
+        network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+        play_sound=CapabilityExecute(PlaySound),
+        settings=CapabilitySettings(
+            advanced_mode=CapabilitySetEnable(
+                AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
+            ),
+            carpet_auto_fan_boost=CapabilitySetEnable(
+                CarpetAutoFanBoostEvent,
+                [GetCarpetAutoFanBoost()],
+                SetCarpetAutoFanBoost,
+            ),
+            sweep_mode=CapabilitySetEnable(
+                SweepModeEvent, [GetSweepMode()], SetSweepMode
+            ),
+            true_detect=CapabilitySetEnable(
+                TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+            ),
+            voice_assistant=CapabilitySetEnable(
+                VoiceAssistantStateEvent,
+                [GetVoiceAssistantState()],
+                SetVoiceAssistantState,
+            ),
+            volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+        ),
+        state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfo()]),
+        stats=CapabilityStats(
+            clean=CapabilityEvent(StatsEvent, [GetStats()]),
+            report=CapabilityEvent(ReportStatsEvent, []),
+            total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+        ),
+        water=CapabilitySetTypes(
+            event=WaterInfoEvent,
+            get=[GetWaterInfo()],
+            set=SetWaterInfo,
+            types=(
+                WaterAmount.LOW,
+                WaterAmount.MEDIUM,
+                WaterAmount.HIGH,
+                WaterAmount.ULTRAHIGH,
+            ),
+        ),
+    ),
+)

--- a/deebot_client/hardware/deebot/e6ofmn.py
+++ b/deebot_client/hardware/deebot/e6ofmn.py
@@ -149,7 +149,7 @@ DEVICES[short_name(__name__)] = StaticDeviceInfo(
             ),
         ),
         life_span=CapabilityLifeSpan(
-			types=(
+		types=(
                 LifeSpan.BRUSH,
                 LifeSpan.FILTER,
                 LifeSpan.SIDE_BRUSH,

--- a/deebot_client/hardware/deebot/e6ofmn.py
+++ b/deebot_client/hardware/deebot/e6ofmn.py
@@ -149,7 +149,7 @@ DEVICES[short_name(__name__)] = StaticDeviceInfo(
             ),
         ),
         life_span=CapabilityLifeSpan(
-		types=(
+            types=(
                 LifeSpan.BRUSH,
                 LifeSpan.FILTER,
                 LifeSpan.SIDE_BRUSH,

--- a/deebot_client/hardware/deebot/lf3bn4.py
+++ b/deebot_client/hardware/deebot/lf3bn4.py
@@ -1,1 +1,1 @@
-p1jij8.py
+e6ofmn.py

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -286,6 +286,7 @@ def test_all_models_loaded() -> None:
         "85nbtp",
         "9ku8nu",
         "clojes",
+        "e6ofmn",
         "fallback",
         "itk04l",
         "lf3bn4",


### PR DESCRIPTION
Added an own deviceclass-file "e6ofmn.py" for Deebot X2 series and changed target in file "lf3bn4.py" to e6ofmn.py
Classname extracted from ecovacs-deebot.js (e6ofmn)
Used p1jij8.py as sourcefile for Mainfeatureset(T20 Omni) and upgraded with missing features from 2o4lnm.py file (X1 series)
Features missing was Sweep-mode and Voice Assistant

Hopefully i didnt make any mistakes while merging, feel free to double check my changes.
Should be ok but better safe than sorry...