### PR TITLE
Use number event to set water amount for T80 OMNI (9eamof)

### DIFF
--- a/deebot_client/hardware/9eamof.py
+++ b/deebot_client/hardware/9eamof.py
@@ -12,6 +12,7 @@ from deebot_client.capabilities import (
     CapabilityExecuteTypes,
     CapabilityLifeSpan,
     CapabilityMap,
+    CapabilityNumber,
     CapabilitySet,
     CapabilitySetEnable,
     CapabilitySettings,
@@ -277,16 +278,12 @@ def get_device_info() -> StaticDeviceInfo:
                 total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
             ),
             water=CapabilityWater(
-                amount=CapabilitySetTypes(
-                    event=water_info.WaterAmountEvent,
+                amount=CapabilityNumber(
+                    event=water_info.WaterCustomAmountEvent,
                     get=[GetWaterInfo()],
-                    set=SetWaterInfo,
-                    types=(
-                        water_info.WaterAmount.LOW,
-                        water_info.WaterAmount.MEDIUM,
-                        water_info.WaterAmount.HIGH,
-                        water_info.WaterAmount.ULTRAHIGH,
-                    ),
+                    set=lambda custom_amount: SetWaterInfo(custom_amount=custom_amount),
+                    min=0,
+                    max=50,
                 ),
                 mop_attached=CapabilityEvent(
                     water_info.MopAttachedEvent, [GetWaterInfo()]


### PR DESCRIPTION
The T80 uses the same number-based system as some of the other bots. This updates the config to use that, based on the change in #1100. I briefly tested it with a script like this: 

```python
async def on_water_amount_change(event: WaterCustomAmountEvent):
    print(f"Water amount changed to: {event.value}")

bot.events.subscribe(WaterCustomAmountEvent, on_water_amount_change)

await bot.initialize(mqtt)

print("Setting water amount to 30...")
await bot.execute_command(SetWaterInfo(custom_amount=30))
```

And verified that (1) the amount changed to 30 in the app from the value it was previously set to (the bot also beeps any time it changes, which it did), and (2) the script prints `Water amount changed to: 27` when I change it on the app. 