### PR TITLE
Add support for DEEBOT NEO 3.0 OMNI (zg6qbz)

### DIFF
--- a/deebot_client/hardware/zg6qbz.py
+++ b/deebot_client/hardware/zg6qbz.py
@@ -28,7 +28,6 @@ from deebot_client.commands.json.carpet import (
 from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.clean import Clean, CleanArea
-from deebot_client.commands.json.work_state import GetWorkState
 from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
 from deebot_client.commands.json.clean_logs import GetCleanLogs
 from deebot_client.commands.json.clean_preference import (
@@ -63,6 +62,7 @@ from deebot_client.commands.json.stats import GetStats, GetTotalStats
 from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
 from deebot_client.commands.json.volume import GetVolume, SetVolume
 from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.commands.json.work_state import GetWorkState
 from deebot_client.const import DataType
 from deebot_client.events import (
     AdvancedModeEvent,

--- a/deebot_client/hardware/zg6qbz.py
+++ b/deebot_client/hardware/zg6qbz.py
@@ -1,0 +1,213 @@
+"""DEEBOT NEO 3.0 OMNI Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityLifeSpan,
+    CapabilityMap,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStats,
+    CapabilityWater,
+    DeviceType,
+)
+from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.carpet import (
+    GetCarpetAutoFanBoost,
+    SetCarpetAutoFanBoost,
+)
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.clean import Clean, CleanArea
+from deebot_client.commands.json.work_state import GetWorkState
+from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
+from deebot_client.commands.json.clean_logs import GetCleanLogs
+from deebot_client.commands.json.clean_preference import (
+    GetCleanPreference,
+    SetCleanPreference,
+)
+from deebot_client.commands.json.continuous_cleaning import (
+    GetContinuousCleaning,
+    SetContinuousCleaning,
+)
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import (
+    GetCachedMapInfo,
+    GetMajorMap,
+    GetMapSet,
+    GetMapTrace,
+    GetMinorMap,
+    SetMajorMap,
+)
+from deebot_client.commands.json.multimap_state import (
+    GetMultimapState,
+    SetMultimapState,
+)
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
+from deebot_client.commands.json.relocation import SetRelocationState
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AdvancedModeEvent,
+    AvailabilityEvent,
+    BatteryEvent,
+    CachedMapInfoEvent,
+    CarpetAutoFanBoostEvent,
+    CleanCountEvent,
+    CleanLogEvent,
+    CleanPreferenceEvent,
+    ContinuousCleaningEvent,
+    CustomCommandEvent,
+    ErrorEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    LifeSpan,
+    LifeSpanEvent,
+    MajorMapEvent,
+    MapChangedEvent,
+    MapTraceEvent,
+    MultimapStateEvent,
+    NetworkInfoEvent,
+    PositionsEvent,
+    ReportStatsEvent,
+    RoomsEvent,
+    StateEvent,
+    StatsEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VolumeEvent,
+    water_info,
+)
+from deebot_client.models import StaticDeviceInfo
+
+
+def get_device_info() -> StaticDeviceInfo:
+    """Get device info for this model."""
+    return StaticDeviceInfo(
+        DataType.JSON,
+        Capabilities(
+            device_type=DeviceType.VACUUM,
+            availability=CapabilityEvent(
+                AvailabilityEvent, [GetBattery(is_available_check=True)]
+            ),
+            battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+            charge=CapabilityExecute(Charge),
+            clean=CapabilityClean(
+                action=CapabilityCleanAction(command=Clean, area=CleanArea),
+                continuous=CapabilitySetEnable(
+                    ContinuousCleaningEvent,
+                    [GetContinuousCleaning()],
+                    SetContinuousCleaning,
+                ),
+                count=CapabilitySet(CleanCountEvent, [GetCleanCount()], SetCleanCount),
+                log=CapabilityEvent(CleanLogEvent, [GetCleanLogs()]),
+                preference=CapabilitySetEnable(
+                    CleanPreferenceEvent, [GetCleanPreference()], SetCleanPreference
+                ),
+            ),
+            custom=CapabilityCustomCommand(
+                event=CustomCommandEvent, get=[], set=CustomCommand
+            ),
+            error=CapabilityEvent(ErrorEvent, [GetError()]),
+            fan_speed=CapabilitySetTypes(
+                event=FanSpeedEvent,
+                get=[GetFanSpeed()],
+                set=SetFanSpeed,
+                types=(
+                    FanSpeedLevel.QUIET,
+                    FanSpeedLevel.NORMAL,
+                    FanSpeedLevel.MAX,
+                    FanSpeedLevel.MAX_PLUS,
+                ),
+            ),
+            life_span=CapabilityLifeSpan(
+                types=(
+                    LifeSpan.BRUSH,
+                    LifeSpan.FILTER,
+                    LifeSpan.SIDE_BRUSH,
+                    LifeSpan.UNIT_CARE,
+                ),
+                event=LifeSpanEvent,
+                get=[
+                    GetLifeSpan(
+                        [
+                            LifeSpan.BRUSH,
+                            LifeSpan.FILTER,
+                            LifeSpan.SIDE_BRUSH,
+                            LifeSpan.UNIT_CARE,
+                        ]
+                    )
+                ],
+                reset=ResetLifeSpan,
+            ),
+            map=CapabilityMap(
+                cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo()]),
+                changed=CapabilityEvent(MapChangedEvent, []),
+                major=CapabilitySet(MajorMapEvent, [GetMajorMap()], SetMajorMap),
+                minor=CapabilityExecute(GetMinorMap),
+                multi_state=CapabilitySetEnable(
+                    MultimapStateEvent, [GetMultimapState()], SetMultimapState
+                ),
+                position=CapabilityEvent(PositionsEvent, [GetPos()]),
+                relocation=CapabilityExecute(SetRelocationState),
+                rooms=CapabilityEvent(RoomsEvent, [GetCachedMapInfo()]),
+                set=CapabilityExecute(GetMapSet),
+                trace=CapabilityEvent(MapTraceEvent, [GetMapTrace()]),
+            ),
+            network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+            play_sound=CapabilityExecute(PlaySound),
+            settings=CapabilitySettings(
+                advanced_mode=CapabilitySetEnable(
+                    AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
+                ),
+                carpet_auto_fan_boost=CapabilitySetEnable(
+                    CarpetAutoFanBoostEvent,
+                    [GetCarpetAutoFanBoost()],
+                    SetCarpetAutoFanBoost,
+                ),
+                true_detect=CapabilitySetEnable(
+                    TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+                ),
+                volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+            ),
+            state=CapabilityEvent(StateEvent, [GetChargeState(), GetWorkState()]),
+            stats=CapabilityStats(
+                clean=CapabilityEvent(StatsEvent, [GetStats()]),
+                report=CapabilityEvent(ReportStatsEvent, []),
+                total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+            ),
+            water=CapabilityWater(
+                amount=CapabilitySetTypes(
+                    event=water_info.WaterAmountEvent,
+                    get=[GetWaterInfo()],
+                    set=SetWaterInfo,
+                    types=(
+                        water_info.WaterAmount.LOW,
+                        water_info.WaterAmount.MEDIUM,
+                        water_info.WaterAmount.HIGH,
+                        water_info.WaterAmount.ULTRAHIGH,
+                    ),
+                ),
+                mop_attached=CapabilityEvent(
+                    water_info.MopAttachedEvent, [GetWaterInfo()]
+                ),
+            ),
+        ),
+    )


### PR DESCRIPTION
## Add support for DEEBOT NEO 3.0 OMNI (device class: zg6qbz)

### Device Information
- Device Class: `zg6qbz`
- Model: SS_ANZ
- Product Name: DEEBOT NEO 3.0 OMNI
- UILogicId: omni_ww_h_ssh5
- Protocol: CtsX (MQTT)

### Changes Made
- Added `hardware/zg6qbz.py` based on similar OMNI models
- Uses `GetWorkState()` for proper state reporting (not `GetCleanInfo()`)

### Testing
Tested with actual DEEBOT NEO 3.0 OMNI hardware:
- ✅ Device recognized without warnings
- ✅ State reporting works correctly
- ✅ All sensors functioning
- ✅ Commands work (start, stop, dock, fan speed)

### Related Issues
