### PR TITLE
Upgrade macos intel runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
             runner: windows-latest
             target: x64
           - name: Macos
-            runner: macos-13
+            runner: macos-15-intel
             target: x86_64
           - name: Macos
             runner: macos-15


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/