### PR TITLE
Add support for GOAT A3000 LiDAR Pro (51rcxt)

### DIFF
--- a/deebot_client/hardware/51rcxt.py
+++ b/deebot_client/hardware/51rcxt.py
@@ -1,0 +1,141 @@
+"""DEEBOT GOAT G1 Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityLifeSpan,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilityStats,
+    DeviceType,
+)
+from deebot_client.commands.json import (
+    GetBorderSwitch,
+    GetChildLock,
+    GetCrossMapBorderWarning,
+    GetCutDirection,
+    GetMoveUpWarning,
+    GetSafeProtect,
+    SetBorderSwitch,
+    SetChildLock,
+    SetCrossMapBorderWarning,
+    SetCutDirection,
+    SetMoveUpWarning,
+    SetSafeProtect,
+)
+from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.clean import CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AdvancedModeEvent,
+    AvailabilityEvent,
+    BatteryEvent,
+    BorderSwitchEvent,
+    ChildLockEvent,
+    CrossMapBorderWarningEvent,
+    CustomCommandEvent,
+    CutDirectionEvent,
+    ErrorEvent,
+    LifeSpan,
+    LifeSpanEvent,
+    MoveUpWarningEvent,
+    NetworkInfoEvent,
+    ReportStatsEvent,
+    SafeProtectEvent,
+    StateEvent,
+    StatsEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VolumeEvent,
+)
+from deebot_client.models import StaticDeviceInfo
+
+
+def get_device_info() -> StaticDeviceInfo:
+    """Get device info for this model."""
+    return StaticDeviceInfo(
+        DataType.JSON,
+        Capabilities(
+            device_type=DeviceType.MOWER,
+            availability=CapabilityEvent(
+                AvailabilityEvent, [GetBattery(is_available_check=True)]
+            ),
+            battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+            charge=CapabilityExecute(Charge),
+            clean=CapabilityClean(
+                action=CapabilityCleanAction(command=CleanV2),
+            ),
+            custom=CapabilityCustomCommand(
+                event=CustomCommandEvent, get=[], set=CustomCommand
+            ),
+            error=CapabilityEvent(ErrorEvent, [GetError()]),
+            life_span=CapabilityLifeSpan(
+                types=(LifeSpan.BLADE, LifeSpan.LENS_BRUSH),
+                event=LifeSpanEvent,
+                get=[
+                    GetLifeSpan(
+                        [
+                            LifeSpan.BLADE,
+                            LifeSpan.LENS_BRUSH,
+                        ]
+                    )
+                ],
+                reset=ResetLifeSpan,
+            ),
+            network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+            play_sound=CapabilityExecute(PlaySound),
+            settings=CapabilitySettings(
+                advanced_mode=CapabilitySetEnable(
+                    AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
+                ),
+                border_switch=CapabilitySetEnable(
+                    BorderSwitchEvent, [GetBorderSwitch()], SetBorderSwitch
+                ),
+                cut_direction=CapabilitySet(
+                    CutDirectionEvent, [GetCutDirection()], SetCutDirection
+                ),
+                child_lock=CapabilitySetEnable(
+                    ChildLockEvent, [GetChildLock()], SetChildLock
+                ),
+                moveup_warning=CapabilitySetEnable(
+                    MoveUpWarningEvent, [GetMoveUpWarning()], SetMoveUpWarning
+                ),
+                cross_map_border_warning=CapabilitySetEnable(
+                    CrossMapBorderWarningEvent,
+                    [GetCrossMapBorderWarning()],
+                    SetCrossMapBorderWarning,
+                ),
+                safe_protect=CapabilitySetEnable(
+                    SafeProtectEvent, [GetSafeProtect()], SetSafeProtect
+                ),
+                true_detect=CapabilitySetEnable(
+                    TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+                ),
+                volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+            ),
+            state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfoV2()]),
+            stats=CapabilityStats(
+                clean=CapabilityEvent(StatsEvent, [GetStats()]),
+                report=CapabilityEvent(ReportStatsEvent, []),
+                total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+            ),
+        ),
+    )

--- a/deebot_client/hardware/51rcxt.py
+++ b/deebot_client/hardware/51rcxt.py
@@ -1,4 +1,4 @@
-"""DEEBOT GOAT G1 Capabilities."""
+"""GOAT A3000 LiDAR Pro."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Adds hardware definition for the **GOAT A3000 LiDAR Pro** (class `51rcxt`).

This is a copy of the existing GOAT G1 (`5xu9h3.py`) hardware file, following the same pattern as `cr0e4u.py` (A3000 LiDAR), `o4kvvk.py` (A3000 base), `2i0fns.py` (O1200 LiDAR Pro), and all other GOAT mower definitions which share an identical capability set.

## Device Details

| Field | Value |
|---|---|
| `class` | `51rcxt` |
| `deviceName` | GOAT A3000 LiDAR Pro |
| `model` | `GOAT_INT_A2600_LIDAR_PLUS_NA` |
| `UILogicId` | `goatl_ww_h_goat2plus` |
| `product_category` | `GOATBOT` |
| `btName` | `GOAT-51rcxt-0147` |
| `btMac` | `EC:30:8E:33:7A:B2` |

## Testing

Tested on Home Assistant core-2026.4.2 (HAOS 17.2). After adding the hardware file and reloading the Ecovacs integration, the mower appears with battery level, mower state, clean/charge controls, settings (volume, child lock, border switch, cut direction, advanced mode), life span sensors (blade, lens brush), network info, and stats.

Closes #1537