### PR TITLE
Make Multimap support optional.

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -176,7 +176,7 @@ class CapabilityMap:
     changed: CapabilityEvent[MapChangedEvent]
     clear: CapabilityExecute[[]] | None = None
     major: CapabilityEvent[MajorMapEvent]
-    multi_state: CapabilitySetEnable[MultimapStateEvent]
+    multi_state: CapabilitySetEnable[MultimapStateEvent] | None = None
     position: CapabilityEvent[PositionsEvent]
     relocation: CapabilityExecute[[]]
     rooms: CapabilityEvent[RoomsEvent]


### PR DESCRIPTION
This is needed as OZMO 905 has no Multimap support.

NOTE: This is a breaking change