### PR TITLE
Add support for X8 Pro AI Plus (eom321)

### DIFF
--- a/deebot_client/hardware/eom321.py
+++ b/deebot_client/hardware/eom321.py
@@ -1,0 +1,1 @@
+n0vyif.py


### PR DESCRIPTION
Fix #804 

Tested with ECOVAS integration in Home Assistant OS that uses this repository to talk to the robot. 

What I did was simply create a file for eom321 with its content being identical to `n0vyif.py` merged in #1167 

It seems X8 Pro AI Plus and X8 Pro Omni use the same protocol despite different class names.