### PR TITLE
Add support for DEEBOT T90 PRO OMNI

### DIFF
--- a/deebot_client/hardware/twunby.py
+++ b/deebot_client/hardware/twunby.py
@@ -1,0 +1,267 @@
+"""DEEBOT T90 PRO OMNI Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityExecuteTypes,
+    CapabilityLifeSpan,
+    CapabilityMap,
+    CapabilityNumber,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStation,
+    CapabilityStats,
+    CapabilityWater,
+    DeviceType,
+)
+from deebot_client.commands import StationAction
+from deebot_client.commands.json import station_action
+from deebot_client.commands.json.auto_empty import GetAutoEmpty, SetAutoEmpty
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
+from deebot_client.commands.json.clean import (
+    Clean,
+    CleanArea,
+)
+from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
+from deebot_client.commands.json.clean_logs import GetCleanLogs
+from deebot_client.commands.json.continuous_cleaning import (
+    GetContinuousCleaning,
+    SetContinuousCleaning,
+)
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import (
+    GetCachedMapInfo,
+    GetMajorMap,
+    GetMapInfoV2,
+    GetMapSetV2,
+    GetMapTrace,
+    GetMinorMap,
+    SetMajorMap,
+)
+from deebot_client.commands.json.mop_auto_wash_frequency import (
+    GetMopAutoWashFrequency,
+    SetMopAutoWashFrequency,
+)
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.ota import GetOta, SetOta
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
+from deebot_client.commands.json.relocation import SetRelocationState
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.sweep_mode import GetSweepMode, SetSweepMode
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.voice_assistant_state import (
+    GetVoiceAssistantState,
+    SetVoiceAssistantState,
+)
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.commands.json.work_mode import GetWorkMode, SetWorkMode
+from deebot_client.commands.json.work_state import GetWorkState
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AvailabilityEvent,
+    BatteryEvent,
+    CachedMapInfoEvent,
+    ChildLockEvent,
+    CleanCountEvent,
+    CleanLogEvent,
+    ContinuousCleaningEvent,
+    CustomCommandEvent,
+    ErrorEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    LifeSpan,
+    LifeSpanEvent,
+    MajorMapEvent,
+    MapChangedEvent,
+    MapTraceEvent,
+    NetworkInfoEvent,
+    OtaEvent,
+    PositionsEvent,
+    ReportStatsEvent,
+    RoomsEvent,
+    StateEvent,
+    StationEvent,
+    StatsEvent,
+    SweepModeEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VoiceAssistantStateEvent,
+    VolumeEvent,
+    WorkMode,
+    WorkModeEvent,
+    auto_empty,
+    water_info,
+)
+from deebot_client.events.auto_empty import AutoEmptyEvent
+from deebot_client.events.mop_auto_wash_frequency import MopAutoWashFrequencyEvent
+from deebot_client.models import StaticDeviceInfo
+
+
+def get_device_info() -> StaticDeviceInfo:
+    """Get device info for this model."""
+    return StaticDeviceInfo(
+        DataType.JSON,
+        Capabilities(
+            device_type=DeviceType.VACUUM,
+            availability=CapabilityEvent(
+                AvailabilityEvent, [GetBattery(is_available_check=True)]
+            ),
+            battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+            charge=CapabilityExecute(Charge),
+            clean=CapabilityClean(
+                action=CapabilityCleanAction(command=Clean, area=CleanArea),
+                continuous=CapabilitySetEnable(
+                    ContinuousCleaningEvent,
+                    [GetContinuousCleaning()],
+                    SetContinuousCleaning,
+                ),
+                count=CapabilitySet(CleanCountEvent, [GetCleanCount()], SetCleanCount),
+                log=CapabilityEvent(CleanLogEvent, [GetCleanLogs()]),
+                work_mode=CapabilitySetTypes(
+                    event=WorkModeEvent,
+                    get=[GetWorkMode()],
+                    set=SetWorkMode,
+                    types=(
+                        WorkMode.MOP,
+                        WorkMode.MOP_AFTER_VACUUM,
+                        WorkMode.VACUUM,
+                        WorkMode.VACUUM_AND_MOP,
+                    ),
+                ),
+            ),
+            custom=CapabilityCustomCommand(
+                event=CustomCommandEvent, get=[], set=CustomCommand
+            ),
+            error=CapabilityEvent(ErrorEvent, [GetError()]),
+            fan_speed=CapabilitySetTypes(
+                event=FanSpeedEvent,
+                get=[GetFanSpeed()],
+                set=SetFanSpeed,
+                types=(
+                    FanSpeedLevel.QUIET,
+                    FanSpeedLevel.NORMAL,
+                    FanSpeedLevel.MAX,
+                    FanSpeedLevel.MAX_PLUS,
+                ),
+            ),
+            life_span=CapabilityLifeSpan(
+                types=(
+                    LifeSpan.SIDE_BRUSH,
+                    LifeSpan.BRUSH,
+                    LifeSpan.FILTER,
+                    LifeSpan.UNIT_CARE,
+                    LifeSpan.ROUND_MOP,
+                    LifeSpan.DUST_BAG,
+                    LifeSpan.CLEANING_SOLUTION,
+                ),
+                event=LifeSpanEvent,
+                get=[
+                    GetLifeSpan(
+                        [
+                            LifeSpan.SIDE_BRUSH,
+                            LifeSpan.BRUSH,
+                            LifeSpan.FILTER,
+                            LifeSpan.UNIT_CARE,
+                            LifeSpan.ROUND_MOP,
+                            LifeSpan.DUST_BAG,
+                            LifeSpan.CLEANING_SOLUTION,
+                        ]
+                    )
+                ],
+                reset=ResetLifeSpan,
+            ),
+            map=CapabilityMap(
+                cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo()]),
+                changed=CapabilityEvent(MapChangedEvent, []),
+                info=CapabilityExecute(GetMapInfoV2),
+                major=CapabilitySet(MajorMapEvent, [GetMajorMap()], SetMajorMap),
+                minor=CapabilityExecute(GetMinorMap),
+                position=CapabilityEvent(PositionsEvent, [GetPos()]),
+                relocation=CapabilityExecute(SetRelocationState),
+                rooms=CapabilityEvent(RoomsEvent, [GetCachedMapInfo()]),
+                set=CapabilityExecute(GetMapSetV2),
+                trace=CapabilityEvent(MapTraceEvent, [GetMapTrace()]),
+            ),
+            network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+            play_sound=CapabilityExecute(PlaySound),
+            settings=CapabilitySettings(
+                child_lock=CapabilitySetEnable(
+                    ChildLockEvent, [GetChildLock()], SetChildLock
+                ),
+                mop_auto_wash_frequency=CapabilityNumber(
+                    event=MopAutoWashFrequencyEvent,
+                    get=[GetMopAutoWashFrequency()],
+                    set=SetMopAutoWashFrequency,
+                    min=0,
+                    max=60,
+                ),
+                ota=CapabilitySetEnable(OtaEvent, [GetOta()], SetOta),
+                sweep_mode=CapabilitySetEnable(
+                    SweepModeEvent, [GetSweepMode()], SetSweepMode
+                ),
+                true_detect=CapabilitySetEnable(
+                    TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+                ),
+                voice_assistant=CapabilitySetEnable(
+                    VoiceAssistantStateEvent,
+                    [GetVoiceAssistantState()],
+                    SetVoiceAssistantState,
+                ),
+                volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+            ),
+            state=CapabilityEvent(StateEvent, [GetChargeState(), GetWorkState()]),
+            station=CapabilityStation(
+                action=CapabilityExecuteTypes(
+                    station_action.StationAction,
+                    types=(
+                        StationAction.EMPTY_DUSTBIN,
+                        StationAction.DRY_MOP,
+                        StationAction.WASH_MOP,
+                    ),
+                ),
+                auto_empty=CapabilitySetTypes(
+                    event=AutoEmptyEvent,
+                    get=[GetAutoEmpty()],
+                    set=SetAutoEmpty,
+                    types=(
+                        auto_empty.Frequency.AUTO,
+                        auto_empty.Frequency.SMART,
+                    ),
+                ),
+                state=CapabilityEvent(StationEvent, [GetWorkState()]),
+            ),
+            stats=CapabilityStats(
+                clean=CapabilityEvent(StatsEvent, [GetStats()]),
+                report=CapabilityEvent(ReportStatsEvent, []),
+                total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+            ),
+            water=CapabilityWater(
+                amount=CapabilityNumber(
+                    event=water_info.WaterCustomAmountEvent,
+                    get=[GetWaterInfo()],
+                    set=lambda custom_amount: SetWaterInfo(custom_amount=custom_amount),
+                    min=0,
+                    max=50,
+                ),
+                mop_attached=CapabilityEvent(
+                    water_info.MopAttachedEvent, [GetWaterInfo()]
+                ),
+            ),
+        ),
+    )


### PR DESCRIPTION
Adds support for the DEEBOT T90 PRO OMNI, device class `twunby`.

This follows the new-device guidance from #612. I started from the closest OMNI-style profiles, then adjusted the capabilities based on real-device smoke testing.

## Device info

From Home Assistant logs:

- deviceName: `DEEBOT T90 PRO OMNI`
- class: `twunby`
- company: `eco-ng`
- model: `SHAKESPEARE_AM_BLK`
- UILogicId: `shakespeare_ww_h_shakespeareh5`
- materialNo: `110-2522-0200`

## Verification

Tested against a real T90 PRO OMNI.

Confirmed working:

- Device is discovered as supported
- `GetBattery`
- `GetChargeState`
- `GetWorkState`
- `GetSweepMode`
- `GetStationState`
- Other read-only getters used in the profile, including fan speed, water info, work mode, continuous cleaning, clean logs/count, child lock, mop auto-wash frequency, OTA, TrueDetect, voice assistant, volume, auto-empty, stats, and lifespan

Not supported by this model during smoke testing:

- `getCleanInfo`
- `getCleanInfo_V2`
- `getCarpertPressure`
- `getMultiMapState`
- `getAdvancedMode`

Because of that, this profile uses `GetWorkState` for state/station refresh and does not include the unsupported T50-derived capabilities.