### PR TITLE
Fix clean area v2 for HA

### DIFF
--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -95,8 +95,9 @@ class CleanAreaV2(CleanV2):
     """Clean area command."""
 
     def __init__(self, mode: CleanMode, area: list[int | float], _: int = 1) -> None:
+        mode = CleanMode.FREE_CLEAN
         self._additional_content = {
-            "type": CleanMode.FREE_CLEAN.value,
+            "type": mode.value,
             "value": ";".join(("1," + str(i)) for i in area),
         }
         super().__init__(CleanAction.START)

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -95,7 +95,7 @@ class CleanAreaV2(CleanV2):
     """Clean area command."""
 
     def __init__(self, mode: CleanMode, area: list[int | float], _: int = 1) -> None:
-        if mode == CleanMode.SPOT_AREA
+        if mode == CleanMode.SPOT_AREA:
             self._additional_content = {
                 "type": CleanMode.FREE_CLEAN.value,
                 "value": ";".join(("1," + str(i)) for i in area),

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -96,8 +96,8 @@ class CleanAreaV2(CleanV2):
 
     def __init__(self, mode: CleanMode, area: list[int | float], _: int = 1) -> None:
         self._additional_content = {
-            "type": mode.value,
-            "value": ",".join(str(i) for i in area),
+            "type": CleanMode.FREE_CLEAN.value,
+            "value": ";".join(("1," + str(i)) for i in area),
         }
         super().__init__(CleanAction.START)
 

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -95,11 +95,16 @@ class CleanAreaV2(CleanV2):
     """Clean area command."""
 
     def __init__(self, mode: CleanMode, area: list[int | float], _: int = 1) -> None:
-        mode = CleanMode.FREE_CLEAN
-        self._additional_content = {
-            "type": mode.value,
-            "value": ";".join(("1," + str(i)) for i in area),
-        }
+        if mode == CleanMode.SPOT_AREA
+            self._additional_content = {
+                "type": CleanMode.FREE_CLEAN.value,
+                "value": ";".join(("1," + str(i)) for i in area),
+            }
+        else
+            self._additional_content = {
+                "type": mode,
+                "value": ",".join(str(i) for i in area),
+            }
         super().__init__(CleanAction.START)
 
     def _get_args(self, action: CleanAction) -> dict[str, Any]:

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -100,7 +100,7 @@ class CleanAreaV2(CleanV2):
                 "type": CleanMode.FREE_CLEAN.value,
                 "value": ";".join(("1," + str(i)) for i in area),
             }
-        else
+        else:
             self._additional_content = {
                 "type": mode,
                 "value": ",".join(str(i) for i in area),

--- a/deebot_client/models.py
+++ b/deebot_client/models.py
@@ -81,6 +81,7 @@ class CleanMode(StrEnumWithXml):
     AUTO = "auto", "auto"
     SPOT_AREA = "spotArea", "SpotArea"
     CUSTOM_AREA = "customArea", "spot"
+    FREE_CLEAN = "freeClean", "freeClean"
 
 
 @dataclass(frozen=True)

--- a/tests/commands/json/test_clean.py
+++ b/tests/commands/json/test_clean.py
@@ -115,7 +115,7 @@ async def test_Clean_act(
         ),
         (
             CleanAreaV2(CleanMode.SPOT_AREA, [5, 8]),
-            {"act": "start", "content": {"type": "spotArea", "value": "5,8"}},
+            {"act": "start", "content": {"type": "freeClean", "value": "1,5;1,8"}},
         ),
         (
             CleanArea(CleanMode.CUSTOM_AREA, [1580.0, -4087.0, 3833.0, -7525.0]),


### PR DESCRIPTION
Makes the clean area method available to Home Assistant for newer models using the V2 API. 
Related to: https://github.com/home-assistant/core/issues/165933