### PR TITLE
Use SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name        = "deebot-client"
-license     = {text = "GPL-3.0"}
+license     = "GPL-3.0-or-later"
 description = "Deebot client library in python 3"
 readme      = "README.md"
 authors     = [
@@ -14,7 +14,6 @@ keywords    = ["home", "automation", "homeassistant", "vacuum", "robot", "deebot
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3.12",
     "Topic :: Home Automation",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -189,4 +188,3 @@ overgeneral-exceptions = [
     "builtins.BaseException",
     "builtins.Exception",
 ]
-


### PR DESCRIPTION
`hatchling` recommends the use of SPDX license expressions for `project.license`.
https://hatch.pypa.io/1.9/config/metadata/#license

Chose the `-or-later` variant based on the license text
https://github.com/DeebotUniverse/client.py/blob/1edfda03f2459709d14330fe7cab5051505af943/LICENSE.txt#L637-L640

The alternative would be `GPL-3.0-only`.
https://spdx.org/licenses/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated project license to a more flexible format: "GPL-3.0-or-later."
- **Chores**
	- Removed outdated classifier entry related to the previous license representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->