### PR TITLE
Fix room detection for robots with 11+ field subsets

### DIFF
--- a/deebot_client/commands/json/map/__init__.py
+++ b/deebot_client/commands/json/map/__init__.py
@@ -273,7 +273,7 @@ class GetMapSetV2(GetMapSet):
         map_id: str,
     ) -> HandlingResult:
         # there are two versions of this message, depending on the number of values
-        if subsets and len(subsets[0]) == 10:
+        if subsets and len(subsets[0]) >= 10:
             # subset values
             # 1 -> id
             # 2 -> name

--- a/tests/commands/json/map/test_init.py
+++ b/tests/commands/json/map/test_init.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from testfixtures import LogCapture
+
+from deebot_client.event_bus import EventBus
 
 from deebot_client.commands.json import (
     GetMapSet,
@@ -461,6 +464,66 @@ async def test_getMapSetV2_rooms_v2() -> None:
         json,
         events,
     )
+
+
+@pytest.mark.parametrize(
+    ("subsets", "expected_rooms"),
+    [
+        # 10-field subsets (standard)
+        (
+            [
+                ["3", "Kitchen", "1", "1", "0", "100", "200", "1-1-1", "0", "1"],
+                ["5", "Bedroom", "2", "2", "0", "300", "400", "1-1-1", "0", "0"],
+            ],
+            [Room("Kitchen", 3, ""), Room("Bedroom", 5, "")],
+        ),
+        # 11-field subsets (e.g. DEEBOT X11 OmniCyclone)
+        (
+            [
+                [
+                    "0",
+                    "Bathroom",
+                    "1",
+                    "1",
+                    "0",
+                    "100",
+                    "200",
+                    "1-1-1",
+                    "0",
+                    "0",
+                    "1",
+                ],
+                [
+                    "1",
+                    "Hallway",
+                    "2",
+                    "2",
+                    "0",
+                    "300",
+                    "400",
+                    "1-1-1",
+                    "0",
+                    "0",
+                    "0",
+                ],
+            ],
+            [Room("Bathroom", 0, ""), Room("Hallway", 1, "")],
+        ),
+    ],
+    ids=["10-field", "11-field"],
+)
+def test_handle_rooms_subsets_field_count(
+    subsets: list[list[str]], expected_rooms: list[Room]
+) -> None:
+    """Test that _handle_rooms_subsets handles both 10 and 11 field subsets."""
+    event_bus = Mock(spec_set=EventBus)
+    mid = "123456"
+    data: dict[str, Any] = {"mid": mid, "type": MapSetType.ROOMS}
+
+    result = GetMapSetV2._handle_rooms_subsets(event_bus, data, subsets, mid)
+
+    assert result == HandlingResult.success()
+    event_bus.notify.assert_called_once_with(RoomsEvent(mid, expected_rooms))
 
 
 async def test_getMapTrace() -> None:


### PR DESCRIPTION
## Problem

Robots like the DEEBOT X11 OmniCyclone (model class `huhcip`) return 11-field room subsets from `getMapSet_V2`, but `_handle_rooms_subsets` only matches exactly 10 fields (`len(subsets[0]) == 10`).

This causes the code to fall through to the 8-field path which calls `GetMapSubSet` — a command the X11 doesn't support, returning error code 20003 ("rcp not support"). The result is empty room attributes on vacuum entities in Home Assistant.

## Fix

Change `== 10` to `>= 10`. The 10+ field branch only reads `subset[0]` (id) and `subset[1]` (name), so extra trailing fields are safely ignored.

The 11th field appears to be related to floor material/carpet detection, consistent with the X11's automatic carpet recognition feature.

## Tested on

- DEEBOT X11 OmniCyclone (huhcip), firmware 1.67.0
- deebot-client 17.1.0 installed in Home Assistant OS
- Two vacuums, both now show correct room names after this fix