### PR TITLE
Remove ultra high waterflow level from X2

### DIFF
--- a/deebot_client/hardware/deebot/e6ofmn.py
+++ b/deebot_client/hardware/deebot/e6ofmn.py
@@ -220,7 +220,6 @@ DEVICES[short_name(__name__)] = StaticDeviceInfo(
                 WaterAmount.LOW,
                 WaterAmount.MEDIUM,
                 WaterAmount.HIGH,
-                WaterAmount.ULTRAHIGH,
             ),
         ),
     ),


### PR DESCRIPTION
Update the waterflow for X2 series as in Ecovacs App available

(deleted the Ultrahigh option)