### PR TITLE
Fix symlink for T50 Pro Omni (elrxgb)

### DIFF
--- a/deebot_client/hardware/elrxgb.py
+++ b/deebot_client/hardware/elrxgb.py
@@ -1,1 +1,1 @@
-xco2fc.py
+c8rj4y.py


### PR DESCRIPTION
This replaced the invocations of Clean, CleanArea, and GetCleanInfo with their V2 variants.

Clean does not work on the T50 Pro Omni, CleanV2 does.