### PR TITLE
Add Deebot T30S Care (63cum9)

### DIFF
--- a/deebot_client/hardware/deebot/63cum9.py
+++ b/deebot_client/hardware/deebot/63cum9.py
@@ -1,0 +1,1 @@
+xco2fc.py


### PR DESCRIPTION
Add support for the Deebot T30S Care (63cum9) using symlink to xco2fc