### PR TITLE
Add Autoempty2

### DIFF
--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -29,7 +29,8 @@ class SetAutoEmpty(ExecuteCommand):
             frequency = get_enum(Frequency, frequency)
 
         if isinstance(enable, str):
-            if frequency is None: frequency = get_enum(Frequency, enable)
+            if frequency is None:
+                frequency = get_enum(Frequency, enable)
             enable = frequency != "manual"
 
         params: dict[str, Any] = {}

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,28 +28,16 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
+        if enable is not bool and frequency is None:
+            frequency = get_enum(Frequency, enable)
+            if frequency == “manual”:
+                enable = 0
+            else:
+                enable = 1
+
         params: dict[str, Any] = {}
         if enable is not None:
             params["enable"] = int(enable)
-        if frequency:
-            params["frequency"] = frequency.value
-        super().__init__(params)
-
-
-class SetAutoEmpty2(ExecuteCommand):
-    """Set auto empty command without enable."""
-
-    NAME = "setAutoEmpty"
-
-    def __init__(self, frequency: Frequency | str | None = None) -> None:
-        if frequency is not None and not isinstance(frequency, Frequency):
-            frequency = get_enum(Frequency, frequency)
-
-        params: dict[str, Any] = {}
-        if frequency == "manual":
-            params["enable"] = 0
-        else:
-            params["enable"] = 1
         if frequency:
             params["frequency"] = frequency.value
         super().__init__(params)

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -30,10 +30,7 @@ class SetAutoEmpty(ExecuteCommand):
 
         if enable is not bool and frequency is None:
             frequency = get_enum(Frequency, enable)
-            if frequency == "manual":
-                enable = 0
-            else:
-                enable = 1
+            enable = 0 if frequency == "manual" else 1
 
         params: dict[str, Any] = {}
         if enable is not None:

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,8 +28,8 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if type(enable) is str and frequency is None:
-            frequency = get_enum(Frequency, enable)
+        if type(enable) is not bool and frequency is None:
+            frequency = get_enum(Frequency, str(enable))
             enable = False if frequency == "manual" else True
 
         params: dict[str, Any] = {}

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,9 +28,10 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if enable is not bool and frequency is None:
-            frequency = get_enum(Frequency, enable)
-            enable = 0 if frequency == "manual" else 1
+        if type(enable) is not bool and frequency is None:
+            frequency = enable
+            frequency = get_enum(Frequency, frequency)
+            enable = false if frequency == "manual" else true
 
         params: dict[str, Any] = {}
         if enable is not None:

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -30,7 +30,7 @@ class SetAutoEmpty(ExecuteCommand):
 
         if type(enable) is not bool and frequency is None:
             frequency = get_enum(Frequency, str(enable))
-            enable = False if frequency == "manual" else True
+            enable = frequency != "manual"
 
         params: dict[str, Any] = {}
         if enable is not None:

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -34,3 +34,22 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency:
             params["frequency"] = frequency.value
         super().__init__(params)
+
+
+class SetAutoEmpty2(ExecuteCommand):
+    """Set auto empty command without enable."""
+
+    NAME = "setAutoEmpty"
+
+    def __init__(self, frequency: Frequency | str | None = None) -> None:
+        if frequency is not None and not isinstance(frequency, Frequency):
+            frequency = get_enum(Frequency, frequency)
+
+        params: dict[str, Any] = {}
+        if frequency == "manual":
+            params["enable"] = 0
+        else:
+            params["enable"] = 1
+        if frequency:
+            params["frequency"] = frequency.value
+        super().__init__(params)

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,7 +28,7 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if enable is not None type(enable) is not bool and frequency is None:
+        if enable is not None and type(enable) is not bool and frequency is None:
             frequency = get_enum(Frequency, str(enable))
             enable = frequency != "manual"
 

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -29,7 +29,7 @@ class SetAutoEmpty(ExecuteCommand):
             frequency = get_enum(Frequency, frequency)
 
         if isinstance(enable, str):
-            frequency = get_enum(Frequency, enable) if frequency is None
+            if frequency is None: frequency = get_enum(Frequency, enable)
             enable = frequency != "manual"
 
         params: dict[str, Any] = {}

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -30,7 +30,7 @@ class SetAutoEmpty(ExecuteCommand):
 
         if enable is not bool and frequency is None:
             frequency = get_enum(Frequency, enable)
-            if frequency == “manual”:
+            if frequency == "manual":
                 enable = 0
             else:
                 enable = 1

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,10 +28,9 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if type(enable) is not bool and frequency is None:
-            frequency = enable
-            frequency = get_enum(Frequency, frequency)
-            enable = false if frequency == "manual" else true
+        if type(enable) is str and frequency is None:
+            frequency = get_enum(Frequency, enable)
+            enable = False if frequency == "manual" else True
 
         params: dict[str, Any] = {}
         if enable is not None:

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,9 +28,10 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if enable is not None and type(enable) is not bool and frequency is None:
-            frequency = get_enum(Frequency, str(enable))
-            enable = frequency != "manual"
+        if not isinstance(enable, bool) and frequency is None:
+            if enable is not None:
+                frequency = get_enum(Frequency, str(enable))
+                enable = frequency != "manual"
 
         params: dict[str, Any] = {}
         if enable is not None:

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,10 +28,9 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if not isinstance(enable, bool) and frequency is None:
-            if enable is not None:
-                frequency = get_enum(Frequency, str(enable))
-                enable = frequency != "manual"
+        if not isinstance(enable, bool | None) and frequency is None:
+            frequency = get_enum(Frequency, str(enable))
+            enable = frequency != "manual"
 
         params: dict[str, Any] = {}
         if enable is not None:

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,7 +28,7 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if type(enable) is not bool | None and frequency is None:
+        if enable is not None type(enable) is not bool and frequency is None:
             frequency = get_enum(Frequency, str(enable))
             enable = frequency != "manual"
 

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -23,13 +23,13 @@ class SetAutoEmpty(ExecuteCommand):
     NAME = "setAutoEmpty"
 
     def __init__(
-        self, enable: bool | None = None, frequency: Frequency | str | None = None
+        self, enable: bool | str | None = None, frequency: Frequency | str | None = None
     ) -> None:
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if not isinstance(enable, bool | None) and frequency is None:
-            frequency = get_enum(Frequency, str(enable))
+        if isinstance(enable, str):
+            frequency = get_enum(Frequency, enable) if frequency is None
             enable = frequency != "manual"
 
         params: dict[str, Any] = {}

--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -28,7 +28,7 @@ class SetAutoEmpty(ExecuteCommand):
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
 
-        if type(enable) is not bool and frequency is None:
+        if type(enable) is not bool | None and frequency is None:
             frequency = get_enum(Frequency, str(enable))
             enable = frequency != "manual"
 

--- a/deebot_client/events/auto_empty.py
+++ b/deebot_client/events/auto_empty.py
@@ -19,6 +19,7 @@ class Frequency(StrEnum):
     MIN_25 = "25"
     AUTO = "auto"
     SMART = "smart"
+    MANUAL = "manual"
 
 
 @dataclass(frozen=True)

--- a/tests/commands/json/test_auto_empty.py
+++ b/tests/commands/json/test_auto_empty.py
@@ -66,6 +66,11 @@ async def test_GetAutoEmpty(json: dict[str, Any], expected: AutoEmptyEvent) -> N
         ),
         (
             True,
+            Frequency.MANUAL,
+            {"enable": 1, "frequency": "manual"},
+        ),
+        (
+            True,
             "smart",
             {"enable": 1, "frequency": "smart"},
         ),
@@ -108,6 +113,21 @@ async def test_GetAutoEmpty(json: dict[str, Any], expected: AutoEmptyEvent) -> N
             False,
             None,
             {"enable": 0},
+        ),
+        (
+            "min_10",
+            None,
+            {"enable": 1, "frequency": "10"},
+        ),
+        (
+            "smart",
+            None,
+            {"enable": 1, "frequency": "smart"},
+        ),
+        (
+            "manual",
+            None,
+            {"enable": 0, "frequency": "manual"},
         ),
     ],
 )

--- a/tests/commands/json/test_auto_empty.py
+++ b/tests/commands/json/test_auto_empty.py
@@ -129,6 +129,11 @@ async def test_GetAutoEmpty(json: dict[str, Any], expected: AutoEmptyEvent) -> N
             None,
             {"enable": 0, "frequency": "manual"},
         ),
+        (
+            "manual",
+            "manual",
+            {"enable": 0, "frequency": "manual"},
+        ),
     ],
 )
 async def test_SetAutoEmpty(


### PR DESCRIPTION
When selecting from “select” in HA, it calls executeCommand with the selected string as an option. However, auto empty requires two parameters, causing an error in SetAutoEmpty. (GetAutoEmpty works without any issues.)

```
  File "/usr/local/lib/python3.13/site-packages/deebot_client/commands/json/auto_empty.py", line 33, in __init__
    params["enable"] = int(enable)
                       ~~~^^^^^^^^
ValueError: invalid literal for int() with base 10: 'smart'
```




By the way, the Deebot T50 OMNI sets enable=0 when frequency=manual.
Therefore, I added SetAutoEmpty2, which limits the received parameter to frequency only. It sets enable=0 only when frequency=manual and enable=1 otherwise.
Tested in HAOS (Deebot Client 16.0.0, HA Core 2025.10.4) with translation added.

If you see any strange code or know a better way, please leave a comment.
