### PR TITLE
Add cut direction for lawn mower goat g1

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -21,6 +21,7 @@ from deebot_client.events import (
     ContinuousCleaningEvent,
     CrossMapBorderWarningEvent,
     CustomCommandEvent,
+    CutDirectionEvent,
     ErrorEvent,
     Event,
     FanSpeedEvent,
@@ -189,6 +190,7 @@ class CapabilitySettings:
     )
     border_switch: CapabilitySetEnable[BorderSwitchEvent] | None = None
     child_lock: CapabilitySetEnable[ChildLockEvent] | None = None
+    cut_direction: CapabilitySet[CutDirectionEvent, int] | None = None
     moveup_warning: CapabilitySetEnable[MoveUpWarningEvent] | None = None
     cross_map_border_warning: CapabilitySetEnable[CrossMapBorderWarningEvent] | None = (
         None

--- a/deebot_client/commands/json/__init__.py
+++ b/deebot_client/commands/json/__init__.py
@@ -20,6 +20,7 @@ from .clean_preference import GetCleanPreference, SetCleanPreference
 from .clear_map import ClearMap
 from .continuous_cleaning import GetContinuousCleaning, SetContinuousCleaning
 from .cross_map_border_warning import GetCrossMapBorderWarning, SetCrossMapBorderWarning
+from .cut_direction import GetCutDirection, SetCutDirection
 from .efficiency import GetEfficiencyMode, SetEfficiencyMode
 from .error import GetError
 from .fan_speed import GetFanSpeed, SetFanSpeed
@@ -77,6 +78,8 @@ __all__ = [
     "GetCleanLogs",
     "GetContinuousCleaning",
     "SetContinuousCleaning",
+    "SetCutDirection",
+    "GetCutDirection",
     "GetCrossMapBorderWarning",
     "SetCrossMapBorderWarning",
     "GetEfficiencyMode",

--- a/deebot_client/commands/json/cut_direction.py
+++ b/deebot_client/commands/json/cut_direction.py
@@ -1,0 +1,43 @@
+"""Cut direction command module."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.command import InitParam
+from deebot_client.events import CutDirectionEvent
+from deebot_client.message import HandlingResult
+
+from .common import JsonGetCommand, JsonSetCommand
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+
+class GetCutDirection(JsonGetCommand):
+    """Get cut direction command."""
+
+    name = "getCutDirection"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        """Handle message->body->data and notify the correct event subscribers.
+
+        :return: A message response
+        """
+        event_bus.notify(CutDirectionEvent(angle=data["angle"]))
+        return HandlingResult.success()
+
+
+class SetCutDirection(JsonSetCommand):
+    """Set cut direction command."""
+
+    name = "setCutDirection"
+    get_command = GetCutDirection
+    _mqtt_params = MappingProxyType({"angle": InitParam(int)})
+
+    def __init__(self, angle: int) -> None:
+        super().__init__({"angle": angle})

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -287,3 +287,10 @@ class MoveUpWarningEvent(EnableEvent):
 @dataclass(frozen=True)
 class SafeProtectEvent(EnableEvent):
     """Safe protect event."""
+
+
+@dataclass(frozen=True)
+class CutDirectionEvent(Event):
+    """Cut direction event representation."""
+
+    angle: int

--- a/deebot_client/hardware/deebot/5xu9h3.py
+++ b/deebot_client/hardware/deebot/5xu9h3.py
@@ -19,11 +19,13 @@ from deebot_client.commands.json import (
     GetBorderSwitch,
     GetChildLock,
     GetCrossMapBorderWarning,
+    GetCutDirection,
     GetMoveUpWarning,
     GetSafeProtect,
     SetBorderSwitch,
     SetChildLock,
     SetCrossMapBorderWarning,
+    SetCutDirection,
     SetMoveUpWarning,
     SetSafeProtect,
 )
@@ -49,6 +51,7 @@ from deebot_client.events import (
     ChildLockEvent,
     CrossMapBorderWarningEvent,
     CustomCommandEvent,
+    CutDirectionEvent,
     ErrorEvent,
     LifeSpan,
     LifeSpanEvent,
@@ -103,6 +106,9 @@ DEVICES[short_name(__name__)] = StaticDeviceInfo(
             ),
             border_switch=CapabilitySetEnable(
                 BorderSwitchEvent, [GetBorderSwitch()], SetBorderSwitch
+            ),
+            cut_direction=CapabilitySet(
+                CutDirectionEvent, [GetCutDirection()], SetCutDirection
             ),
             child_lock=CapabilitySetEnable(
                 ChildLockEvent, [GetChildLock()], SetChildLock

--- a/tests/commands/json/test_cut_direction.py
+++ b/tests/commands/json/test_cut_direction.py
@@ -15,6 +15,6 @@ async def test_GetCutDirection() -> None:
 
 
 @pytest.mark.parametrize("angle", [1, 45, 90])
-async def test_SetCleanCount(angle: int) -> None:
+async def test_SetCutDirection(angle: int) -> None:
     args = {"angle": angle}
     await assert_set_command(SetCutDirection(angle), args, CutDirectionEvent(angle))

--- a/tests/commands/json/test_cut_direction.py
+++ b/tests/commands/json/test_cut_direction.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from deebot_client.commands.json import GetCutDirection, SetCutDirection
+from deebot_client.events import CutDirectionEvent
+from tests.helpers import get_request_json, get_success_body
+
+from . import assert_command, assert_set_command
+
+
+async def test_GetCutDirection() -> None:
+    json = get_request_json(get_success_body({"angle": 90}))
+    await assert_command(GetCutDirection(), json, CutDirectionEvent(90))
+
+
+@pytest.mark.parametrize("angle", [1, 45, 90])
+async def test_SetCleanCount(angle: int) -> None:
+    args = {"angle": angle}
+    await assert_set_command(SetCutDirection(angle), args, CutDirectionEvent(angle))

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from deebot_client.commands.json import GetCutDirection
 from deebot_client.commands.json.advanced_mode import GetAdvancedMode
 from deebot_client.commands.json.battery import GetBattery
 from deebot_client.commands.json.border_switch import GetBorderSwitch
@@ -49,6 +50,7 @@ from deebot_client.events import (
     ContinuousCleaningEvent,
     CrossMapBorderWarningEvent,
     CustomCommandEvent,
+    CutDirectionEvent,
     ErrorEvent,
     LifeSpan,
     LifeSpanEvent,
@@ -147,6 +149,7 @@ async def test_get_static_device_info(
                 AvailabilityEvent: [GetBattery(is_available_check=True)],
                 BatteryEvent: [GetBattery()],
                 BorderSwitchEvent: [GetBorderSwitch()],
+                CutDirectionEvent: [GetCutDirection()],
                 ChildLockEvent: [GetChildLock()],
                 CrossMapBorderWarningEvent: [GetCrossMapBorderWarning()],
                 CustomCommandEvent: [],
@@ -170,6 +173,7 @@ async def test_get_static_device_info(
                 AvailabilityEvent: [GetBattery(is_available_check=True)],
                 BatteryEvent: [GetBattery()],
                 BorderSwitchEvent: [GetBorderSwitch()],
+                CutDirectionEvent: [GetCutDirection()],
                 ChildLockEvent: [GetChildLock()],
                 CrossMapBorderWarningEvent: [GetCrossMapBorderWarning()],
                 CustomCommandEvent: [],


### PR DESCRIPTION
Extends goat lawn mower settings to adjust the cutting angle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced cut direction capability, allowing users to get and set the cut direction for their Deebot devices.

- **Bug Fixes**
  - Added comprehensive test cases for new cut direction commands to ensure reliability and correctness.

- **Improvements**
  - Enhanced event handling with the new `CutDirectionEvent` class, improving device interaction and control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->