### PR TITLE
Add dict to types of CapabilityTypes

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -115,7 +115,7 @@ class CapabilityExecute[**P]:
 class CapabilityTypes[T]:
     """Capability to specify types support."""
 
-    types: tuple[T, ...]
+    types: tuple[T, ...] | dict[T, dict[str, Any]]
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -113,7 +113,7 @@ class CapabilityExecute[**P]:
 
 @dataclass(frozen=True, kw_only=True)
 class CapabilityTypes[T]:
-    """Capability to specify types support."""
+    """Capability to specify types support (use dict when passing two or more parameters)."""
 
     types: tuple[T, ...] | dict[T, dict[str, Any]]
 

--- a/deebot_client/events/auto_empty.py
+++ b/deebot_client/events/auto_empty.py
@@ -19,6 +19,7 @@ class Frequency(StrEnum):
     MIN_25 = "25"
     AUTO = "auto"
     SMART = "smart"
+    MANUAL = "manual"
 
 
 @dataclass(frozen=True)

--- a/deebot_client/hardware/fd60kt.py
+++ b/deebot_client/hardware/fd60kt.py
@@ -253,10 +253,11 @@ def get_device_info() -> StaticDeviceInfo:
                     event=AutoEmptyEvent,
                     get=[GetAutoEmpty()],
                     set=SetAutoEmpty,
-                    types=(
-                        auto_empty.Frequency.AUTO,
-                        auto_empty.Frequency.SMART,
-                    ),
+                    types={
+                        auto_empty.Frequency.AUTO: {"enable": 1, "frequency": auto_empty.Frequency.AUTO},
+                        auto_empty.Frequency.SMART: {"enable": 1, "frequency": auto_empty.Frequency.SMART},
+                        auto_empty.Frequency.MANUAL: {"enable": 0, "frequency": auto_empty.Frequency.MANUAL},
+                    },
                 ),
                 state=CapabilityEvent(StationEvent, [GetStationState()]),
             ),

--- a/deebot_client/hardware/fd60kt.py
+++ b/deebot_client/hardware/fd60kt.py
@@ -254,9 +254,18 @@ def get_device_info() -> StaticDeviceInfo:
                     get=[GetAutoEmpty()],
                     set=SetAutoEmpty,
                     types={
-                        auto_empty.Frequency.AUTO: {"enable": 1, "frequency": auto_empty.Frequency.AUTO},
-                        auto_empty.Frequency.SMART: {"enable": 1, "frequency": auto_empty.Frequency.SMART},
-                        auto_empty.Frequency.MANUAL: {"enable": 0, "frequency": auto_empty.Frequency.MANUAL},
+                        auto_empty.Frequency.AUTO: {
+                            "enable": 1,
+                            "frequency": auto_empty.Frequency.AUTO,
+                        },
+                        auto_empty.Frequency.SMART: {
+                            "enable": 1,
+                            "frequency": auto_empty.Frequency.SMART,
+                        },
+                        auto_empty.Frequency.MANUAL: {
+                            "enable": 0,
+                            "frequency": auto_empty.Frequency.MANUAL,
+                        },
                     },
                 ),
                 state=CapabilityEvent(StationEvent, [GetStationState()]),


### PR DESCRIPTION
For the DEEBOT T50 OMNI (fd60kt), both `enable` and `frequency` must be specified simultaneously for the auto_empty command to be accepted. However, the current select entity only allows sending a single parameter, resulting in an error.

To pass multiple parameters to integration with a single selection, I modified the type to allow both `dict` and `tuple`. (due to the number of changes required, I didn't replace the `tuples` with `dict`) Since the integration side remains unchanged, this modification alone does not alter the behavior. For example, the following code will behave identically in either case. 
`options_fn=lambda cap: [get_name_key(freq) for freq in cap.types]`

I think adding test is sufficient in integration, but if necessary, specific instructions would be helpful.
I'm not sure if this is the correct approach as code... Any advice would be appreciated.