### PR TITLE
Add support for WorkState messages/commands

### DIFF
--- a/deebot_client/commands/json/work_state.py
+++ b/deebot_client/commands/json/work_state.py
@@ -1,0 +1,13 @@
+"""Work state commands."""
+
+from __future__ import annotations
+
+from deebot_client.messages.json.work_state import OnWorkState
+
+from .common import JsonCommandWithMessageHandling
+
+
+class GetWorkState(OnWorkState, JsonCommandWithMessageHandling):
+    """Get work state command."""
+
+    NAME = "getWorkState"

--- a/deebot_client/events/station.py
+++ b/deebot_client/events/station.py
@@ -16,6 +16,8 @@ class State(IntEnum):
 
     IDLE = 0
     EMPTYING = 1
+    WASHING = 2
+    DRYING = 3
 
 
 @dataclass(frozen=True)

--- a/deebot_client/hardware/deebot/ilt3k8.py
+++ b/deebot_client/hardware/deebot/ilt3k8.py
@@ -38,7 +38,6 @@ from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
 from deebot_client.commands.json.clean import (
     CleanArea,
     CleanV2,
-    GetCleanInfoV2,
 )
 from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
 from deebot_client.commands.json.clean_logs import GetCleanLogs
@@ -54,7 +53,6 @@ from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
 from deebot_client.commands.json.network import GetNetInfo
 from deebot_client.commands.json.ota import GetOta, SetOta
 from deebot_client.commands.json.play_sound import PlaySound
-from deebot_client.commands.json.station_state import GetStationState
 from deebot_client.commands.json.stats import GetStats, GetTotalStats
 from deebot_client.commands.json.sweep_mode import GetSweepMode, SetSweepMode
 from deebot_client.commands.json.voice_assistant_state import (
@@ -64,6 +62,7 @@ from deebot_client.commands.json.voice_assistant_state import (
 from deebot_client.commands.json.volume import GetVolume, SetVolume
 from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
 from deebot_client.commands.json.work_mode import GetWorkMode, SetWorkMode
+from deebot_client.commands.json.work_state import GetWorkState
 from deebot_client.const import DataType
 from deebot_client.events import (
     AdvancedModeEvent,
@@ -217,7 +216,7 @@ DEVICES[short_name(__name__)] = StaticDeviceInfo(
             volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
             # TODO: add true detect once the implementation supports the 'level' attribute
         ),
-        state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfoV2()]),
+        state=CapabilityEvent(StateEvent, [GetChargeState(), GetWorkState()]),
         station=CapabilityStation(
             action=CapabilityExecuteTypes(
                 station_action.StationAction, types=(StationAction.EMPTY_DUSTBIN,)
@@ -231,7 +230,7 @@ DEVICES[short_name(__name__)] = StaticDeviceInfo(
                     auto_empty.Frequency.SMART,
                 ),
             ),
-            state=CapabilityEvent(StationEvent, [GetStationState()]),
+            state=CapabilityEvent(StationEvent, [GetWorkState()]),
         ),
         stats=CapabilityStats(
             clean=CapabilityEvent(StatsEvent, [GetStats()]),

--- a/deebot_client/messages/json/__init__.py
+++ b/deebot_client/messages/json/__init__.py
@@ -9,6 +9,7 @@ from .battery import OnBattery
 from .map import OnMapSetV2
 from .station_state import OnStationState
 from .stats import OnStats, ReportStats
+from .work_state import OnWorkState
 
 if TYPE_CHECKING:
     from deebot_client.message import Message
@@ -33,6 +34,8 @@ _MESSAGES: list[type[Message]] = [
 
     OnStats,
     ReportStats,
+
+    OnWorkState,
 ]
 # fmt: on
 

--- a/deebot_client/messages/json/work_state.py
+++ b/deebot_client/messages/json/work_state.py
@@ -1,0 +1,66 @@
+"""Base work state messages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.events import StateEvent
+from deebot_client.events.station import State as StationState, StationEvent
+from deebot_client.message import HandlingResult, MessageBodyDataDict
+from deebot_client.models import State as RobotState
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+_WORK_STATE_2_EVENTS: dict[str, dict[str, tuple[RobotState | None, StationState]]] = {
+    "idle": {
+        "idle": (None, StationState.IDLE),
+        "goCharging": (RobotState.RETURNING, StationState.IDLE),
+        "goEmptying": (RobotState.RETURNING, StationState.IDLE),
+        "emptying": (RobotState.DOCKED, StationState.EMPTYING),
+        "washing": (RobotState.DOCKED, StationState.WASHING),
+        "drying": (RobotState.DOCKED, StationState.DRYING),
+    },
+    "cleaning": {
+        "idle": (RobotState.CLEANING, StationState.IDLE),
+        "goCharging": (RobotState.RETURNING, StationState.IDLE),
+        "goEmptying": (RobotState.RETURNING, StationState.IDLE),
+        "emptying": (RobotState.DOCKED, StationState.EMPTYING),
+        "washing": (RobotState.DOCKED, StationState.WASHING),
+        "drying": (RobotState.DOCKED, StationState.DRYING),
+    },
+}
+
+
+class OnWorkState(MessageBodyDataDict):
+    """On work state message."""
+
+    NAME = "onWorkState"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        """Handle message->body->data and notify the correct event subscribers.
+
+        :return: A message response
+        """
+        robot_state = data.get("robotState", {}).get("state")
+        station_state = data.get("stationState", {}).get("state")
+
+        robot_status, station_status = _WORK_STATE_2_EVENTS.get(robot_state, {}).get(
+            station_state, (None, None)
+        )
+
+        if (robot_status, station_status) == (None, None):
+            return HandlingResult.analyse()
+
+        if data.get("paused") == 1:
+            robot_status = RobotState.PAUSED
+
+        if robot_status is not None:
+            event_bus.notify(StateEvent(robot_status))
+        if station_status is not None:
+            event_bus.notify(StationEvent(station_status))
+
+        return HandlingResult.success()

--- a/tests/commands/json/test_work_state.py
+++ b/tests/commands/json/test_work_state.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from deebot_client.command import CommandResult
+from deebot_client.commands.json.work_state import GetWorkState
+from deebot_client.events import StateEvent
+from deebot_client.events.station import State as StationState, StationEvent
+from deebot_client.message import HandlingState
+from deebot_client.models import State as RobotState
+from tests.helpers import get_request_json, get_success_body
+
+from . import assert_command
+
+if TYPE_CHECKING:
+    from deebot_client.events.base import Event
+
+
+@pytest.mark.parametrize(
+    ("paused", "robot_state", "additional_content", "station_state", "expected"),
+    [
+        (
+            0,
+            "idle",
+            {},
+            "idle",
+            [StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "goCharging",
+            [StateEvent(RobotState.RETURNING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "goEmptying",
+            [StateEvent(RobotState.RETURNING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "emptying",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.EMPTYING)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "washing",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.WASHING)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "drying",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.DRYING)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "idle",
+            [StateEvent(RobotState.CLEANING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "goCharging",
+            [StateEvent(RobotState.RETURNING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "goEmptying",
+            [StateEvent(RobotState.RETURNING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "emptying",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.EMPTYING)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "washing",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.WASHING)],
+        ),
+        (
+            1,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "idle",
+            [StateEvent(RobotState.PAUSED), StationEvent(StationState.IDLE)],
+        ),
+    ],
+)
+async def test_GetWorkState(
+    paused: int,
+    robot_state: str,
+    additional_content: dict[str, Any],
+    station_state: str,
+    expected: list[Event],
+) -> None:
+    json, firmware_event = get_request_json(
+        get_success_body(
+            {
+                "paused": paused,
+                "robotState": {
+                    "state": robot_state,
+                    "trigger": "app",
+                    **additional_content,
+                },
+                "stationState": {"state": station_state, "trigger": "app"},
+            }
+        )
+    )
+    await assert_command(GetWorkState(), json, (firmware_event, *expected))
+
+
+async def test_GetWorkStateUnknownValues() -> None:
+    json, firmware_event = get_request_json(
+        get_success_body(
+            {
+                "paused": 0,
+                "robotState": {
+                    "state": "unknownState",
+                    "trigger": "app",
+                },
+                "stationState": {"state": "anotherUnknownState", "trigger": "app"},
+            }
+        )
+    )
+    await assert_command(
+        GetWorkState(),
+        json,
+        firmware_event,
+        command_result=CommandResult(HandlingState.ANALYSE_LOGGED),
+    )

--- a/tests/commands/json/test_work_state.py
+++ b/tests/commands/json/test_work_state.py
@@ -130,19 +130,35 @@ async def test_GetWorkState(
     await assert_command(GetWorkState(), json, (firmware_event, *expected))
 
 
-async def test_GetWorkStateUnknownValues() -> None:
-    json, firmware_event = get_request_json(
-        get_success_body(
-            {
-                "paused": 0,
-                "robotState": {
-                    "state": "unknownState",
-                    "trigger": "app",
-                },
-                "stationState": {"state": "anotherUnknownState", "trigger": "app"},
-            }
-        )
-    )
+@pytest.mark.parametrize(
+    "request_data",
+    [
+        {
+            "paused": 0,
+            "robotState": {
+                "state": "unknownState",
+                "trigger": "app",
+            },
+            "stationState": {"state": "anotherUnknownState", "trigger": "app"},
+        },
+        {
+            "paused": 0,
+        },
+        {
+            "paused": 0,
+            "robotState": {
+                "state": "cleaning",
+                "trigger": "app",
+            },
+        },
+        {
+            "paused": 0,
+            "stationState": {"state": "emptying", "trigger": "app"},
+        },
+    ],
+)
+async def test_GetWorkState_edge_cases(request_data: dict[str, Any]) -> None:
+    json, firmware_event = get_request_json(get_success_body(request_data))
     await assert_command(
         GetWorkState(),
         json,

--- a/tests/messages/__init__.py
+++ b/tests/messages/__init__.py
@@ -35,10 +35,18 @@ def assert_message_failure(
     message: type[Message],
     data: MessagePayloadType,
     expected_result_state: HandlingState,
+    expected_events: Event | None | Sequence[Event] = None,
 ) -> None:
     event_bus = Mock(spec_set=EventBus)
 
     result = message.handle(event_bus, data)
 
     assert result.state == expected_result_state
-    event_bus.notify.assert_not_called()
+    if expected_events:
+        if isinstance(expected_events, Sequence):
+            event_bus.notify.assert_has_calls([call(x) for x in expected_events])
+            assert event_bus.notify.call_count == len(expected_events)
+        else:
+            event_bus.notify.assert_called_once_with(expected_events)
+    else:
+        event_bus.notify.assert_not_called()

--- a/tests/messages/json/test_work_state.py
+++ b/tests/messages/json/test_work_state.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from deebot_client.events import FirmwareEvent, StateEvent
+from deebot_client.events.station import State as StationState, StationEvent
+from deebot_client.message import HandlingState
+from deebot_client.messages.json.work_state import OnWorkState
+from deebot_client.models import State as RobotState
+from tests.messages import assert_message, assert_message_failure
+
+if TYPE_CHECKING:
+    from deebot_client.events.base import Event
+
+
+@pytest.mark.parametrize(
+    ("paused", "robot_state", "additional_content", "station_state", "expected"),
+    [
+        (
+            0,
+            "idle",
+            {},
+            "idle",
+            [StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "goCharging",
+            [StateEvent(RobotState.RETURNING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "goEmptying",
+            [StateEvent(RobotState.RETURNING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "emptying",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.EMPTYING)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "washing",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.WASHING)],
+        ),
+        (
+            0,
+            "idle",
+            {},
+            "drying",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.DRYING)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "idle",
+            [StateEvent(RobotState.CLEANING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "goCharging",
+            [StateEvent(RobotState.RETURNING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "goEmptying",
+            [StateEvent(RobotState.RETURNING), StationEvent(StationState.IDLE)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "emptying",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.EMPTYING)],
+        ),
+        (
+            0,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "washing",
+            [StateEvent(RobotState.DOCKED), StationEvent(StationState.WASHING)],
+        ),
+        (
+            1,
+            "cleaning",
+            {"cleanState": {"cid": "122", "type": "freeClean"}},
+            "idle",
+            [StateEvent(RobotState.PAUSED), StationEvent(StationState.IDLE)],
+        ),
+    ],
+)
+def test_onWorkState(
+    paused: int,
+    robot_state: str,
+    additional_content: dict[str, Any],
+    station_state: str,
+    expected: list[Event],
+) -> None:
+    data: dict[str, Any] = {
+        "header": {
+            "pri": 1,
+            "tzm": 60,
+            "ts": "1734719921057",
+            "ver": "0.0.1",
+            "fwVer": "1.30.0",
+            "hwVer": "0.1.1",
+            "wkVer": "0.1.54",
+        },
+        "body": {
+            "data": {
+                "paused": paused,
+                "robotState": {
+                    "state": robot_state,
+                    "trigger": "app",
+                    **additional_content,
+                },
+                "stationState": {
+                    "state": station_state,
+                    "trigger": "app",
+                },
+            },
+        },
+    }
+
+    assert_message(OnWorkState, data, (FirmwareEvent("1.30.0"), *expected))
+
+
+async def test_onWorkStateUnknownValues() -> None:
+    data: dict[str, Any] = {
+        "header": {
+            "pri": 1,
+            "tzm": 60,
+            "ts": "1734719921057",
+            "ver": "0.0.1",
+            "fwVer": "1.30.0",
+            "hwVer": "0.1.1",
+            "wkVer": "0.1.54",
+        },
+        "body": {
+            "data": {
+                "paused": 0,
+                "robotState": {
+                    "state": "unknownState",
+                    "trigger": "app",
+                },
+                "stationState": {
+                    "state": "anotherUnknownState",
+                    "trigger": "app",
+                },
+            },
+        },
+    }
+
+    assert_message_failure(
+        OnWorkState, data, HandlingState.ANALYSE_LOGGED, FirmwareEvent("1.30.0")
+    )

--- a/tests/messages/json/test_work_state.py
+++ b/tests/messages/json/test_work_state.py
@@ -140,7 +140,34 @@ def test_onWorkState(
     assert_message(OnWorkState, data, (FirmwareEvent("1.30.0"), *expected))
 
 
-async def test_onWorkStateUnknownValues() -> None:
+@pytest.mark.parametrize(
+    "message_data",
+    [
+        {
+            "paused": 0,
+            "robotState": {
+                "state": "unknownState",
+                "trigger": "app",
+            },
+            "stationState": {"state": "anotherUnknownState", "trigger": "app"},
+        },
+        {
+            "paused": 0,
+        },
+        {
+            "paused": 0,
+            "robotState": {
+                "state": "cleaning",
+                "trigger": "app",
+            },
+        },
+        {
+            "paused": 0,
+            "stationState": {"state": "emptying", "trigger": "app"},
+        },
+    ],
+)
+async def test_onWorkState_edge_cases(message_data: dict[str, Any]) -> None:
     data: dict[str, Any] = {
         "header": {
             "pri": 1,
@@ -151,19 +178,7 @@ async def test_onWorkStateUnknownValues() -> None:
             "hwVer": "0.1.1",
             "wkVer": "0.1.54",
         },
-        "body": {
-            "data": {
-                "paused": 0,
-                "robotState": {
-                    "state": "unknownState",
-                    "trigger": "app",
-                },
-                "stationState": {
-                    "state": "anotherUnknownState",
-                    "trigger": "app",
-                },
-            },
-        },
+        "body": {"data": message_data},
     }
 
     assert_message_failure(


### PR DESCRIPTION
Hey,

I've noticed that on my X9 Pro the status of the vacuum is always docked. This is basically set once when the robot is charged with the `GetChargeState` but never updated later. This is because the `getCleanInfo_V2` message always returns the same response regardless of the robot's status:
```json
{
    "code": 0,
    "data": {
        "state": "idle",
        "trigger": "none"
    },
    "msg": "ok"
}
```
In addition, the station state never changes as, despite it being reported as supported, it always sends the following response:
```json
{
    "code": 0,
    "data": {
        "content": {
            "error": [
                314
            ],
            "motionState": 0,
            "subContent": {
                "handEmpty": {
                    "charging": 0,
                    "connect": 0,
                    "emptying": 0,
                    "powerFull": 0
                }
            },
            "type": 0
        },
        "state": 0
    },
    "msg": "ok"
}
```

This is where the `WorkState` command/message comes in play. It includes the state of both the robot and the station together in one message, for example:
```json
{
    "data": {
        "paused": 0,
        "robotState": {
            "cleanState": {
                "cid": "122",
                "type": "freeClean"
            },
            "state": "cleaning",
            "trigger": "app"
        },
        "stationState": {
            "state": "idle",
            "trigger": "app"
        }
    }
}
```

I've added support for it but had a few questions comments before this PR will be ready for review. In no particular order:
* My robot is the X9 Pro which is linked to the X9 Pro Omni. I don't know if that one has the same issue and, as you've pointed out to me (sorry about that), the developer who added it didn't want to be disturbed. For now, I "forked" the configuration for it. Do you think that's best or should I modify the configuration for the X9 Pro Omni instead?
* I've added more states for the docking station and also changed it's enum to start from 1 like was done for others. I didn't find anywhere that might be broken from that, WDYT? I'll also add the translations for Home Assistant once this PR is merged
* I don't know what the code should do if both the robot and station is idle. In that case, I don't know if the robot is docked or not and need to rely on the `GetChargeState`. What should the `WorkState` handler do if both are idle? I'm not sure how different messages are handled if they publish the same events.
* When the robot is going back to the station for emptying before its finished its job, should its state still be "cleaning" or "returning"? For now, I switch it to "returning" only when its idle again, meaning it completed it's job
* I don't know how to force the robot into an error state so not sure how to test what it publishes in that case. Any ideas?

Thanks in advance!
