### PR TITLE
test(hardware): cover xmp9ds (GOAT A1600 RTK) in capabilities event extraction test

### DIFF
--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -142,6 +142,30 @@ async def test_get_static_device_info(
             },
         ),
         (
+            "xmp9ds",
+            {
+                AdvancedModeEvent: [GetAdvancedMode()],
+                AvailabilityEvent: [GetBattery(is_available_check=True)],
+                BatteryEvent: [GetBattery()],
+                BorderSwitchEvent: [GetBorderSwitch()],
+                CutDirectionEvent: [GetCutDirection()],
+                ChildLockEvent: [GetChildLock()],
+                CrossMapBorderWarningEvent: [GetCrossMapBorderWarning()],
+                CustomCommandEvent: [],
+                ErrorEvent: [GetError()],
+                LifeSpanEvent: [GetLifeSpan([LifeSpan.BLADE, LifeSpan.LENS_BRUSH])],
+                MoveUpWarningEvent: [GetMoveUpWarning()],
+                NetworkInfoEvent: [GetNetInfo()],
+                ReportStatsEvent: [],
+                SafeProtectEvent: [GetSafeProtect()],
+                StateEvent: [GetChargeState(), GetCleanInfoV2()],
+                StatsEvent: [GetStats()],
+                TotalStatsEvent: [GetTotalStats()],
+                TrueDetectEvent: [GetTrueDetect()],
+                VolumeEvent: [GetVolume()],
+            },
+        ),
+        (
             "itk04l",
             {
                 AdvancedModeEvent: [GetAdvancedMode()],
@@ -245,7 +269,7 @@ async def test_get_static_device_info(
             },
         ),
     ],
-    ids=["5xu9h3", "itk04l", "yna5xi", "p95mgv"],
+    ids=["5xu9h3", "xmp9ds", "itk04l", "yna5xi", "p95mgv"],
 )
 async def test_capabilities_event_extraction(
     class_: str, expected: dict[type[Event], list[Command]]


### PR DESCRIPTION
## Summary

The hardware definition for `xmp9ds` (Ecovacs GOAT A1600 RTK) is already present in the repo and identical in capability set to `5xu9h3` (GOAT G1) and `aadham` (GOAT A3000 LiDAR Pro). However, only `test_all_models_loaded` exercises it — that test only confirms the module loads, not which event refresh commands are exposed.

This PR adds an explicit `xmp9ds` parametrize entry to `test_capabilities_event_extraction` mirroring the existing `5xu9h3` assertions. It locks in the contract that GOAT A1600 RTK has the same capability surface as the other GOATs.

## Why

A user (running firmware 1.15.13) reported in HA logs hundreds of thousands of `Could not parse getMapTrace` warnings per day. Investigation showed that `xmp9ds.py` exists upstream so the model IS recognized. The map trace warnings are caused separately by the legacy fallback in `messages/json/__init__.py:_LEGACY_USE_GET_COMMAND` trying to parse spontaneous `getMapTrace` pushes from the firmware, even though MOWER hardware definitions don't expose a `map=` capability. That is being addressed in a follow-up PR.

In the meantime, having explicit test coverage for `xmp9ds` would have made the diagnostic easier — the missing test entry initially led me to assume `xmp9ds.py` was missing entirely. Adding the assertion locks the model down properly.

## Refs

- DeebotUniverse/client.py#852 (GOAT A1600 RTK Support)
- DeebotUniverse/client.py#1376 (Disable getMapTrace for GOAT — separate follow-up PR)

## Test plan

- [x] `uv run pytest tests/hardware/test_init.py -v` — all 8 tests pass including new `test_capabilities_event_extraction[xmp9ds]`
- [x] No new file added — pure test addition, no production code changed