### PR TITLE
feat(camera): add KVS WebRTC camera support module

### DIFF
--- a/deebot_client/camera/__init__.py
+++ b/deebot_client/camera/__init__.py
@@ -1,0 +1,3 @@
+"""KVS camera support for Deebot robots."""
+
+from __future__ import annotations

--- a/deebot_client/camera/api.py
+++ b/deebot_client/camera/api.py
@@ -1,0 +1,336 @@
+"""KVS camera HTTP API client for Ecovacs robots.
+
+This module handles all HTTP interactions with the Ecovacs cloud required to
+establish and terminate a KVS (AWS Kinesis Video Streams) WebRTC camera session:
+
+- ``start_watch_v2`` — authenticates with the Ecovacs API and returns the AWS
+  credentials, KVS channel ARN, ICE server config, and a session-ID that must
+  be presented to ``end_watch`` when the stream is closed.
+- ``end_watch`` — cleanly terminates the cloud-side session so the robot stops
+  streaming and the channel can be reused by another viewer.
+- ``verify_video_pwd`` — validates the numeric camera PIN before starting a
+  session; robots with a PIN lock reject ``start_watch_v2`` with a specific
+  error code if the PIN has not been verified first.
+- ``encode_pin`` / ``generate_video_track_id`` — small helpers shared between
+  the API layer and the HA integration options flow.
+
+The module also contains two thin wrappers — ``send_video_opened`` and
+``set_audio_call_state`` — that publish the MQTT P2P messages the robot needs
+in order to open its video encoder and properly track viewer presence.
+
+The API gateway URL is continent-scoped (``eu``, ``na``, ``ww``).  All calls
+use standard Ecovacs V3 request headers including a timestamp-based HMAC-SHA1
+signature that prevents replay attacks.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import logging
+import random
+import string
+import time
+from typing import Any, cast
+import uuid
+
+import orjson
+from aiohttp import ClientSession, ClientTimeout
+
+_LOGGER = logging.getLogger(__name__)
+
+# API gateway for KVS session control.
+# Different from the portal URL used by deebot-client for GetDeviceList.
+# The datacenter segment (eu / na / ww) must match the user's continent.
+_MA_GW_TEMPLATE = "https://api-app.dc-{continent}.ww.ecouser.net"
+
+
+def get_ma_gw(continent: str) -> str:
+    """Return the KVS API gateway URL for the given continent (eu / na / ww)."""
+    return _MA_GW_TEMPLATE.format(continent=continent)
+
+
+_APP_VERSION = "2.1.0"
+_APP_VERSION_HEADER = "3.12.0"
+_APP_PLATFORM = "android"
+_APP_PLATFORM_PARAMS = "Android"
+_APP_LANG = "en"
+
+# PIN encoding: MD5("eco_" + pin_digits)
+PIN_PREFIX = "eco_"
+
+_TRACK_ID_CHARS = string.ascii_letters + string.digits
+
+
+def encode_pin(pin_digits: str) -> str:
+    """Encode the camera PIN as MD5(PIN_PREFIX + pin_digits)."""
+    return hashlib.md5((PIN_PREFIX + pin_digits).encode()).hexdigest()  # noqa: S324
+
+
+def generate_video_track_id() -> str:
+    """Generate a random 10-character alphanumeric video track ID."""
+    return "".join(random.choices(_TRACK_ID_CHARS, k=10))  # noqa: S311
+
+
+def _sign(ts_ms: str) -> str:
+    """Compute request signature as SHA1(shared_secret + timestamp_ms)."""
+    return hashlib.sha1(  # noqa: S324
+        ("ecovacs2ea31cf06e6711eaa0aff7b9558a534e" + ts_ms).encode()
+    ).hexdigest()
+
+
+def _make_headers(token: str, user_id: str, country: str) -> dict[str, str]:
+    """Build standard HTTP request headers for Ecovacs API calls."""
+    ts = str(int(time.time() * 1000))
+    return {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "appid": "ecovacs",
+        "plat": _APP_PLATFORM,
+        "ts": ts,
+        "country": country,
+        "lang": _APP_LANG,
+        "ucid": "",
+        "v": _APP_VERSION_HEADER,
+        "sign": _sign(ts),
+        "token": token,
+        "Authorization": f"Bearer {token}",
+        "userid": user_id,
+    }
+
+
+async def verify_video_pwd(
+    session: ClientSession,
+    *,
+    token: str,
+    user_id: str,
+    did: str,
+    pin_hash: str,
+    country: str,
+    ma_gw: str = "",
+) -> dict[str, Any]:
+    """Verify the camera PIN before initiating a stream.
+
+    POST /api/appsvr/video/pwd/verify
+
+    Returns the raw JSON response dict.  The caller should check
+    ``data["ret"] == "ok"`` before proceeding.
+    """
+    if not ma_gw:
+        ma_gw = get_ma_gw("ww")
+    url = f"{ma_gw}/api/appsvr/video/pwd/verify"
+    body = orjson.dumps({"did": did, "pwd": pin_hash})
+    async with session.post(
+        url,
+        data=body,
+        headers=_make_headers(token, user_id, country),
+        timeout=ClientTimeout(total=10),
+    ) as resp:
+        raw = await resp.read()
+        try:
+            data = orjson.loads(raw)
+        except orjson.JSONDecodeError:
+            data = {"raw": raw.decode(errors="replace")}
+    _LOGGER.debug("verify_video_pwd ret=%s code=%s", data.get("ret"), data.get("code"))
+    return cast("dict[str, Any]", data)
+
+
+async def start_watch_v2(
+    session: ClientSession,
+    *,
+    token: str,
+    user_id: str,
+    did: str,
+    mid: str,
+    res: str,
+    pin_hash: str,
+    video_track_id: str | None = None,
+    country: str,
+    ma_gw: str = "",
+) -> dict[str, Any]:
+    """Initiate a KVS video session for the robot.
+
+    GET /api/appsvr/akvs/start_watch/v2
+
+    On success the response contains:
+
+    - ``channelArn`` — the KVS signaling channel ARN.
+    - ``region`` — AWS region where the channel lives.
+    - ``credentials`` — temporary ``AccessKeyId``, ``SecretAccessKey``,
+      ``SessionToken`` for signing the WebSocket URL.
+    - ``iceServerList`` — STUN/TURN servers for ICE negotiation.
+    - ``clientId`` — the viewer client ID to embed in all signaling messages.
+    - ``session`` — opaque session ID for ``end_watch``.
+    """
+    if not ma_gw:
+        ma_gw = get_ma_gw("ww")
+    if video_track_id is None:
+        video_track_id = generate_video_track_id()
+
+    params = {
+        "videoTrackId": video_track_id,
+        "lang": _APP_LANG,
+        "plat": _APP_PLATFORM_PARAMS,
+        "av": _APP_VERSION,
+        "did": did,
+        "mid": mid,
+        "res": res,
+        "pwd": pin_hash,
+    }
+
+    async with session.get(
+        f"{ma_gw}/api/appsvr/akvs/start_watch/v2",
+        params=params,
+        headers=_make_headers(token, user_id, country),
+        timeout=ClientTimeout(total=20),
+    ) as resp:
+        raw = await resp.read()
+        try:
+            data = orjson.loads(raw)
+        except orjson.JSONDecodeError:
+            data = {"raw": raw.decode(errors="replace")}
+        _LOGGER.debug(
+            "start_watch_v2 ret=%s session=%s", data.get("ret"), data.get("session")
+        )
+    return cast("dict[str, Any]", data)
+
+
+async def end_watch(
+    session: ClientSession,
+    *,
+    token: str,
+    user_id: str,
+    session_id: str,
+    video_track_id: str,
+    country: str,
+    ma_gw: str = "",
+) -> None:
+    """Terminate the video session server-side.
+
+    GET /api/appsvr/akvs/end_watch
+
+    Best-effort: failures are logged as warnings and swallowed so that camera
+    teardown never blocks Home Assistant entity unloading.
+    """
+    if not ma_gw:
+        ma_gw = get_ma_gw("ww")
+    params = {
+        "videoTrackId": video_track_id,
+        "lang": _APP_LANG,
+        "plat": _APP_PLATFORM_PARAMS,
+        "av": _APP_VERSION,
+        "sid": session_id,
+    }
+    try:
+        async with session.get(
+            f"{ma_gw}/api/appsvr/akvs/end_watch",
+            params=params,
+            headers=_make_headers(token, user_id, country),
+            timeout=ClientTimeout(total=10),
+        ) as resp:
+            _LOGGER.debug("end_watch HTTP %d", resp.status)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.warning("End_watch failed: %s", err)
+
+
+async def send_video_opened(
+    *,
+    enqueue_publish: Any,
+    token: str,
+    user_id: str,
+    user_resource: str,
+    did: str,
+    mid: str,
+    res: str,
+) -> None:
+    """Notify the robot via MQTT that the viewer is ready to receive video.
+
+    The robot will not start encoding until it receives this P2P message on
+    the JMQ broker.  It must be sent *after* the WebRTC offer/answer exchange
+    completes and the ICE connection is established.
+    """
+    await _send_p2p_mqtt_cmd(
+        enqueue_publish=enqueue_publish,
+        token=token,
+        user_id=user_id,
+        user_resource=user_resource,
+        did=did,
+        mid=mid,
+        res=res,
+        cmd_name="videoOpened",
+        cmd_data=None,
+    )
+
+
+async def set_audio_call_state(
+    *,
+    enqueue_publish: Any,
+    token: str,
+    user_id: str,
+    user_resource: str,
+    did: str,
+    mid: str,
+    res: str,
+    client_id: str,
+    state: int,
+) -> None:
+    """Send ``setAudioCallState`` to the robot via MQTT.
+
+    ``state=1`` signals that a viewer has connected; ``state=0`` that the last
+    viewer has disconnected.  The robot uses this to manage its streaming
+    encoder lifecycle.
+    """
+    await _send_p2p_mqtt_cmd(
+        enqueue_publish=enqueue_publish,
+        token=token,
+        user_id=user_id,
+        user_resource=user_resource,
+        did=did,
+        mid=mid,
+        res=res,
+        cmd_name="setAudioCallState",
+        cmd_data={"clientId": client_id, "state": state},
+    )
+
+
+async def _send_p2p_mqtt_cmd(
+    *,
+    enqueue_publish: Any,
+    token: str,
+    user_id: str,
+    user_resource: str,
+    did: str,
+    mid: str,
+    res: str,
+    cmd_name: str,
+    cmd_data: dict[str, Any] | None,
+) -> None:
+    """Publish a P2P MQTT command to the robot on the KVS JMQ broker.
+
+    The topic follows the Ecovacs P2P routing scheme:
+    ``iot/p2p/{cmd}/{from_uid}/{from_class}/{from_res}/{to_did}/{to_mid}/{to_res}/q/{req_id}/j``
+
+    The payload is a JSON-encoded header/body envelope compatible with the
+    Ecovacs MQTT protocol version 0.0.22.
+    """
+    req_id = uuid.uuid4().hex[:8]
+    ts = str(int(time.time() * 1000))
+    tz_offset = int(
+        (
+            _dt.datetime.now(_dt.UTC).astimezone().utcoffset() or _dt.timedelta()
+        ).total_seconds()
+        / 60
+    )
+
+    payload = orjson.dumps(
+        {
+            "header": {"pri": 2, "ts": ts, "tzm": tz_offset, "ver": "0.0.22"},
+            "body": {"data": cmd_data},
+        }
+    )
+    topic = (
+        f"iot/p2p/{cmd_name}/{user_id}/ecouser/{user_resource}"
+        f"/{did}/{mid}/{res}/q/{req_id}/j"
+    )
+    _LOGGER.debug("MQTT P2P %s topic=%s", cmd_name, topic)
+    await enqueue_publish(topic, payload, qos=0)

--- a/deebot_client/camera/api.py
+++ b/deebot_client/camera/api.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import datetime as _dt
 import hashlib
-import logging
 import random
 import string
 import time
@@ -36,8 +35,9 @@ import uuid
 
 import orjson
 from aiohttp import ClientSession, ClientTimeout
+from deebot_client.logging_filter import get_logger
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = get_logger(__name__)
 
 # API gateway for KVS session control.
 # Different from the portal URL used by deebot-client for GetDeviceList.
@@ -251,7 +251,7 @@ async def send_video_opened(
     """
     await _send_p2p_mqtt_cmd(
         enqueue_publish=enqueue_publish,
-        token=token,
+        _token=token,
         user_id=user_id,
         user_resource=user_resource,
         did=did,
@@ -282,7 +282,7 @@ async def set_audio_call_state(
     """
     await _send_p2p_mqtt_cmd(
         enqueue_publish=enqueue_publish,
-        token=token,
+        _token=token,
         user_id=user_id,
         user_resource=user_resource,
         did=did,
@@ -296,7 +296,7 @@ async def set_audio_call_state(
 async def _send_p2p_mqtt_cmd(
     *,
     enqueue_publish: Any,
-    token: str,
+    _token: str,
     user_id: str,
     user_resource: str,
     did: str,

--- a/deebot_client/camera/mqtt.py
+++ b/deebot_client/camera/mqtt.py
@@ -44,7 +44,6 @@ import asyncio
 from collections.abc import Callable
 import contextlib
 import datetime as _dt
-import logging
 import ssl
 import time
 from typing import Any
@@ -52,8 +51,9 @@ from typing import Any
 import aiomqtt
 import orjson
 from deebot_client.authentication import Authenticator
+from deebot_client.logging_filter import get_logger
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = get_logger(__name__)
 
 _JMQ_BROKER_PORT = 443
 _RECONNECT_DELAY = 5  # seconds between MQTT reconnection attempts
@@ -217,7 +217,7 @@ class KvsMqttListener:
                     except orjson.JSONDecodeError:
                         raw = (
                             message.payload.decode(errors="replace")
-                            if isinstance(message.payload, bytes | bytearray)
+                            if isinstance(message.payload, (bytes, bytearray))
                             else str(message.payload)
                         )
                         payload = {"raw": raw}

--- a/deebot_client/camera/mqtt.py
+++ b/deebot_client/camera/mqtt.py
@@ -1,0 +1,302 @@
+"""KVS camera MQTT P2P listener for Ecovacs robots.
+
+Ecovacs camera-equipped robots use a **dedicated JMQ MQTT broker** for all
+camera-related P2P signaling.  This broker is separate from the standard
+deebot-client broker (``mq-*.ecouser.net``) and is the only broker that
+authorises the P2P camera topics — publishing to the regular broker on those
+topics returns MQTT return-code 135 (Not Authorized), and the SUBSCRIBE
+is silently dropped.
+
+The JMQ broker hostname is continent-scoped:
+``jmq-ngiot-{eu|na|as}.dc.ww.ecouser.net:443``
+
+**P2P protocol**
+
+The robot sends ``p2pReq`` messages to the viewer on topics matching::
+
+    iot/p2p/{cmd}/{robot_did}/{robot_mid}/{robot_res}/{user_id}/ecouser/{user_res}/q/{req_id}/j
+
+The viewer is expected to respond with a ``p2pDataResp`` on the corresponding
+``/p/`` (response) topic so that the robot knows the request was received.
+
+The commands of interest are:
+
+- ``videoOpened`` — the robot acknowledges that it has opened its encoder and
+  the video stream is ready.
+- ``setAudioCallState`` — state-change notification (viewer connected /
+  disconnected).
+- ``p2pDataResp`` — generic P2P acknowledgement.
+
+**Usage**
+
+Create a single ``KvsMqttListener`` instance per HA installation (not per
+robot), start it with ``await listener.start()``, and pass a ``on_p2p_req``
+callback that dispatches messages to the correct robot handler by DID.
+
+Outgoing messages (``videoOpened``, ``setAudioCallState``) should be queued
+via ``enqueue_publish``; the listener drains the queue on the same persistent
+connection used for subscriptions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import contextlib
+import datetime as _dt
+import logging
+import ssl
+import time
+from typing import Any
+
+import aiomqtt
+import orjson
+from deebot_client.authentication import Authenticator
+
+_LOGGER = logging.getLogger(__name__)
+
+_JMQ_BROKER_PORT = 443
+_RECONNECT_DELAY = 5  # seconds between MQTT reconnection attempts
+_MQTT_TIMEOUT = 30  # seconds for MQTT client keep-alive / connect timeout
+_MQTT_QOS = 1  # QoS level for P2P subscriptions
+
+
+def _jmq_host(continent: str) -> str:
+    """Return the JMQ broker hostname for the given continent code (eu/na/as)."""
+    region = continent if continent in ("eu", "na", "as") else "eu"
+    return f"jmq-ngiot-{region}.dc.ww.ecouser.net"
+
+
+class KvsMqttListener:
+    """Persistent MQTT connection to the Ecovacs JMQ broker for KVS P2P signaling.
+
+    A single TCP/TLS connection is used for both SUBSCRIBE (receiving robot
+    P2P requests) and PUBLISH (sending viewer commands back to the robot).
+    Outgoing messages are enqueued and drained by a background worker task on
+    the same connection.
+
+    The listener automatically reconnects after disconnections and refreshes
+    the authentication token on each reconnect when an :class:`Authenticator`
+    is provided.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_id: str,
+        user_resource: str,
+        on_p2p_req: Callable[[str, dict[str, Any]], None],
+        authenticator: Authenticator | None = None,
+        token: str | None = None,
+        continent: str = "eu",
+    ) -> None:
+        """Initialize the KVS MQTT listener.
+
+        Args:
+            user_id: The Ecovacs account user ID.
+            user_resource: The MQTT client resource string for this installation.
+            on_p2p_req: Callback invoked for every incoming robot P2P request.
+                Receives ``(topic: str, payload: dict)`` and must not block.
+            authenticator: Preferred; enables automatic token refresh on
+                reconnect.  Mutually exclusive with ``token``.
+            token: Static auth token.  Use when no :class:`Authenticator` is
+                available.  Not refreshed automatically.
+            continent: Two-letter continent code (``eu``, ``na``, ``as``).
+                Defaults to ``"eu"``.
+        """
+        if authenticator is None and token is None:
+            msg = "Either 'authenticator' or 'token' must be provided"
+            raise ValueError(msg)
+        self._authenticator = authenticator
+        self._token = token
+        self._user_id = user_id
+        self._user_resource = user_resource
+        self._on_p2p_req = on_p2p_req
+        self._continent = continent
+        self._publish_queue: asyncio.Queue[tuple[str, bytes, int]] = asyncio.Queue()
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+
+    async def _resolve_token(self) -> str:
+        """Return a valid auth token, refreshing via Authenticator if available."""
+        if self._authenticator is not None:
+            creds = await self._authenticator.authenticate()
+            return creds.token
+        assert self._token is not None  # noqa: S101
+        return self._token
+
+    async def start(self) -> None:
+        """Start the MQTT listener task (auto-reconnects on disconnect)."""
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run_forever())
+
+    async def stop(self) -> None:
+        """Stop the MQTT listener task and wait for it to finish."""
+        self._stop_event.set()
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                await asyncio.wait_for(asyncio.shield(self._task), timeout=3.0)
+        self._task = None
+
+    async def enqueue_publish(self, topic: str, payload: bytes, qos: int = 0) -> None:
+        """Enqueue a message for publish on the persistent MQTT connection.
+
+        Thread-safe; can be called from any asyncio coroutine.
+        """
+        await self._publish_queue.put((topic, payload, qos))
+
+    async def _run_forever(self) -> None:
+        """Run the MQTT connection loop, reconnecting after each disconnection."""
+        while not self._stop_event.is_set():
+            try:
+                await self._run()
+            except asyncio.CancelledError:
+                return
+            except Exception as err:  # noqa: BLE001
+                if not self._stop_event.is_set():
+                    _LOGGER.warning("KVS MQTT error: %s", err)
+            if not self._stop_event.is_set():
+                _LOGGER.info(
+                    "KVS MQTT disconnected — reconnecting in %ds", _RECONNECT_DELAY
+                )
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=_RECONNECT_DELAY
+                    )
+
+    async def _run(self) -> None:
+        """Establish a single MQTT connection, subscribe and dispatch messages."""
+        loop = asyncio.get_running_loop()
+        ssl_ctx = await loop.run_in_executor(None, ssl.create_default_context)
+        # The Ecovacs JMQ video-signaling broker presents a certificate issued by
+        # a private CA that is not in the system trust store, causing TLS
+        # verification to fail with the default context.  Certificate verification
+        # is therefore disabled for this specific connection only; the broker
+        # hostname is a hard-coded Ecovacs infrastructure endpoint and the traffic
+        # is additionally protected by MQTT credentials.
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+        client_id = f"{self._user_id}@ecouser/{self._user_resource}"
+        sub_topic = (
+            f"iot/p2p/+/+/+/+/{self._user_id}/ecouser/{self._user_resource}/+/+/+"
+        )
+
+        _LOGGER.debug(
+            "KVS MQTT: connecting to %s:%d client_id=%s",
+            _jmq_host(self._continent),
+            _JMQ_BROKER_PORT,
+            client_id,
+        )
+
+        token = await self._resolve_token()
+        publish_task: asyncio.Task[None] | None = None
+        try:
+            async with aiomqtt.Client(
+                hostname=_jmq_host(self._continent),
+                port=_JMQ_BROKER_PORT,
+                username=self._user_id,
+                password=token,
+                identifier=client_id,
+                tls_context=ssl_ctx,
+                timeout=_MQTT_TIMEOUT,
+            ) as client:
+                _LOGGER.debug("KVS MQTT: connected, subscribing to %s", sub_topic)
+                await client.subscribe(sub_topic, qos=_MQTT_QOS)
+                publish_task = asyncio.create_task(
+                    self._publish_worker(client, self._publish_queue)
+                )
+
+                async for message in client.messages:
+                    if self._stop_event.is_set():
+                        break
+                    topic = str(message.topic)
+                    try:
+                        payload = orjson.loads(message.payload)
+                    except orjson.JSONDecodeError:
+                        raw = (
+                            message.payload.decode(errors="replace")
+                            if isinstance(message.payload, bytes | bytearray)
+                            else str(message.payload)
+                        )
+                        payload = {"raw": raw}
+
+                    parts = topic.split("/")
+                    if len(parts) >= 10 and parts[9] == "q":  # noqa: PLR2004
+                        try:
+                            self._on_p2p_req(topic, payload)
+                        except Exception as err:  # noqa: BLE001
+                            _LOGGER.warning("KVS MQTT on_p2p_req error: %s", err)
+
+        finally:
+            if publish_task is not None and not publish_task.done():
+                publish_task.cancel()
+                with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                    await asyncio.wait_for(asyncio.shield(publish_task), timeout=2.0)
+
+    @staticmethod
+    async def _publish_worker(
+        client: Any,
+        queue: asyncio.Queue[tuple[str, bytes, int]],
+    ) -> None:
+        """Drain the publish queue and publish each message on ``client``."""
+        while True:
+            topic, payload, qos = await queue.get()
+            try:
+                await client.publish(topic, payload=payload, qos=qos)
+                _LOGGER.debug("KVS MQTT publish OK: %s", topic[:80])
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning("KVS MQTT publish error: %s | topic=%s", err, topic)
+            finally:
+                queue.task_done()
+
+    async def send_p2p_data_resp(
+        self,
+        req_topic: str,
+    ) -> None:
+        """Acknowledge a robot P2P request with a ``p2pDataResp`` response.
+
+        Parses the request topic to reconstruct the symmetric response topic
+        (``/q/`` → ``/p/``) and sends a success acknowledgement so the robot
+        knows the request was received and processed.
+
+        Args:
+            req_topic: The full topic string of the received P2P request.
+        """
+        parts = req_topic.split("/")
+        if len(parts) < 12:  # noqa: PLR2004
+            _LOGGER.warning("P2pDataResp: malformed request topic: %s", req_topic)
+            return
+
+        cmd = parts[2]
+        app_user_id = parts[6]
+        app_vendor = parts[7]
+        app_res = parts[8]
+        from_id = parts[3]
+        from_class = parts[4]
+        from_res = parts[5]
+        req_id = parts[10]
+        fmt = parts[11]
+
+        resp_topic = (
+            f"iot/p2p/{cmd}/{app_user_id}/{app_vendor}/{app_res}"
+            f"/{from_id}/{from_class}/{from_res}/p/{req_id}/{fmt}"
+        )
+
+        ts = str(int(time.time() * 1000))
+        tz_offset = int(
+            (
+                _dt.datetime.now(_dt.UTC).astimezone().utcoffset() or _dt.timedelta()
+            ).total_seconds()
+            / 60
+        )
+        resp_payload = orjson.dumps(
+            {
+                "header": {"pri": 1, "ts": ts, "tzm": tz_offset, "ver": "0.0.22"},
+                "body": {"code": 0, "msg": "ok"},
+            }
+        )
+
+        _LOGGER.debug("KVS MQTT p2pDataResp → %s", resp_topic)
+        await self.enqueue_publish(resp_topic, resp_payload, qos=1)

--- a/deebot_client/camera/signaling.py
+++ b/deebot_client/camera/signaling.py
@@ -24,12 +24,9 @@ import base64
 from datetime import UTC, datetime
 import hashlib
 import hmac
-import logging
 import urllib.parse
 
 import orjson
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def _b64(data: str | bytes) -> str:

--- a/deebot_client/camera/signaling.py
+++ b/deebot_client/camera/signaling.py
@@ -1,0 +1,206 @@
+"""KVS WebRTC signaling utilities for Ecovacs robots.
+
+Provides two categories of helpers used during the WebRTC handshake between
+Home Assistant (VIEWER) and the robot (MASTER):
+
+**AWS SigV4 URL signing** — ``sign_wss_url``
+    KVS uses standard AWS Signature Version 4 to authenticate the WebSocket
+    upgrade request.  This function constructs the canonical request, derives
+    the signing key using HMAC-SHA256 chains, and appends the signature and all
+    required ``X-Amz-*`` query parameters to the WSS endpoint URL returned by
+    ``start_watch_v2``.  No AWS SDK is needed; the algorithm is implemented
+    here in pure Python (``hashlib`` + ``hmac``).
+
+**KVS WebSocket message builders** — ``make_sdp_offer_msg``, ``make_ice_msg``
+    The KVS signaling protocol wraps WebRTC SDP and ICE payloads in a simple
+    JSON envelope with a base64-encoded ``messagePayload``.  These helpers
+    produce the ``SDP_OFFER`` and ``ICE_CANDIDATE`` messages that the VIEWER
+    sends to the MASTER over the signed WebSocket connection.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+import hashlib
+import hmac
+import logging
+import urllib.parse
+
+import orjson
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _b64(data: str | bytes) -> str:
+    """Encode a string or bytes value as base64."""
+    if isinstance(data, str):
+        data = data.encode()
+    return base64.b64encode(data).decode()
+
+
+def sign_wss_url(
+    wss_endpoint: str,
+    channel_arn: str,
+    client_id: str,
+    creds: dict[str, str],
+    region: str,
+) -> str:
+    """Sign a KVS WebSocket URL using AWS Signature Version 4 (VIEWER role).
+
+    The signing procedure follows the standard AWS SigV4 algorithm:
+    1. Build a canonical query string that includes all ``X-Amz-*`` parameters
+       sorted lexicographically.
+    2. Construct the canonical request (HTTP method, URI, query string,
+       canonical headers, payload hash).
+    3. Derive the signing key through a chain of four HMAC-SHA256 operations:
+       ``DateKey → DateRegionKey → DateRegionServiceKey → SigningKey``.
+    4. Compute the final signature and append ``X-Amz-Signature`` to the URL.
+
+    The ``X-Amz-ClientId`` parameter identifies this viewer connection to the
+    KVS signaling channel and must match the ``clientId`` returned by
+    ``start_watch_v2``.
+
+    Args:
+        wss_endpoint: The base WSS URL from ``start_watch_v2`` (e.g.
+            ``wss://m-a1b2c3d4e5f6.kinesisvideo.eu-west-1.amazonaws.com``).
+        channel_arn: The KVS channel ARN from ``start_watch_v2``.
+        client_id: The viewer client ID from ``start_watch_v2``.
+        creds: A dict with ``AccessKeyId``, ``SecretAccessKey``, and
+            optionally ``SessionToken`` (from the temporary STS credentials
+            returned by ``start_watch_v2``).
+        region: AWS region string (e.g. ``"eu-west-1"``).
+
+    Returns:
+        A fully-signed ``wss://`` URL ready for use with a WebSocket client.
+    """
+    host = wss_endpoint.replace("wss://", "").split("/")[0]
+    now = datetime.now(UTC)
+    date_str = now.strftime("%Y%m%d")
+    time_str = now.strftime("%Y%m%dT%H%M%SZ")
+    service = "kinesisvideo"
+
+    qs_params: dict[str, str] = {
+        "X-Amz-ChannelARN": channel_arn,
+        "X-Amz-ClientId": client_id,
+        "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+        "X-Amz-Credential": (
+            f"{creds['AccessKeyId']}/{date_str}/{region}/{service}/aws4_request"
+        ),
+        "X-Amz-Date": time_str,
+        "X-Amz-Expires": "299",
+        "X-Amz-SignedHeaders": "host",
+    }
+    if creds.get("SessionToken"):
+        qs_params["X-Amz-Security-Token"] = creds["SessionToken"]
+
+    def _url_encode(s: str) -> str:
+        return urllib.parse.quote(s, safe="")
+
+    sorted_qs = "&".join(
+        f"{_url_encode(k)}={_url_encode(v)}" for k, v in sorted(qs_params.items())
+    )
+
+    canonical_req = "\n".join(
+        [
+            "GET",
+            "/",
+            sorted_qs,
+            f"host:{host}\n",
+            "host",
+            # Empty payload hash (GET request with no body)
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ]
+    )
+    scope = f"{date_str}/{region}/{service}/aws4_request"
+    string_to_sign = "\n".join(
+        [
+            "AWS4-HMAC-SHA256",
+            time_str,
+            scope,
+            hashlib.sha256(canonical_req.encode()).hexdigest(),
+        ]
+    )
+
+    def _hmac_sha256(key: bytes | str, msg: str) -> bytes:
+        if isinstance(key, str):
+            key = key.encode()
+        return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+    signing_key = _hmac_sha256(
+        _hmac_sha256(
+            _hmac_sha256(
+                _hmac_sha256(f"AWS4{creds['SecretAccessKey']}", date_str),
+                region,
+            ),
+            service,
+        ),
+        "aws4_request",
+    )
+    signature = _hmac_sha256(signing_key, string_to_sign).hex()
+    qs_params["X-Amz-Signature"] = signature
+    final_qs = "&".join(
+        f"{_url_encode(k)}={_url_encode(v)}" for k, v in sorted(qs_params.items())
+    )
+    return f"wss://{host}/?{final_qs}"
+
+
+def make_sdp_offer_msg(sdp: str, client_id: str) -> bytes:
+    """Build a KVS WebSocket ``SDP_OFFER`` message.
+
+    The ``messagePayload`` field is base64-encoded JSON containing the SDP
+    offer string and type identifier, as required by the KVS signaling
+    protocol.
+
+    Args:
+        sdp: The SDP offer string produced by the local WebRTC peer connection.
+        client_id: The viewer client ID to include as ``senderClientId``.
+
+    Returns:
+        JSON-encoded bytes ready to send over the KVS signaling WebSocket.
+    """
+    return orjson.dumps(
+        {
+            "action": "SDP_OFFER",
+            "recipientClientId": "",
+            "messagePayload": _b64(
+                orjson.dumps({"type": "offer", "sdp": sdp}).decode()
+            ),
+            "senderClientId": client_id,
+        }
+    )
+
+
+def make_ice_msg(
+    candidate: str, sdp_mid: str, sdp_mline: int, client_id: str
+) -> bytes:
+    """Build a KVS WebSocket ``ICE_CANDIDATE`` message.
+
+    Encodes an ICE candidate (obtained from the local WebRTC peer connection
+    ``on_icecandidate`` callback) in the KVS signaling wire format.
+
+    Args:
+        candidate: The ICE candidate string (e.g. ``"candidate:…"``).
+        sdp_mid: The media stream ID associated with the candidate.
+        sdp_mline: The zero-based media description index (``sdpMLineIndex``).
+        client_id: The viewer client ID to include as ``senderClientId``.
+
+    Returns:
+        JSON-encoded bytes ready to send over the KVS signaling WebSocket.
+    """
+    return orjson.dumps(
+        {
+            "action": "ICE_CANDIDATE",
+            "recipientClientId": "",
+            "messagePayload": _b64(
+                orjson.dumps(
+                    {
+                        "candidate": candidate,
+                        "sdpMid": sdp_mid,
+                        "sdpMLineIndex": sdp_mline,
+                    }
+                ).decode()
+            ),
+            "senderClientId": client_id,
+        }
+    )


### PR DESCRIPTION
## Summary

This PR adds a new `deebot_client/camera/` subpackage implementing the Ecovacs KVS (AWS Kinesis Video Streams) WebRTC camera protocol, extracted from the `ecovacs` Home Assistant integration (home-assistant/core#167564).

The move was requested by a Home Assistant core reviewer, who noted that protocol-level code should live in the upstream library rather than in the integration itself.

---

## Why these files belong in deebot-client

The Ecovacs camera stream uses a **proprietary multi-layer protocol** on top of AWS KVS WebRTC:

1. **A dedicated Ecovacs HTTP API** (`/api/appsvr/akvs/start_watch/v2`) that issues temporary AWS credentials for the KVS signaling channel — this is Ecovacs protocol, not generic WebRTC.
2. **AWS SigV4 URL signing** for the KVS WebSocket endpoint — required because the credentials from step 1 must be signed before use; no AWS SDK is needed when implemented in pure Python.
3. **A separate JMQ MQTT broker** (`jmq-ngiot-{eu|na|as}.dc.ww.ecouser.net:443`) for P2P camera signaling — this broker rejects camera topics on the standard deebot-client MQTT broker with code 135 (Not Authorized).

All three layers are **Ecovacs-specific protocol details** that have no business being embedded in a Home Assistant integration. They belong here.

---

## What is included

### `deebot_client/camera/api.py`

HTTP client for the Ecovacs camera API gateway. All requests use the standard Ecovacs V3 header format (timestamp + HMAC-SHA1 signature).

| Function | Endpoint | Description |
|---|---|---|
| `start_watch_v2` | `GET /api/appsvr/akvs/start_watch/v2` | Authenticates and returns AWS credentials, KVS channel ARN, ICE server list, client ID, and session ID |
| `end_watch` | `GET /api/appsvr/akvs/end_watch` | Terminates the cloud-side session so the robot stops streaming |
| `verify_video_pwd` | `POST /api/appsvr/video/pwd/verify` | Validates the numeric camera PIN before starting a session |
| `send_video_opened` | MQTT P2P | Notifies the robot that the viewer is ready (robot will not start encoding otherwise) |
| `set_audio_call_state` | MQTT P2P | Notifies the robot of viewer connect/disconnect (state 1 / 0) |
| `encode_pin` | — | MD5("eco_" + digits) PIN hash helper |
| `generate_video_track_id` | — | Random 10-char alphanumeric session correlation ID |

**No new dependencies** — uses `aiohttp` and `orjson` already present in deebot-client.

---

### `deebot_client/camera/signaling.py`

Pure-Python AWS SigV4 URL signing and KVS WebSocket message builders.

| Function | Description |
|---|---|
| `sign_wss_url` | Signs the KVS WSS endpoint URL with SigV4 (HMAC-SHA256 key derivation chain). No boto3/botocore required. |
| `make_sdp_offer_msg` | Encodes an SDP offer in the KVS SDP_OFFER wire format (base64 JSON envelope) |
| `make_ice_msg` | Encodes an ICE candidate in the KVS ICE_CANDIDATE wire format |

**No new dependencies** — pure Python (hashlib, hmac, urllib.parse).

---

### `deebot_client/camera/mqtt.py`

KvsMqttListener: a persistent aiomqtt connection to the Ecovacs JMQ broker used exclusively for camera P2P signaling.

**Why a separate broker connection?**
The regular deebot-client broker (mq-*.ecouser.net) returns MQTT code 135 (Not Authorized) when the viewer tries to subscribe to camera P2P topics. The JMQ broker (jmq-ngiot-{eu|na|as}.dc.ww.ecouser.net:443) is dedicated to camera signaling and must be used instead.

**Design:**
- One shared instance per installation (not per robot) — a single TCP/TLS connection covers all robots.
- Auto-reconnects on disconnection; refreshes the auth token from an Authenticator on each reconnect.
- Outgoing messages (videoOpened, setAudioCallState, p2pDataResp) are enqueued and drained by a background worker on the same connection to avoid multiplexing issues.

**No new dependencies** — uses aiomqtt already present in deebot-client.

---

## What is NOT included

The `kvs_stream` module (WebRTC peer connection lifecycle, ICE/SDP negotiation, H264 decoding via aiortc/av) is intentionally **not** included.

It belongs at the **application layer** (Home Assistant) because aiortc and av (PyAV) are heavy UI-level dependencies with compiled Rust/C extensions that have no place in a general-purpose protocol library.

---

## Relation to Home Assistant

Once this PR is merged and a new release of deebot-client is published, home-assistant/core#167564 will be updated to import from `deebot_client.camera` instead of the local kvs_*.py module files, which will be removed from the integration.