### PR TITLE
Update Deebot X2 Omni to use version 2 map commands

### DIFF
--- a/deebot_client/hardware/deebot/e6ofmn.py
+++ b/deebot_client/hardware/deebot/e6ofmn.py
@@ -175,7 +175,9 @@ DEVICES[short_name(__name__)] = StaticDeviceInfo(
             reset=ResetLifeSpan,
         ),
         map=CapabilityMap(
-            cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo(version=2)]),
+            cached_info=CapabilityEvent(
+                CachedMapInfoEvent, [GetCachedMapInfo(version=2)]
+            ),
             changed=CapabilityEvent(MapChangedEvent, []),
             major=CapabilityEvent(MajorMapEvent, [GetMajorMap()]),
             multi_state=CapabilitySetEnable(


### PR DESCRIPTION
Since my X2 still wont show the map and rooms, i'll set it to Version 2 as a try