### PR TITLE
Remove main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - main
       - dev
   pull_request:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,6 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - main
       - dev
   pull_request:
   schedule:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - main
+      - dev
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Currently, it's an overhead to maintain two branches and only release from the main branch.
Remove it for now and release directly from the dev branch