### PR TITLE
Add freeClean support for newer robots

### DIFF
--- a/deebot_client/commands/json/__init__.py
+++ b/deebot_client/commands/json/__init__.py
@@ -13,7 +13,7 @@ from .carpet import GetCarpetAutoFanBoost, SetCarpetAutoFanBoost
 from .charge import Charge
 from .charge_state import GetChargeState
 from .child_lock import GetChildLock, SetChildLock
-from .clean import Clean, CleanArea, CleanV2, GetCleanInfo, GetCleanInfoV2
+from .clean import Clean, CleanArea, CleanAreaFreeClean, CleanV2, GetCleanInfo, GetCleanInfoV2
 from .clean_count import GetCleanCount, SetCleanCount
 from .clean_logs import GetCleanLogs
 from .clean_preference import GetCleanPreference, SetCleanPreference
@@ -62,6 +62,7 @@ __all__ = [
     "Charge",
     "Clean",
     "CleanArea",
+    "CleanAreaFreeClean",
     "CleanV2",
     "ClearMap",
     "GetAdvancedMode",
@@ -174,6 +175,7 @@ _COMMANDS: list[type[JsonCommand]] = [
     Clean,
     CleanV2,
     CleanArea,
+    CleanAreaFreeClean,
     GetCleanInfo,
     GetCleanInfoV2,
 

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -108,6 +108,29 @@ class CleanAreaV2(CleanV2):
         return args
 
 
+class CleanAreaFreeClean(CleanV2):
+    """Clean area command using freeClean type.
+
+    Used by newer robots (e.g. DEEBOT X11 OmniCyclone) that use the freeClean
+    clean type instead of spotArea. The value format is "<cleanings>,<room_ids>".
+    """
+
+    def __init__(
+        self, mode: CleanMode, area: list[int | float], cleanings: int = 1
+    ) -> None:
+        self._additional_content = {
+            "type": CleanMode.FREE_CLEAN.value,
+            "value": f"{cleanings},{','.join(str(int(i)) for i in area)}",
+        }
+        super().__init__(CleanAction.START)
+
+    def _get_args(self, action: CleanAction) -> dict[str, Any]:
+        args = super()._get_args(action)
+        if action == CleanAction.START:
+            args["content"].update(self._additional_content)
+        return args
+
+
 class GetCleanInfo(JsonCommandWithMessageHandling, MessageBodyDataDict):
     """Get clean info command."""
 

--- a/deebot_client/hardware/ilt3k8.py
+++ b/deebot_client/hardware/ilt3k8.py
@@ -37,7 +37,7 @@ from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
 from deebot_client.commands.json.clean import (
-    CleanAreaFreeClean,
+    CleanArea,
     CleanV2,
 )
 from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
@@ -136,7 +136,7 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaFreeClean),
+                action=CapabilityCleanAction(command=CleanV2, area=CleanArea),
                 continuous=CapabilitySetEnable(
                     ContinuousCleaningEvent,
                     [GetContinuousCleaning()],

--- a/deebot_client/hardware/ilt3k8.py
+++ b/deebot_client/hardware/ilt3k8.py
@@ -37,7 +37,7 @@ from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
 from deebot_client.commands.json.clean import (
-    CleanArea,
+    CleanAreaFreeClean,
     CleanV2,
 )
 from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
@@ -136,7 +136,7 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=CleanV2, area=CleanArea),
+                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaFreeClean),
                 continuous=CapabilitySetEnable(
                     ContinuousCleaningEvent,
                     [GetContinuousCleaning()],

--- a/deebot_client/models.py
+++ b/deebot_client/models.py
@@ -81,6 +81,7 @@ class CleanMode(StrEnumWithXml):
     AUTO = "auto", "auto"
     SPOT_AREA = "spotArea", "SpotArea"
     CUSTOM_AREA = "customArea", "spot"
+    FREE_CLEAN = "freeClean", "freeClean"
 
 
 @dataclass(frozen=True)

--- a/tests/commands/json/test_clean.py
+++ b/tests/commands/json/test_clean.py
@@ -9,6 +9,7 @@ from deebot_client.commands.json import GetCleanInfo
 from deebot_client.commands.json.clean import (
     Clean,
     CleanArea,
+    CleanAreaFreeClean,
     CleanAreaV2,
     CleanV2,
     GetCleanInfoV2,
@@ -136,10 +137,32 @@ async def test_Clean_act(
                 },
             },
         ),
+        (
+            CleanAreaFreeClean(CleanMode.FREE_CLEAN, [5, 8]),
+            {
+                "act": "start",
+                "content": {"type": "freeClean", "value": "1,5,8"},
+            },
+        ),
+        (
+            CleanAreaFreeClean(CleanMode.FREE_CLEAN, [0], cleanings=2),
+            {
+                "act": "start",
+                "content": {"type": "freeClean", "value": "2,0"},
+            },
+        ),
     ],
-    ids=["Rooms", "Rooms V2", "Coordinates", "Coordinates V2"],
+    ids=[
+        "Rooms",
+        "Rooms V2",
+        "Coordinates",
+        "Coordinates V2",
+        "FreeClean",
+        "FreeClean single room 2x",
+    ],
 )
 async def test_CleanArea(
-    command: CleanArea | CleanAreaV2, args: dict[str, str]
+    command: CleanArea | CleanAreaV2 | CleanAreaFreeClean,
+    args: dict[str, str],
 ) -> None:
     await assert_execute_command(command, args)


### PR DESCRIPTION
## Summary

Newer robots like the DEEBOT X11 OmniCyclone ~and X9 PRO OMNI~ use the `freeClean` clean type instead of `spotArea` for room cleaning via `clean_V2`. Without this change, room cleaning commands fail with error 20011 "unknown type".

- Adds `FREE_CLEAN` value to the `CleanMode` enum
- Adds `CleanAreaFreeClean` command class that sends `{"type": "freeClean", "value": "<cleanings>,<room_ids>"}`
- Updates the `huhcip` (ilt3k8) hardware definition to use `CleanAreaFreeClean`
- Adds test cases for the new command class

Follow-up to #1457.

## Testing

Tested on a DEEBOT X11 OmniCyclone — room cleaning commands now work correctly via Home Assistant.

Edit:

Misunderstanding how the hardware definitions work; I assumed the X9 PRO OMNI was the same as the X11.  A new PR is coming to define the X11 OmniCyclone.