### PR TITLE
Add support for DEEBOT OZMO T5 Hero (eazo2f)

### DIFF
--- a/deebot_client/hardware/deebot/eazo2f.py
+++ b/deebot_client/hardware/deebot/eazo2f.py
@@ -1,0 +1,1 @@
+yna5xi.py

--- a/deebot_client/hardware/deebot/eazo2f.py
+++ b/deebot_client/hardware/deebot/eazo2f.py
@@ -1,1 +1,1 @@
-yna5xi.py
+9rft3c.py


### PR DESCRIPTION
I have tested the following command inside the Docker container:
```
docker exec -it $(docker ps -f name=homeassistant -q) bash
cd /usr/local/lib/python3.13/site-packages/deebot_client/hardware/deebot
ln -svfT 9rft3c.py eazo2f.py
```

This symbolic link works correctly with my DEEBOT OZMO T5 Hero, which is the Chinese market version of the DEEBOT OZMO T5.
By adding this link, the integration functions properly without requiring code changes for this variant.

