### PR TITLE
Add tests for json play_sound command

### DIFF
--- a/tests/commands/json/test_play_sound.py
+++ b/tests/commands/json/test_play_sound.py
@@ -16,7 +16,10 @@ from . import assert_command
     ("json", "command_result"),
     [
         (get_request_json(get_success_body()), CommandResult.success()),
-        (get_request_json({"code": -1, "msg": "failed", "data": ""}), CommandResult(HandlingState.FAILED)),
+        (
+            get_request_json({"code": -1, "msg": "failed", "data": ""}),
+            CommandResult(HandlingState.FAILED),
+        ),
     ],
 )
 async def test_play_sound(json: dict[str, Any], command_result: CommandResult) -> None:

--- a/tests/commands/json/test_play_sound.py
+++ b/tests/commands/json/test_play_sound.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from deebot_client.command import CommandResult
+from deebot_client.commands.json import PlaySound
+from deebot_client.message import HandlingState
+from tests.helpers import get_request_json, get_success_body
+
+from . import assert_command
+
+
+@pytest.mark.parametrize(
+    ("json", "command_result"),
+    [
+        (get_request_json(get_success_body()), CommandResult.success()),
+        (get_request_json({"code": -1, "msg": "failed", "data": ""}), CommandResult(HandlingState.FAILED)),
+    ],
+)
+async def test_play_sound(json: dict[str, Any], command_result: CommandResult) -> None:
+    await assert_command(PlaySound(), json, None, command_result=command_result)


### PR DESCRIPTION
I did not find tests for the JSON version of play_sound. I'm not sure if I missed it. 

If it is not needed, feel free to close this PR.