### PR TITLE
Add border spin command

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -12,6 +12,7 @@ from deebot_client.events import (
     AdvancedModeEvent,
     AvailabilityEvent,
     BatteryEvent,
+    BorderSpinEvent,
     BorderSwitchEvent,
     CachedMapInfoEvent,
     CarpetAutoFanBoostEvent,
@@ -206,6 +207,7 @@ class CapabilitySettings:
         CapabilitySetTypes[EfficiencyModeEvent, [EfficiencyMode | str], EfficiencyMode]
         | None
     ) = None
+    border_spin: CapabilitySetEnable[BorderSpinEvent] | None = None
     border_switch: CapabilitySetEnable[BorderSwitchEvent] | None = None
     child_lock: CapabilitySetEnable[ChildLockEvent] | None = None
     cut_direction: CapabilitySet[CutDirectionEvent, [int]] | None = None

--- a/deebot_client/commands/json/__init__.py
+++ b/deebot_client/commands/json/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from . import auto_empty, station_action, station_state
 from .advanced_mode import GetAdvancedMode, SetAdvancedMode
 from .battery import GetBattery
+from .border_spin import GetBorderSpin, SetBorderSpin
 from .border_switch import GetBorderSwitch, SetBorderSwitch
 from .carpet import GetCarpetAutoFanBoost, SetCarpetAutoFanBoost
 from .charge import Charge
@@ -63,6 +64,7 @@ __all__ = [
     "ClearMap",
     "GetAdvancedMode",
     "GetBattery",
+    "GetBorderSpin",
     "GetBorderSwitch",
     "GetCachedMapInfo",
     "GetCarpetAutoFanBoost",
@@ -104,6 +106,7 @@ __all__ = [
     "PlaySound",
     "ResetLifeSpan",
     "SetAdvancedMode",
+    "SetBorderSpin",
     "SetBorderSwitch",
     "SetCarpetAutoFanBoost",
     "SetChildLock",
@@ -136,6 +139,9 @@ _COMMANDS: list[type[JsonCommand]] = [
 
     auto_empty.GetAutoEmpty,
     auto_empty.SetAutoEmpty,
+
+    GetBorderSpin,
+    SetBorderSpin,
 
     GetBorderSwitch,
     SetBorderSwitch,

--- a/deebot_client/commands/json/border_spin.py
+++ b/deebot_client/commands/json/border_spin.py
@@ -1,0 +1,21 @@
+"""Border spin commands."""
+
+from __future__ import annotations
+
+from deebot_client.events import BorderSpinEvent
+
+from .common import GetEnableCommand, SetEnableCommand
+
+
+class GetBorderSpin(GetEnableCommand):
+    """Get border spin command."""
+
+    NAME = "getBorderSpin"
+    EVENT_TYPE = BorderSpinEvent
+
+
+class SetBorderSpin(SetEnableCommand):
+    """Set border spin command."""
+
+    NAME = "setBorderSpin"
+    get_command = GetBorderSpin

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -283,6 +283,11 @@ class ChildLockEvent(EnableEvent):
 
 
 @dataclass(frozen=True)
+class BorderSpinEvent(EnableEvent):
+    """Border spin event."""
+
+
+@dataclass(frozen=True)
 class BorderSwitchEvent(EnableEvent):
     """Border switch event."""
 

--- a/tests/commands/json/test_border_spin.py
+++ b/tests/commands/json/test_border_spin.py
@@ -1,0 +1,30 @@
+"""Tests regarding border spin commands."""
+
+from __future__ import annotations
+
+import pytest
+
+from deebot_client.commands.json import GetBorderSpin, SetBorderSpin
+from deebot_client.events import BorderSpinEvent
+from tests.helpers import get_request_json, get_success_body
+
+from . import assert_command, assert_set_enable_command
+
+
+@pytest.mark.parametrize("value", [False, True])
+async def test_GetBorderSpin(*, value: bool) -> None:
+    """Testing get border spin."""
+    json, firmware_event = get_request_json(
+        get_success_body({"enable": 1 if value else 0})
+    )
+    await assert_command(
+        GetBorderSpin(), json, (firmware_event, BorderSpinEvent(value))
+    )
+
+
+@pytest.mark.parametrize("value", [False, True])
+async def test_SetBorderSpin(*, value: bool) -> None:
+    """Testing set border spin."""
+    await assert_set_enable_command(
+        SetBorderSpin(value), BorderSpinEvent, enabled=value
+    )


### PR DESCRIPTION
Border spin is the way bots like the Mini, without an extendable mop, can reach the edges by tilting itself

(split from https://github.com/DeebotUniverse/client.py/pull/1221)