### PR TITLE
Add support for DEEBOT T50 MAX PRO OMNI (qnkybo)

### DIFF
--- a/deebot_client/hardware/deebot/qnkybo.py
+++ b/deebot_client/hardware/deebot/qnkybo.py
@@ -1,0 +1,1 @@
+cuoipb.py


### PR DESCRIPTION
Add support for DEEBOT T50 MAX PRO OMNI (qnkybo) (sym link to T50 Pro OMNI cuoipb). Tested and looks to be importing and working fine. 