### PR TITLE
Add XML command "GetCleanSum"

### DIFF
--- a/deebot_client/commands/xml/__init__.py
+++ b/deebot_client/commands/xml/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from deebot_client.command import Command, CommandMqttP2P
 
 from .charge_state import GetChargeState
+from .stats import GetCleanSum
 from .error import GetError
 from .fan_speed import GetFanSpeed
 from .pos import GetPos
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GetChargeState",
+    "GetCleanSum",
     "GetError",
     "GetFanSpeed",
     "GetPos",

--- a/deebot_client/commands/xml/__init__.py
+++ b/deebot_client/commands/xml/__init__.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING
 from deebot_client.command import Command, CommandMqttP2P
 
 from .charge_state import GetChargeState
-from .stats import GetCleanSum
 from .error import GetError
 from .fan_speed import GetFanSpeed
 from .pos import GetPos
+from .stats import GetCleanSum
 
 if TYPE_CHECKING:
     from .common import XmlCommand

--- a/deebot_client/commands/xml/stats.py
+++ b/deebot_client/commands/xml/stats.py
@@ -29,7 +29,11 @@ class GetCleanSum(XmlCommandWithMessageHandling):
         if xml.attrib.get("ret") != "ok":
             return HandlingResult.analyse()
 
-        if (area := xml.attrib.get("a")) and (lifetime := xml.attrib.get("l")) and (count := xml.attrib.get("c")):
+        if (
+            (area := xml.attrib.get("a"))
+            and (lifetime := xml.attrib.get("l"))
+            and (count := xml.attrib.get("c"))
+        ):
             event_bus.notify(TotalStatsEvent(int(area), int(lifetime), int(count)))
             return HandlingResult.success()
 

--- a/deebot_client/commands/xml/stats.py
+++ b/deebot_client/commands/xml/stats.py
@@ -1,0 +1,36 @@
+"""CleanSum command module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deebot_client.events import TotalStatsEvent
+from deebot_client.message import HandlingResult
+
+from .common import XmlCommandWithMessageHandling
+
+if TYPE_CHECKING:
+    from xml.etree.ElementTree import Element
+
+    from deebot_client.event_bus import EventBus
+
+
+class GetCleanSum(XmlCommandWithMessageHandling):
+    """GetCleanSum command."""
+
+    name = "GetCleanSum"
+
+    @classmethod
+    def _handle_xml(cls, event_bus: EventBus, xml: Element) -> HandlingResult:
+        """Handle xml message and notify the correct event subscribers.
+
+        :return: A message response
+        """
+        if xml.attrib.get("ret") != "ok":
+            return HandlingResult.analyse()
+
+        if (area := xml.attrib.get("a")) and (lifetime := xml.attrib.get("l")) and (count := xml.attrib.get("c")):
+            event_bus.notify(TotalStatsEvent(int(area), int(lifetime), int(count)))
+            return HandlingResult.success()
+
+        return HandlingResult.analyse()

--- a/tests/commands/xml/test_stats.py
+++ b/tests/commands/xml/test_stats.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deebot_client.command import CommandResult
+from deebot_client.commands.xml import GetCleanSum
+from deebot_client.events import TotalStatsEvent
+from deebot_client.message import HandlingState
+from tests.commands import assert_command
+
+from . import get_request_xml
+
+if TYPE_CHECKING:
+    from deebot_client.events.base import Event
+
+
+@pytest.mark.parametrize(
+    ("area", "lifetime", "count", "expected_event"),
+    [
+        (1000, 20, 30, TotalStatsEvent(1000, 20, 30)),
+    ],
+)
+async def test_get_clean_sum(area: int, lifetime: int, count: int, expected_event: Event) -> None:
+    json = get_request_xml(f"<ctl ret='ok' a='{area}' l='{lifetime}' c='{count}' />")
+    await assert_command(GetCleanSum(), json, expected_event)
+
+
+@pytest.mark.parametrize(
+    "xml",
+    ["<ctl ret='error'/>","<ctl ret='ok' a='34' />"],
+    ids=["error", "error"],
+)
+async def test_get_clean_sum_error(xml: str) -> None:
+    json = get_request_xml(xml)
+    await assert_command(
+        GetCleanSum(),
+        json,
+        None,
+        command_result=CommandResult(HandlingState.ANALYSE_LOGGED),
+    )

--- a/tests/commands/xml/test_stats.py
+++ b/tests/commands/xml/test_stats.py
@@ -22,14 +22,16 @@ if TYPE_CHECKING:
         (1000, 20, 30, TotalStatsEvent(1000, 20, 30)),
     ],
 )
-async def test_get_clean_sum(area: int, lifetime: int, count: int, expected_event: Event) -> None:
+async def test_get_clean_sum(
+    area: int, lifetime: int, count: int, expected_event: Event
+) -> None:
     json = get_request_xml(f"<ctl ret='ok' a='{area}' l='{lifetime}' c='{count}' />")
     await assert_command(GetCleanSum(), json, expected_event)
 
 
 @pytest.mark.parametrize(
     "xml",
-    ["<ctl ret='error'/>","<ctl ret='ok' a='34' />"],
+    ["<ctl ret='error'/>", "<ctl ret='ok' a='34' />"],
     ids=["error", "error"],
 )
 async def test_get_clean_sum_error(xml: str) -> None:


### PR DESCRIPTION
Adds GetCleanSum to get total stats of area, time and clean count.

Runtime tested:

![image](https://github.com/user-attachments/assets/5c662539-e50e-4b02-8d78-e062422bcee7)

Same value like the mobile app displays:

<img src="https://github.com/user-attachments/assets/ebd068d7-582f-41c4-876e-06fc96503fb8" width="200">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command, `GetCleanSum`, for handling XML messages related to cleaning statistics.
	- Expanded the public API to include `GetCleanSum`, allowing easier access for users.

- **Bug Fixes**
	- Enhanced robustness by ensuring only valid and complete data triggers event notifications in the `GetCleanSum` command.

- **Tests**
	- Added unit tests for the `GetCleanSum` command to validate its functionality across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->