### PR TITLE
WIP: Add capabilities definition for ls1ok3

### DIFF
--- a/deebot_client/hardware/deebot/ls1ok3.py
+++ b/deebot_client/hardware/deebot/ls1ok3.py
@@ -1,0 +1,80 @@
+"""ls1ok3 Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityLifeSpan,
+    CapabilitySet,
+    CapabilitySettings,
+    CapabilityStats,
+    DeviceType,
+)
+
+from deebot_client.commands.xml.charge_state import GetChargeState
+from deebot_client.commands.xml.error import GetError
+
+from deebot_client.commands.xml.stats import GetCleanSum
+
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AvailabilityEvent,
+    CustomCommandEvent,
+    ErrorEvent,
+    LifeSpanEvent,
+    NetworkInfoEvent,
+    ReportStatsEvent,
+    StateEvent,
+    StatsEvent,
+    TotalStatsEvent,
+    VolumeEvent,
+    BatteryEvent,
+)
+from deebot_client.models import StaticDeviceInfo, CleanAction
+from deebot_client.util import short_name
+
+from . import DEVICES
+from ...commands.json import SetVolume
+from ...commands.json.custom import CustomCommand
+from ...commands.xml.common import XmlCommand
+
+DEVICES[short_name(__name__)] = StaticDeviceInfo(
+    DataType.XML,
+    Capabilities(
+        availability=CapabilityEvent(AvailabilityEvent, []),
+        battery=CapabilityEvent(BatteryEvent, []),
+        charge=CapabilityExecute(XmlCommand),
+        clean=CapabilityClean(
+            action=CapabilityCleanAction(command=CleanAction),
+        ),
+        custom=CapabilityCustomCommand(event=CustomCommandEvent, get=[], set=CustomCommand),
+        device_type=DeviceType.VACUUM,
+        error=CapabilityEvent(ErrorEvent, [GetError()]),
+        life_span=CapabilityLifeSpan(
+            types=(),
+            event=LifeSpanEvent,
+            get=[],
+            reset=CustomCommand,
+        ),
+        network=CapabilityEvent(NetworkInfoEvent, []),
+        play_sound=CapabilityExecute(XmlCommand),
+        settings=CapabilitySettings(
+            volume=CapabilitySet(
+                event=VolumeEvent,
+                get=[],
+                set=SetVolume,
+            ),
+        ),
+        state=CapabilityEvent(StateEvent, [GetChargeState()]),
+        stats=CapabilityStats(
+            clean=CapabilityEvent(StatsEvent, [GetCleanSum()]),
+            report=CapabilityEvent(ReportStatsEvent, []),
+            total=CapabilityEvent(TotalStatsEvent, [GetCleanSum()]),
+        ),
+    ),
+)


### PR DESCRIPTION
It seems that some Capabilities are required that are not yet implemented. Currently, dummy functions or the JSON setters are used. Will replace them later.

To be implemented before this PR can be merged:

- [ ] GetBattery/GetBatteryInfo
- [x] Charge #813
- [ ] Clean #817
- [ ] CapabilityCustomCommand
- [x] GetLifeSpan https://github.com/DeebotUniverse/client.py/pull/575
- [ ] Set/Get FanSpeed: https://github.com/DeebotUniverse/client.py/pull/560
- [ ] network - IP not available for XML? But maybe signal strength?
- [x] play_sound: https://github.com/DeebotUniverse/client.py/pull/574
- [ ] GetVolume/SetVolume - not available for XML?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for the LS1OK3 robotic vacuum, enhancing its capabilities including battery status, cleaning actions, and settings management.
	- Added structured representation of device functionalities for improved interaction and control.
  
- **Improvements**
	- Enhanced command handling for XML and JSON interactions, allowing for better status reporting and command responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->