### PR TITLE
Add sweep_type to WaterInfo event

### DIFF
--- a/deebot_client/commands/json/water_info.py
+++ b/deebot_client/commands/json/water_info.py
@@ -33,9 +33,8 @@ class GetWaterInfo(JsonGetCommand):
         if mop_attached is not None:
             mop_attached = bool(mop_attached)
 
-        sweep_type = data.get("sweepType")
-        if sweep_type is not None:
-            sweep_type = SweepType(int(data["sweepType"]))
+        if sweep_type := data.get("sweepType"):
+            sweep_type = SweepType(int(sweep_type))
 
         event_bus.notify(
             WaterInfoEvent(
@@ -55,8 +54,8 @@ class SetWaterInfo(JsonSetCommand):
     _mqtt_params = MappingProxyType(
         {
             "amount": InitParam(WaterAmount),
-            "sweepType": InitParam(SweepType),
             "enable": None,  # Remove it as we don't can set it (App includes it)
+            "sweepType": InitParam(SweepType, "sweep_type", optional=True),
         }
     )
 

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -24,7 +24,6 @@ from .map import (
     PositionType,
 )
 from .network import NetworkInfoEvent
-
 from .water_info import SweepType, WaterAmount, WaterInfoEvent
 from .work_mode import WorkMode, WorkModeEvent
 
@@ -52,8 +51,8 @@ __all__ = [
     "Position",
     "PositionType",
     "PositionsEvent",
-    "SweepType",
     "SweepModeEvent",
+    "SweepType",
     "WaterAmount",
     "WaterInfoEvent",
     "WorkMode",

--- a/deebot_client/events/water_info.py
+++ b/deebot_client/events/water_info.py
@@ -32,5 +32,5 @@ class WaterInfoEvent(Event):
 
     amount: WaterAmount
     # None means no data available
-    mop_attached: bool | None = field(kw_only=True, default=None)
     sweep_type: SweepType | None = None
+    mop_attached: bool | None = field(kw_only=True, default=None)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `sweepType` parameter to water information settings, allowing more granular control over water usage modes.
  
- **Bug Fixes**
  - Improved exception handling for missing parameters, ensuring smoother operation and better error messages.

- **Tests**
  - Added new test cases to validate the correct handling of the `sweepType` parameter and other water information settings.

- **Documentation**
  - Updated event notifications to include the new `sweepType` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->