### PR TITLE
Add Support for Deebot N8+ Black Variant

### DIFF
--- a/deebot_client/hardware/deebot/b2jqs4.py
+++ b/deebot_client/hardware/deebot/b2jqs4.py
@@ -1,0 +1,198 @@
+"""DEEBOT N8+ Black Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityLifeSpan,
+    CapabilityMap,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStats,
+    DeviceType,
+)
+from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.carpet import (
+    GetCarpetAutoFanBoost,
+    SetCarpetAutoFanBoost,
+)
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.clean import Clean, CleanArea, GetCleanInfo
+from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
+from deebot_client.commands.json.clean_logs import GetCleanLogs
+from deebot_client.commands.json.clean_preference import (
+    GetCleanPreference,
+    SetCleanPreference,
+)
+from deebot_client.commands.json.continuous_cleaning import (
+    GetContinuousCleaning,
+    SetContinuousCleaning,
+)
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import GetCachedMapInfo, GetMajorMap, GetMapTrace
+from deebot_client.commands.json.multimap_state import (
+    GetMultimapState,
+    SetMultimapState,
+)
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
+from deebot_client.commands.json.relocation import SetRelocationState
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AdvancedModeEvent,
+    AvailabilityEvent,
+    BatteryEvent,
+    CachedMapInfoEvent,
+    CarpetAutoFanBoostEvent,
+    CleanCountEvent,
+    CleanLogEvent,
+    CleanPreferenceEvent,
+    ContinuousCleaningEvent,
+    CustomCommandEvent,
+    ErrorEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    LifeSpan,
+    LifeSpanEvent,
+    MajorMapEvent,
+    MapChangedEvent,
+    MapTraceEvent,
+    MultimapStateEvent,
+    NetworkInfoEvent,
+    PositionsEvent,
+    ReportStatsEvent,
+    RoomsEvent,
+    StateEvent,
+    StatsEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VolumeEvent,
+    WaterAmount,
+    WaterInfoEvent,
+)
+from deebot_client.models import StaticDeviceInfo
+from deebot_client.util import short_name
+
+from . import DEVICES
+
+DEVICES[short_name(__name__)] = StaticDeviceInfo(
+    DataType.JSON,
+    Capabilities(
+        device_type=DeviceType.VACUUM,
+        availability=CapabilityEvent(
+            AvailabilityEvent, [GetBattery(is_available_check=True)]
+        ),
+        battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+        charge=CapabilityExecute(Charge),
+        clean=CapabilityClean(
+            action=CapabilityCleanAction(command=Clean, area=CleanArea),
+            continuous=CapabilitySetEnable(
+                ContinuousCleaningEvent,
+                [GetContinuousCleaning()],
+                SetContinuousCleaning,
+            ),
+            count=CapabilitySet(CleanCountEvent, [GetCleanCount()], SetCleanCount),
+            log=CapabilityEvent(CleanLogEvent, [GetCleanLogs()]),
+            preference=CapabilitySetEnable(
+                CleanPreferenceEvent, [GetCleanPreference()], SetCleanPreference
+            ),
+        ),
+        custom=CapabilityCustomCommand(
+            event=CustomCommandEvent, get=[], set=CustomCommand
+        ),
+        error=CapabilityEvent(ErrorEvent, [GetError()]),
+        fan_speed=CapabilitySetTypes(
+            event=FanSpeedEvent,
+            get=[GetFanSpeed()],
+            set=SetFanSpeed,
+            types=(
+                FanSpeedLevel.QUIET,
+                FanSpeedLevel.NORMAL,
+                FanSpeedLevel.MAX,
+                FanSpeedLevel.MAX_PLUS,
+            ),
+        ),
+        life_span=CapabilityLifeSpan(
+            types=(
+                LifeSpan.BRUSH,
+                LifeSpan.FILTER,
+                LifeSpan.SIDE_BRUSH,
+                LifeSpan.UNIT_CARE,
+            ),
+            event=LifeSpanEvent,
+            get=[
+                GetLifeSpan(
+                    [
+                        LifeSpan.BRUSH,
+                        LifeSpan.FILTER,
+                        LifeSpan.SIDE_BRUSH,
+                        LifeSpan.UNIT_CARE,
+                    ]
+                )
+            ],
+            reset=ResetLifeSpan,
+        ),
+        map=CapabilityMap(
+            cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo()]),
+            changed=CapabilityEvent(MapChangedEvent, []),
+            major=CapabilityEvent(MajorMapEvent, [GetMajorMap()]),
+            multi_state=CapabilitySetEnable(
+                MultimapStateEvent, [GetMultimapState()], SetMultimapState
+            ),
+            position=CapabilityEvent(PositionsEvent, [GetPos()]),
+            relocation=CapabilityExecute(SetRelocationState),
+            rooms=CapabilityEvent(RoomsEvent, [GetCachedMapInfo()]),
+            trace=CapabilityEvent(MapTraceEvent, [GetMapTrace()]),
+        ),
+        network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+        play_sound=CapabilityExecute(PlaySound),
+        settings=CapabilitySettings(
+            advanced_mode=CapabilitySetEnable(
+                AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
+            ),
+            carpet_auto_fan_boost=CapabilitySetEnable(
+                CarpetAutoFanBoostEvent,
+                [GetCarpetAutoFanBoost()],
+                SetCarpetAutoFanBoost,
+            ),
+            true_detect=CapabilitySetEnable(
+                TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+            ),
+            volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+        ),
+        state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfo()]),
+        stats=CapabilityStats(
+            clean=CapabilityEvent(StatsEvent, [GetStats()]),
+            report=CapabilityEvent(ReportStatsEvent, []),
+            total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+        ),
+        water=CapabilitySetTypes(
+            event=WaterInfoEvent,
+            get=[GetWaterInfo()],
+            set=SetWaterInfo,
+            types=(
+                WaterAmount.LOW,
+                WaterAmount.MEDIUM,
+                WaterAmount.HIGH,
+                WaterAmount.ULTRAHIGH,
+            ),
+        ),
+    ),
+)

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -265,6 +265,7 @@ def test_all_models_loaded() -> None:
         "8kwdb4",
         "9ku8nu",
         "9s1s80",
+        "b2jqs4",
         "b742vd",
         "clojes",
         "e6ofmn",


### PR DESCRIPTION
Good Evening!

Apparently the white and black vaccums each have a different class ID.  I only have the White one at my disposal, and someone commented on my original pull request that theirs wasn't working with the log.

Please merge this file to add support for the Deebot N8+ Black Variant.  It is the same as the other one I submitted as they are identical vacuums other than the color of the plastic.

Thank you.