### PR TITLE
Add dry mop and clean base actions and drying status reporting

### DIFF
--- a/deebot_client/commands/__init__.py
+++ b/deebot_client/commands/__init__.py
@@ -34,3 +34,5 @@ class StationAction(IntEnum):
     """Enum class for all possible station actions."""
 
     EMPTY_DUSTBIN = 1
+    DRY_MOP = 2
+    CLEAN_BASE = 3

--- a/deebot_client/messages/json/station_state.py
+++ b/deebot_client/messages/json/station_state.py
@@ -26,6 +26,7 @@ class OnStationState(MessageBodyDataDict):
         """
         # "body":{"data":{"content":{"error":[],"type":0},"state":0},"code":0,"msg":"ok"} - Idle
         # "body":{"data":{"content":{"error":[],"type":1,"motionState":1},"state":1},"code":0,"msg":"ok"} - Emptying
+        # "body":{"data":{"content":{"error":[],"type":2,"motionState":1},"state":1},"code":0,"msg":"ok"} - Drying mop
 
         if (state := data.get("state")) == 0:
             reported_state = State.IDLE
@@ -36,6 +37,13 @@ class OnStationState(MessageBodyDataDict):
             and content.get("motionState") == 1
         ):
             reported_state = State.EMPTYING_DUSTBIN
+        elif (
+            state == 1
+            and (content := data.get("content"))
+            and content.get("type") == 2
+            and content.get("motionState") == 1
+        ):
+            reported_state = State.DRYING_MOP
         else:
             return HandlingResult.analyse()
 

--- a/tests/commands/json/test_station_action.py
+++ b/tests/commands/json/test_station_action.py
@@ -19,6 +19,14 @@ from . import assert_execute_command
             StationAction.EMPTY_DUSTBIN,
             {"act": 1, "type": 1},
         ),
+        (
+            StationAction.DRY_MOP,
+            {"act": 1, "type": 2},
+        ),
+        (
+            StationAction.CLEAN_BASE,
+            {"act": 1, "type": 3},
+        ),
     ],
 )
 async def test_StationAction(

--- a/tests/commands/json/test_station_state.py
+++ b/tests/commands/json/test_station_state.py
@@ -6,6 +6,7 @@ import pytest
 
 from deebot_client.commands.json.station_state import GetStationState
 from deebot_client.events.station import State, StationEvent
+from deebot_client.message import HandlingResult, HandlingState
 from tests.helpers import get_request_json, get_success_body
 
 from . import assert_command
@@ -16,6 +17,7 @@ from . import assert_command
     [
         (0, {"type": 0}, State.IDLE),
         (1, {"type": 1, "motionState": 1}, State.EMPTYING_DUSTBIN),
+        (1, {"type": 2, "motionState": 1}, State.DRYING_MOP),
     ],
 )
 async def test_GetStationState(
@@ -33,4 +35,38 @@ async def test_GetStationState(
     )
     await assert_command(
         GetStationState(), json, (firmware_event, StationEvent(expected))
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "additional_content"),
+    [
+        # content missing
+        (1, {}),
+        # type present but motionState missing
+        (1, {"type": 2}),
+        # type matches but motionState different
+        (1, {"type": 2, "motionState": 0}),
+        # unexpected state value
+        (2, {"type": 2, "motionState": 1}),
+    ],
+)
+async def test_GetStationState_analyse(
+    state: int,
+    additional_content: dict[str, Any],
+) -> None:
+    json, firmware_event = get_request_json(
+        get_success_body(
+            {
+                "content": {"error": [], **additional_content},
+                "state": state,
+            }
+        )
+    )
+
+    await assert_command(
+        GetStationState(),
+        json,
+        firmware_event,
+        handling_result=HandlingResult(HandlingState.ANALYSE_LOGGED),
     )

--- a/tests/messages/json/test_station_state.py
+++ b/tests/messages/json/test_station_state.py
@@ -6,6 +6,7 @@ import pytest
 
 from deebot_client.events import FirmwareEvent
 from deebot_client.events.station import State, StationEvent
+from deebot_client.message import HandlingState
 from deebot_client.messages.json.station_state import OnStationState
 from tests.messages.json import assert_message
 
@@ -15,6 +16,7 @@ from tests.messages.json import assert_message
     [
         (0, {"type": 0}, State.IDLE),
         (1, {"type": 1, "motionState": 1}, State.EMPTYING_DUSTBIN),
+        (1, {"type": 2, "motionState": 1}, State.DRYING_MOP),
     ],
 )
 async def test_onStationState(
@@ -41,4 +43,46 @@ async def test_onStationState(
 
     await assert_message(
         OnStationState, data, (FirmwareEvent("1.30.0"), StationEvent(expected))
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "additional_content"),
+    [
+        # content missing
+        (1, {}),
+        # type present but motionState missing
+        (1, {"type": 2}),
+        # type matches but motionState different
+        (1, {"type": 2, "motionState": 0}),
+        # unexpected state value
+        (2, {"type": 2, "motionState": 1}),
+    ],
+)
+async def test_onStationState_analyse(
+    state: int, additional_content: dict[str, Any]
+) -> None:
+    """Cases that should fall through to analyse() (not handled)."""
+    data: dict[str, Any] = {
+        "header": {
+            "pri": 1,
+            "tzm": 60,
+            "ts": "1734719921057",
+            "ver": "0.0.1",
+            "fwVer": "1.30.0",
+            "hwVer": "0.1.1",
+            "wkVer": "0.1.54",
+        },
+        "body": {
+            "data": {"content": {"error": [], **additional_content}, "state": state},
+            "code": 0,
+            "msg": "ok",
+        },
+    }
+
+    await assert_message(
+        OnStationState,
+        data,
+        (FirmwareEvent("1.30.0"),),
+        expected_state=HandlingState.ANALYSE_LOGGED,
     )


### PR DESCRIPTION
Add station actions to trigger mop drying and clean cleaning base. Also, adjust station state reporting to handle mop drying.

Note: the "clean cleaning base" action does not report or change any bot nor station status, its just a trigger.

(split from https://github.com/DeebotUniverse/client.py/pull/1221)