### PR TITLE
Add basic support for T80 Omni (9eamof)

### DIFF
--- a/deebot_client/hardware/deebot/9eamof.py
+++ b/deebot_client/hardware/deebot/9eamof.py
@@ -34,9 +34,7 @@ from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
 from deebot_client.commands.json.clean import (
-    Clean,
     CleanArea,
-    GetCleanInfo,
     CleanV2,
     GetCleanInfoV2,
 )

--- a/deebot_client/hardware/deebot/9eamof.py
+++ b/deebot_client/hardware/deebot/9eamof.py
@@ -1,0 +1,290 @@
+"""Deebot DEEBOT T80 OMNI Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityExecuteTypes,
+    CapabilityLifeSpan,
+    CapabilityMap,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStation,
+    CapabilityStats,
+    CapabilityWater,
+    DeviceType,
+)
+from deebot_client.commands import StationAction
+from deebot_client.commands.json import station_action
+from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
+from deebot_client.commands.json.auto_empty import GetAutoEmpty, SetAutoEmpty
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.carpet import (
+    GetCarpetAutoFanBoost,
+    SetCarpetAutoFanBoost,
+)
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
+from deebot_client.commands.json.clean import (
+    Clean,
+    CleanArea,
+    GetCleanInfo,
+    CleanV2,
+    GetCleanInfoV2,
+)
+from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
+from deebot_client.commands.json.clean_logs import GetCleanLogs
+from deebot_client.commands.json.clean_preference import (
+    GetCleanPreference,
+    SetCleanPreference,
+)
+from deebot_client.commands.json.continuous_cleaning import (
+    GetContinuousCleaning,
+    SetContinuousCleaning,
+)
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.efficiency import GetEfficiencyMode, SetEfficiencyMode
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import (
+    GetCachedMapInfo,
+    GetMajorMap,
+    GetMapTrace,
+    GetMinorMap,
+)
+from deebot_client.commands.json.multimap_state import (
+    GetMultimapState,
+    SetMultimapState,
+)
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.ota import GetOta, SetOta
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
+from deebot_client.commands.json.relocation import SetRelocationState
+from deebot_client.commands.json.station_state import GetStationState
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.sweep_mode import GetSweepMode, SetSweepMode
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.voice_assistant_state import (
+    GetVoiceAssistantState,
+    SetVoiceAssistantState,
+)
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.commands.json.work_mode import GetWorkMode, SetWorkMode
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AdvancedModeEvent,
+    AvailabilityEvent,
+    BatteryEvent,
+    CachedMapInfoEvent,
+    CarpetAutoFanBoostEvent,
+    ChildLockEvent,
+    CleanCountEvent,
+    CleanLogEvent,
+    CleanPreferenceEvent,
+    ContinuousCleaningEvent,
+    CustomCommandEvent,
+    EfficiencyModeEvent,
+    ErrorEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    LifeSpan,
+    LifeSpanEvent,
+    MajorMapEvent,
+    MapChangedEvent,
+    MapTraceEvent,
+    MultimapStateEvent,
+    NetworkInfoEvent,
+    OtaEvent,
+    PositionsEvent,
+    ReportStatsEvent,
+    RoomsEvent,
+    StateEvent,
+    StationEvent,
+    StatsEvent,
+    SweepModeEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VoiceAssistantStateEvent,
+    VolumeEvent,
+    WorkMode,
+    WorkModeEvent,
+    auto_empty,
+    water_info,
+)
+from deebot_client.events.auto_empty import AutoEmptyEvent
+from deebot_client.events.efficiency_mode import EfficiencyMode
+from deebot_client.models import StaticDeviceInfo
+from deebot_client.util import short_name
+
+from . import DEVICES
+
+DEVICES[short_name(__name__)] = StaticDeviceInfo(
+    DataType.JSON,
+    Capabilities(
+        device_type=DeviceType.VACUUM,
+        availability=CapabilityEvent(
+            AvailabilityEvent, [GetBattery(is_available_check=True)]
+        ),
+        battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+        charge=CapabilityExecute(Charge),
+        clean=CapabilityClean(
+            action=CapabilityCleanAction(command=CleanV2, area=CleanArea),
+            continuous=CapabilitySetEnable(
+                ContinuousCleaningEvent,
+                [GetContinuousCleaning()],
+                SetContinuousCleaning,
+            ),
+            count=CapabilitySet(CleanCountEvent, [GetCleanCount()], SetCleanCount),
+            log=CapabilityEvent(CleanLogEvent, [GetCleanLogs()]),
+            preference=CapabilitySetEnable(
+                CleanPreferenceEvent, [GetCleanPreference()], SetCleanPreference
+            ),
+            work_mode=CapabilitySetTypes(
+                event=WorkModeEvent,
+                get=[GetWorkMode()],
+                set=SetWorkMode,
+                types=(
+                    WorkMode.MOP,
+                    WorkMode.MOP_AFTER_VACUUM,
+                    WorkMode.VACUUM,
+                    WorkMode.VACUUM_AND_MOP,
+                ),
+            ),
+        ),
+        custom=CapabilityCustomCommand(
+            event=CustomCommandEvent, get=[], set=CustomCommand
+        ),
+        error=CapabilityEvent(ErrorEvent, [GetError()]),
+        fan_speed=CapabilitySetTypes(
+            event=FanSpeedEvent,
+            get=[GetFanSpeed()],
+            set=SetFanSpeed,
+            types=(
+                FanSpeedLevel.QUIET,
+                FanSpeedLevel.NORMAL,
+                FanSpeedLevel.MAX,
+                FanSpeedLevel.MAX_PLUS,
+            ),
+        ),
+        life_span=CapabilityLifeSpan(
+            types=(
+                LifeSpan.BRUSH,
+                LifeSpan.FILTER,
+                LifeSpan.HAND_FILTER,
+                LifeSpan.SIDE_BRUSH,
+                LifeSpan.UNIT_CARE,
+            ),
+            event=LifeSpanEvent,
+            get=[
+                GetLifeSpan(
+                    [
+                        LifeSpan.BRUSH,
+                        LifeSpan.FILTER,
+                        LifeSpan.HAND_FILTER,
+                        LifeSpan.SIDE_BRUSH,
+                        LifeSpan.UNIT_CARE,
+                    ]
+                )
+            ],
+            reset=ResetLifeSpan,
+        ),
+        map=CapabilityMap(
+            cached_info=CapabilityEvent(
+                CachedMapInfoEvent, [GetCachedMapInfo(version=2)]
+            ),
+            changed=CapabilityEvent(MapChangedEvent, []),
+            major=CapabilityEvent(MajorMapEvent, [GetMajorMap()]),
+            minor=CapabilityExecute(GetMinorMap),
+            multi_state=CapabilitySetEnable(
+                MultimapStateEvent, [GetMultimapState()], SetMultimapState
+            ),
+            position=CapabilityEvent(PositionsEvent, [GetPos()]),
+            relocation=CapabilityExecute(SetRelocationState),
+            rooms=CapabilityEvent(RoomsEvent, [GetCachedMapInfo(version=2)]),
+            trace=CapabilityEvent(MapTraceEvent, [GetMapTrace()]),
+        ),
+        network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+        play_sound=CapabilityExecute(PlaySound),
+        settings=CapabilitySettings(
+            advanced_mode=CapabilitySetEnable(
+                AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
+            ),
+            carpet_auto_fan_boost=CapabilitySetEnable(
+                CarpetAutoFanBoostEvent,
+                [GetCarpetAutoFanBoost()],
+                SetCarpetAutoFanBoost,
+            ),
+            child_lock=CapabilitySetEnable(
+                ChildLockEvent, [GetChildLock()], SetChildLock
+            ),
+            efficiency_mode=CapabilitySetTypes(
+                event=EfficiencyModeEvent,
+                get=[GetEfficiencyMode()],
+                set=SetEfficiencyMode,
+                types=(
+                    EfficiencyMode.ENERGY_EFFICIENT_MODE,
+                    EfficiencyMode.STANDARD_MODE,
+                ),
+            ),
+            ota=CapabilitySetEnable(OtaEvent, [GetOta()], SetOta),
+            sweep_mode=CapabilitySetEnable(
+                SweepModeEvent, [GetSweepMode()], SetSweepMode
+            ),
+            true_detect=CapabilitySetEnable(
+                TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+            ),
+            voice_assistant=CapabilitySetEnable(
+                VoiceAssistantStateEvent,
+                [GetVoiceAssistantState()],
+                SetVoiceAssistantState,
+            ),
+            volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+        ),
+        state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfoV2()]),
+        station=CapabilityStation(
+            action=CapabilityExecuteTypes(
+                station_action.StationAction, types=(StationAction.EMPTY_DUSTBIN,)
+            ),
+            auto_empty=CapabilitySetTypes(
+                event=AutoEmptyEvent,
+                get=[GetAutoEmpty()],
+                set=SetAutoEmpty,
+                types=(
+                    auto_empty.Frequency.AUTO,
+                    auto_empty.Frequency.SMART,
+                ),
+            ),
+            state=CapabilityEvent(StationEvent, [GetStationState()]),
+        ),
+        stats=CapabilityStats(
+            clean=CapabilityEvent(StatsEvent, [GetStats()]),
+            report=CapabilityEvent(ReportStatsEvent, []),
+            total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+        ),
+        water=CapabilityWater(
+            amount=CapabilitySetTypes(
+                event=water_info.WaterAmountEvent,
+                get=[GetWaterInfo()],
+                set=SetWaterInfo,
+                types=(
+                    water_info.WaterAmount.LOW,
+                    water_info.WaterAmount.MEDIUM,
+                    water_info.WaterAmount.HIGH,
+                    water_info.WaterAmount.ULTRAHIGH,
+                ),
+            ),
+            mop_attached=CapabilityEvent(water_info.MopAttachedEvent, [GetWaterInfo()]),
+        ),
+    ),
+)


### PR DESCRIPTION
I originally tested https://github.com/DeebotUniverse/client.py/pull/1043 but found that some of the capabilities need their v2 version to work properly: 

- GetCachedMapInfo needed the version=2 parameter
- CleanV2
- GetCleanInfoV2

Even with this, there are some errors in the HA logs:

```
Could not parse getMapSubSet: {'ret': 'ok', 'resp': {'body': {'code': 20003, 'msg': 'rcp not support'}...
Could not parse getMajorMap: {'cellHeight': 1, 'cellWidth': 1, 'mid': '1847680119', 'pieceHeight': 800, 'pieceWidth': 800, 'pixel': 50, 'type': 'ol', 'value': ''}
Could not parse getWaterInfo: {'customAmount': 30, 'enable': 1, 'mopCount': 2, 'sideMop': 0, 'sweepType': 1, 'type': 1}
Could not parse getLifeSpan: [{'left': 17812, 'total': 18000, 'type': 'brush'}, {'left': 100, 'total': 100, 'type': 'cleaningSolution'}, {'left': 2812, 'total': 3000, 'type': 'dustBag'}, {'left': 30000, 'total': 30000, 'type': 'handFilter'}, {'left': 7012, 'total': 7200, 'type': 'heap'}, {'left': 8926, 'total': 9000, 'type': 'roundMop'}, {'left': 3526, 'total': 3600, 'type': 'sewageBox'}, {'left': 8731, 'total': 9000, 'type': 'sideBrush'}, {'left': 1800, 'total': 1800, 'type': 'strainer'}, {'left': 1531, 'total': 1800, 'type': 'unitCare'}, {'left': 3526, 'total': 3600, 'type': 'waterSink'}]
```

I assume the first will probably have a new V2 or something, and the others just have slightly different behavior on this machine that will need to be updated. I'll see if I can get around to it once I figure out the whole dev setup for this package + HA.