### PR TITLE
Remove requests pinning

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,6 @@ pytest-asyncio==0.23.7
 pytest-cov==5.0.0
 pytest-docker-fixtures==1.3.19
 pytest-timeout==2.3.1
-requests<2.32.0 # Until https://github.com/docker/docker-py/issues/3256 is fixed
 testfixtures==8.3.0
 types-cachetools
 types-mock


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed outdated dependency `requests<2.32.0` from testing requirements for better compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->