### PR TITLE
fix: Add explicit language to prettier hook for Renovate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
     rev: v3.7.1
     hooks:
       - id: prettier
+        language: node
         additional_dependencies:
           - prettier@3.7.1
           - prettier-plugin-sort-json@4.1.1


### PR DESCRIPTION
Add `language: node` to the prettier pre-commit hook so Renovate can update additional_dependencies alongside the hook revision.

See: https://docs.renovatebot.com/modules/manager/pre-commit/#additional-dependencies