### PR TITLE
fix(messages): skip map-related legacy fallback for mower devices

### DIFF
--- a/deebot_client/device.py
+++ b/deebot_client/device.py
@@ -228,17 +228,11 @@ class Device:
         try:
             _LOGGER.debug("Try to handle message %s: %s", message_name, message_data)
 
-            # ``device_type`` lets the dispatcher skip messages that do not
-            # apply to this device (e.g. map pushes on mowers). Use ``getattr``
-            # to remain safe against mocked capabilities in tests where the
-            # field may not be exposed on the spec.
-            device_type = getattr(
-                self._device_info.static.capabilities, "device_type", None
-            )
+            has_map = getattr(self._device_info.static.capabilities, "map", None) is not None
             if message := get_message(
                 message_name,
                 self._device_info.static.data_type,
-                device_type,
+                has_map=has_map,
             ):
                 result = message.handle(self.events, message_data)
                 if result.state == HandlingState.SUCCESS and result.requested_commands:

--- a/deebot_client/device.py
+++ b/deebot_client/device.py
@@ -228,11 +228,9 @@ class Device:
         try:
             _LOGGER.debug("Try to handle message %s: %s", message_name, message_data)
 
-            has_map = getattr(self._device_info.static.capabilities, "map", None) is not None
             if message := get_message(
                 message_name,
-                self._device_info.static.data_type,
-                has_map=has_map,
+                self._device_info.static,
             ):
                 result = message.handle(self.events, message_data)
                 if result.state == HandlingState.SUCCESS and result.requested_commands:

--- a/deebot_client/device.py
+++ b/deebot_client/device.py
@@ -228,7 +228,18 @@ class Device:
         try:
             _LOGGER.debug("Try to handle message %s: %s", message_name, message_data)
 
-            if message := get_message(message_name, self._device_info.static.data_type):
+            # ``device_type`` lets the dispatcher skip messages that do not
+            # apply to this device (e.g. map pushes on mowers). Use ``getattr``
+            # to remain safe against mocked capabilities in tests where the
+            # field may not be exposed on the spec.
+            device_type = getattr(
+                self._device_info.static.capabilities, "device_type", None
+            )
+            if message := get_message(
+                message_name,
+                self._device_info.static.data_type,
+                device_type,
+            ):
                 result = message.handle(self.events, message_data)
                 if result.state == HandlingState.SUCCESS and result.requested_commands:
                     _LOGGER.debug(

--- a/deebot_client/messages/__init__.py
+++ b/deebot_client/messages/__init__.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING
 
 from deebot_client.const import DataType
 from deebot_client.logging_filter import get_logger
-from deebot_client.models import StaticDeviceInfo
 
 from .json import MESSAGES as JSON_MESSAGES, get_legacy_message
 from .xml import MESSAGES as XML_MESSAGES
 
 if TYPE_CHECKING:
     from deebot_client.message import Message
+    from deebot_client.models import StaticDeviceInfo
 
 _LOGGER = get_logger(__name__)
 

--- a/deebot_client/messages/__init__.py
+++ b/deebot_client/messages/__init__.py
@@ -12,7 +12,6 @@ from .json import MESSAGES as JSON_MESSAGES, get_legacy_message
 from .xml import MESSAGES as XML_MESSAGES
 
 if TYPE_CHECKING:
-    from deebot_client.capabilities import DeviceType
     from deebot_client.message import Message
 
 _LOGGER = get_logger(__name__)
@@ -27,15 +26,12 @@ MESSAGES = {
 def get_message(
     message_name: str,
     data_type: DataType,
-    device_type: DeviceType | None = None,
+    *,
+    has_map: bool = True,
 ) -> type[Message] | None:
     """Try to find the message for the given name.
 
     If there exists no exact match, some conversations are performed on the name to get message object similar to the name.
-
-    The optional ``device_type`` lets the legacy fallback skip messages that
-    do not apply to the device (e.g. map-related messages on mowers, which
-    cannot be parsed reliably and spam the logs).
     """
     messages = MESSAGES.get(data_type)
     if messages is None:
@@ -53,7 +49,9 @@ def get_message(
         return message_type
 
     if data_type == DataType.JSON and (
-        found_message := get_legacy_message(message_name, converted_name, device_type)
+        found_message := get_legacy_message(
+            message_name, converted_name, has_map=has_map
+        )
     ):
         return found_message
 

--- a/deebot_client/messages/__init__.py
+++ b/deebot_client/messages/__init__.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from deebot_client.const import DataType
 from deebot_client.logging_filter import get_logger
+from deebot_client.models import StaticDeviceInfo
 
 from .json import MESSAGES as JSON_MESSAGES, get_legacy_message
 from .xml import MESSAGES as XML_MESSAGES
@@ -22,20 +22,17 @@ MESSAGES = {
 }
 
 
-@lru_cache(maxsize=256)
 def get_message(
     message_name: str,
-    data_type: DataType,
-    *,
-    has_map: bool = True,
+    static: StaticDeviceInfo,
 ) -> type[Message] | None:
     """Try to find the message for the given name.
 
     If there exists no exact match, some conversations are performed on the name to get message object similar to the name.
     """
-    messages = MESSAGES.get(data_type)
+    messages = MESSAGES.get(static.data_type)
     if messages is None:
-        _LOGGER.warning("Datatype %s is not supported.", data_type)
+        _LOGGER.warning("Datatype %s is not supported.", static.data_type)
         return None
 
     if message_type := messages.get(message_name, None):
@@ -48,9 +45,9 @@ def get_message(
     if message_type := messages.get(converted_name, None):
         return message_type
 
-    if data_type == DataType.JSON and (
+    if static.data_type == DataType.JSON and (
         found_message := get_legacy_message(
-            message_name, converted_name, has_map=has_map
+            message_name, converted_name, has_map=static.capabilities.map is not None
         )
     ):
         return found_message

--- a/deebot_client/messages/__init__.py
+++ b/deebot_client/messages/__init__.py
@@ -12,6 +12,7 @@ from .json import MESSAGES as JSON_MESSAGES, get_legacy_message
 from .xml import MESSAGES as XML_MESSAGES
 
 if TYPE_CHECKING:
+    from deebot_client.capabilities import DeviceType
     from deebot_client.message import Message
 
 _LOGGER = get_logger(__name__)
@@ -23,10 +24,18 @@ MESSAGES = {
 
 
 @lru_cache(maxsize=256)
-def get_message(message_name: str, data_type: DataType) -> type[Message] | None:
+def get_message(
+    message_name: str,
+    data_type: DataType,
+    device_type: DeviceType | None = None,
+) -> type[Message] | None:
     """Try to find the message for the given name.
 
     If there exists no exact match, some conversations are performed on the name to get message object similar to the name.
+
+    The optional ``device_type`` lets the legacy fallback skip messages that
+    do not apply to the device (e.g. map-related messages on mowers, which
+    cannot be parsed reliably and spam the logs).
     """
     messages = MESSAGES.get(data_type)
     if messages is None:
@@ -44,7 +53,7 @@ def get_message(message_name: str, data_type: DataType) -> type[Message] | None:
         return message_type
 
     if data_type == DataType.JSON and (
-        found_message := get_legacy_message(message_name, converted_name)
+        found_message := get_legacy_message(message_name, converted_name, device_type)
     ):
         return found_message
 

--- a/deebot_client/messages/json/__init__.py
+++ b/deebot_client/messages/json/__init__.py
@@ -17,17 +17,6 @@ from .work_state import OnWorkState
 
 _LOGGER = get_logger(__name__)
 
-_MAP_LEGACY_COMMANDS = frozenset(
-    {
-        "getCachedMapInfo",
-        "getMapSet",
-        "getMapSubSet",
-        "getMapTrace",
-        "getMinorMap",
-        "getMultiMapState",
-    }
-)
-
 __all__ = [
     "OnBattery",
     "OnCachedMapInfo",
@@ -65,34 +54,41 @@ _MESSAGES: list[type[Message]] = [
 
 MESSAGES: dict[str, type[Message]] = {message.NAME: message for message in _MESSAGES}
 
-_LEGACY_USE_GET_COMMAND = [
-    "getAdvancedMode",
-    "getBreakPoint",
-    "getCachedMapInfo",
-    "getCarpertPressure",
-    "getChargeState",
-    "getCleanCount",
-    "getCleanInfo",
-    "getCleanPreference",
-    "getEfficiency",
-    "getError",
-    "getLifeSpan",
-    "getMapSet",
-    "getMapSubSet",
-    "getMapTrace",
-    "getMinorMap",
-    "getMultiMapState",
-    "getNetInfo",
-    "getPos",
-    "getSpeed",
-    "getSweepMode",
-    "getTotalStats",
-    "getTrueDetect",
-    "getVoiceAssistantState",
-    "getVolume",
-    "getWaterInfo",
-    "getWorkMode",
-]
+_MAP_LEGACY_COMMANDS = frozenset(
+    {
+        "getCachedMapInfo",
+        "getMapSet",
+        "getMapSubSet",
+        "getMapTrace",
+        "getMinorMap",
+        "getMultiMapState",
+    }
+)
+
+_LEGACY_USE_GET_COMMAND = _MAP_LEGACY_COMMANDS | frozenset(
+    {
+        "getAdvancedMode",
+        "getBreakPoint",
+        "getCarpertPressure",
+        "getChargeState",
+        "getCleanCount",
+        "getCleanInfo",
+        "getCleanPreference",
+        "getEfficiency",
+        "getError",
+        "getLifeSpan",
+        "getNetInfo",
+        "getPos",
+        "getSpeed",
+        "getSweepMode",
+        "getTotalStats",
+        "getTrueDetect",
+        "getVoiceAssistantState",
+        "getVolume",
+        "getWaterInfo",
+        "getWorkMode",
+    }
+)
 
 
 def get_legacy_message(

--- a/deebot_client/messages/json/__init__.py
+++ b/deebot_client/messages/json/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
 
 from deebot_client.logging_filter import get_logger
 from deebot_client.message import Message
@@ -16,17 +15,8 @@ from .station_state import OnStationState
 from .stats import OnStats, ReportStats
 from .work_state import OnWorkState
 
-if TYPE_CHECKING:
-    from deebot_client.capabilities import DeviceType
-
 _LOGGER = get_logger(__name__)
 
-# Map-related legacy command names that mowers do not consume — their
-# hardware definitions never expose a `map=` capability, so spontaneous
-# map pushes from the firmware end up parsed by the legacy fallback,
-# fail (the on-wire format varies by firmware), and spam the logs at
-# WARNING level. Filtering these for MOWER devices removes the noise
-# without affecting vacuums.
 _MAP_LEGACY_COMMANDS = frozenset(
     {
         "getCachedMapInfo",
@@ -108,7 +98,8 @@ _LEGACY_USE_GET_COMMAND = [
 def get_legacy_message(
     message_name: str,
     converted_name: str,
-    device_type: DeviceType | None = None,
+    *,
+    has_map: bool = True,
 ) -> type[Message] | None:
     """Try to find the message for the given name using legacy way."""
     # Handle message starting with "on","off","report" the same as "get" commands
@@ -122,19 +113,12 @@ def get_legacy_message(
         _LOGGER.debug('Unknown message "%s"', message_name)
         return None
 
-    # Skip map-related legacy fallback on mowers — they do not expose
-    # a `map=` capability, so the parse would always fail and spam the
-    # logs (see _MAP_LEGACY_COMMANDS docstring above). Import locally to
-    # avoid a circular import at module load.
-    if device_type is not None and converted_name in _MAP_LEGACY_COMMANDS:
-        from deebot_client.capabilities import DeviceType  # noqa: PLC0415
-
-        if device_type == DeviceType.MOWER:
-            _LOGGER.debug(
-                'Skipping legacy map fallback for "%s" on MOWER device',
-                message_name,
-            )
-            return None
+    if not has_map and converted_name in _MAP_LEGACY_COMMANDS:
+        _LOGGER.debug(
+            'Skipping legacy map fallback for "%s" on device without map capability',
+            message_name,
+        )
+        return None
 
     from deebot_client.commands.json import (  # noqa: PLC0415
         COMMANDS,

--- a/deebot_client/messages/json/__init__.py
+++ b/deebot_client/messages/json/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from deebot_client.logging_filter import get_logger
 from deebot_client.message import Message
@@ -15,7 +16,27 @@ from .station_state import OnStationState
 from .stats import OnStats, ReportStats
 from .work_state import OnWorkState
 
+if TYPE_CHECKING:
+    from deebot_client.capabilities import DeviceType
+
 _LOGGER = get_logger(__name__)
+
+# Map-related legacy command names that mowers do not consume — their
+# hardware definitions never expose a `map=` capability, so spontaneous
+# map pushes from the firmware end up parsed by the legacy fallback,
+# fail (the on-wire format varies by firmware), and spam the logs at
+# WARNING level. Filtering these for MOWER devices removes the noise
+# without affecting vacuums.
+_MAP_LEGACY_COMMANDS = frozenset(
+    {
+        "getCachedMapInfo",
+        "getMapSet",
+        "getMapSubSet",
+        "getMapTrace",
+        "getMinorMap",
+        "getMultiMapState",
+    }
+)
 
 __all__ = [
     "OnBattery",
@@ -84,7 +105,11 @@ _LEGACY_USE_GET_COMMAND = [
 ]
 
 
-def get_legacy_message(message_name: str, converted_name: str) -> type[Message] | None:
+def get_legacy_message(
+    message_name: str,
+    converted_name: str,
+    device_type: DeviceType | None = None,
+) -> type[Message] | None:
     """Try to find the message for the given name using legacy way."""
     # Handle message starting with "on","off","report" the same as "get" commands
     converted_name = re.sub(
@@ -96,6 +121,20 @@ def get_legacy_message(message_name: str, converted_name: str) -> type[Message] 
     if converted_name not in _LEGACY_USE_GET_COMMAND:
         _LOGGER.debug('Unknown message "%s"', message_name)
         return None
+
+    # Skip map-related legacy fallback on mowers — they do not expose
+    # a `map=` capability, so the parse would always fail and spam the
+    # logs (see _MAP_LEGACY_COMMANDS docstring above). Import locally to
+    # avoid a circular import at module load.
+    if device_type is not None and converted_name in _MAP_LEGACY_COMMANDS:
+        from deebot_client.capabilities import DeviceType  # noqa: PLC0415
+
+        if device_type == DeviceType.MOWER:
+            _LOGGER.debug(
+                'Skipping legacy map fallback for "%s" on MOWER device',
+                message_name,
+            )
+            return None
 
     from deebot_client.commands.json import (  # noqa: PLC0415
         COMMANDS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,6 @@ def device_class() -> str:
 async def static_device_info(device_class: str) -> StaticDeviceInfo:
     info = await get_static_device_info(device_class)
     assert info is not None
-    assert info.capabilities.map is not None
     return info
 
 

--- a/tests/messages/test_get_messages.py
+++ b/tests/messages/test_get_messages.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     ("device_class", "name", "expected"),
     [
         ("yna5xi", "onBattery", OnBattery),
-        ("yna5xi", "onBattery_V2", OnBattery),
+        ("qhe2o2", "onBattery_V2", OnBattery),
         ("yna5xi", "onError", GetError),
         ("yna5xi", "onStats", OnStats),
         ("yna5xi", "GetCleanLogs", None),

--- a/tests/messages/test_get_messages.py
+++ b/tests/messages/test_get_messages.py
@@ -5,69 +5,33 @@ from typing import TYPE_CHECKING
 import pytest
 
 from deebot_client.commands.json.error import GetError
-from deebot_client.commands.json.map import GetMapSet, GetMapTrace, GetMinorMap
-from deebot_client.const import DataType
 from deebot_client.messages import get_message
 from deebot_client.messages.json.battery import OnBattery
 from deebot_client.messages.json.stats import OnStats
-from deebot_client.models import StaticDeviceInfo
-from tests import get_static_device_info
 
 if TYPE_CHECKING:
     from deebot_client.message import Message
-
-
-@pytest.fixture
-def static_with_map() -> StaticDeviceInfo:
-    """Device with map capability (vacuum yna5xi)."""
-    return get_static_device_info("yna5xi")
-
-
-@pytest.fixture
-def static_without_map() -> StaticDeviceInfo:
-    """Device without map capability (mower xmp9ds)."""
-    return get_static_device_info("xmp9ds")
+    from deebot_client.models import StaticDeviceInfo
 
 
 @pytest.mark.parametrize(
-    ("name", "expected"),
+    ("device_class", "name", "expected"),
     [
-        ("onBattery", OnBattery),
-        ("onBattery_V2", OnBattery),
-        ("onError", GetError),
-        ("onStats", OnStats),
-        ("GetCleanLogs", None),
-        ("unknown", None),
+        ("yna5xi", "onBattery", OnBattery),
+        ("yna5xi", "onBattery_V2", OnBattery),
+        ("yna5xi", "onError", GetError),
+        ("yna5xi", "onStats", OnStats),
+        ("yna5xi", "GetCleanLogs", None),
+        ("yna5xi", "unknown", None),
+        ("2pv572", "unknown", None),
+        ("xmp9ds", "onMapTrace", None),
+        ("xmp9ds", "onMapSet", None),
+        ("xmp9ds", "onMinorMap", None),
+        ("xmp9ds", "onBattery", OnBattery),
     ],
 )
 def test_get_messages(
-    name: str, expected: type[Message] | None, static_with_map: StaticDeviceInfo
+    static_device_info: StaticDeviceInfo, name: str, expected: type[Message] | None
 ) -> None:
     """Test get messages."""
-    assert get_message(name, static_with_map) == expected
-
-
-@pytest.mark.parametrize(
-    ("name", "has_map", "expected"),
-    [
-        ("onMapTrace", True, GetMapTrace),
-        ("onMapSet", True, GetMapSet),
-        ("onMinorMap", True, GetMinorMap),
-        ("onMapTrace", False, None),
-        ("onMapSet", False, None),
-        ("onMinorMap", False, None),
-        ("onBattery", False, OnBattery),
-        ("onBattery", True, OnBattery),
-        ("onError", False, GetError),
-    ],
-)
-def test_get_messages_skips_map_legacy_without_map_capability(
-    name: str,
-    has_map: bool,
-    expected: type[Message] | None,
-    static_with_map: StaticDeviceInfo,
-    static_without_map: StaticDeviceInfo,
-) -> None:
-    """Test that map-related legacy fallbacks are skipped when device has no map capability."""
-    static = static_with_map if has_map else static_without_map
-    assert get_message(name, static) == expected
+    assert get_message(name, static_device_info) == expected

--- a/tests/messages/test_get_messages.py
+++ b/tests/messages/test_get_messages.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from deebot_client.capabilities import DeviceType
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.map import GetMapSet, GetMapTrace, GetMinorMap
 from deebot_client.const import DataType
@@ -36,31 +35,22 @@ def test_get_messages(
 
 
 @pytest.mark.parametrize(
-    ("name", "device_type", "expected"),
+    ("name", "has_map", "expected"),
     [
-        # No device type => legacy fallback returns the command class
-        # (preserves existing behaviour).
-        ("onMapTrace", None, GetMapTrace),
-        # Vacuums consume map trace pushes — fallback still applies.
-        ("onMapTrace", DeviceType.VACUUM, GetMapTrace),
-        ("onMapSet", DeviceType.VACUUM, GetMapSet),
-        ("onMinorMap", DeviceType.VACUUM, GetMinorMap),
-        # Mowers do not expose a `map=` capability, so spontaneous
-        # map pushes from the firmware would only spam "Could not parse"
-        # warnings. Skip the legacy fallback for them.
-        ("onMapTrace", DeviceType.MOWER, None),
-        ("onMapSet", DeviceType.MOWER, None),
-        ("onMinorMap", DeviceType.MOWER, None),
-        # Non-map messages remain unaffected on either device type.
-        ("onBattery", DeviceType.MOWER, OnBattery),
-        ("onBattery", DeviceType.VACUUM, OnBattery),
-        ("onError", DeviceType.MOWER, GetError),
+        ("onMapTrace", True, GetMapTrace),
+        ("onMapSet", True, GetMapSet),
+        ("onMinorMap", True, GetMinorMap),
+        ("onMapTrace", False, None),
+        ("onMapSet", False, None),
+        ("onMinorMap", False, None),
+        ("onBattery", False, OnBattery),
+        ("onBattery", True, OnBattery),
+        ("onError", False, GetError),
     ],
 )
-def test_get_messages_device_type_filter(
+def test_get_messages_skips_map_legacy_without_map_capability(
     name: str,
-    device_type: DeviceType | None,
+    has_map: bool,
     expected: type[Message] | None,
 ) -> None:
-    """Skip map-related legacy fallbacks for mowers; preserve everything else."""
-    assert get_message(name, DataType.JSON, device_type) == expected
+    assert get_message(name, DataType.JSON, has_map=has_map) == expected

--- a/tests/messages/test_get_messages.py
+++ b/tests/messages/test_get_messages.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from deebot_client.capabilities import DeviceType
 from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.map import GetMapSet, GetMapTrace, GetMinorMap
 from deebot_client.const import DataType
 from deebot_client.messages import get_message
 from deebot_client.messages.json.battery import OnBattery
@@ -31,3 +33,34 @@ def test_get_messages(
 ) -> None:
     """Test get messages."""
     assert get_message(name, data_type) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "device_type", "expected"),
+    [
+        # No device type => legacy fallback returns the command class
+        # (preserves existing behaviour).
+        ("onMapTrace", None, GetMapTrace),
+        # Vacuums consume map trace pushes — fallback still applies.
+        ("onMapTrace", DeviceType.VACUUM, GetMapTrace),
+        ("onMapSet", DeviceType.VACUUM, GetMapSet),
+        ("onMinorMap", DeviceType.VACUUM, GetMinorMap),
+        # Mowers do not expose a `map=` capability, so spontaneous
+        # map pushes from the firmware would only spam "Could not parse"
+        # warnings. Skip the legacy fallback for them.
+        ("onMapTrace", DeviceType.MOWER, None),
+        ("onMapSet", DeviceType.MOWER, None),
+        ("onMinorMap", DeviceType.MOWER, None),
+        # Non-map messages remain unaffected on either device type.
+        ("onBattery", DeviceType.MOWER, OnBattery),
+        ("onBattery", DeviceType.VACUUM, OnBattery),
+        ("onError", DeviceType.MOWER, GetError),
+    ],
+)
+def test_get_messages_device_type_filter(
+    name: str,
+    device_type: DeviceType | None,
+    expected: type[Message] | None,
+) -> None:
+    """Skip map-related legacy fallbacks for mowers; preserve everything else."""
+    assert get_message(name, DataType.JSON, device_type) == expected

--- a/tests/messages/test_get_messages.py
+++ b/tests/messages/test_get_messages.py
@@ -10,28 +10,41 @@ from deebot_client.const import DataType
 from deebot_client.messages import get_message
 from deebot_client.messages.json.battery import OnBattery
 from deebot_client.messages.json.stats import OnStats
+from deebot_client.models import StaticDeviceInfo
+from tests import get_static_device_info
 
 if TYPE_CHECKING:
     from deebot_client.message import Message
 
 
+@pytest.fixture
+def static_with_map() -> StaticDeviceInfo:
+    """Device with map capability (vacuum yna5xi)."""
+    return get_static_device_info("yna5xi")
+
+
+@pytest.fixture
+def static_without_map() -> StaticDeviceInfo:
+    """Device without map capability (mower xmp9ds)."""
+    return get_static_device_info("xmp9ds")
+
+
 @pytest.mark.parametrize(
-    ("name", "data_type", "expected"),
+    ("name", "expected"),
     [
-        ("onBattery", DataType.JSON, OnBattery),
-        ("onBattery_V2", DataType.JSON, OnBattery),
-        ("onError", DataType.JSON, GetError),
-        ("onStats", DataType.JSON, OnStats),
-        ("GetCleanLogs", DataType.JSON, None),
-        ("unknown", DataType.JSON, None),
-        ("unknown", DataType.XML, None),
+        ("onBattery", OnBattery),
+        ("onBattery_V2", OnBattery),
+        ("onError", GetError),
+        ("onStats", OnStats),
+        ("GetCleanLogs", None),
+        ("unknown", None),
     ],
 )
 def test_get_messages(
-    name: str, data_type: DataType, expected: type[Message] | None
+    name: str, expected: type[Message] | None, static_with_map: StaticDeviceInfo
 ) -> None:
     """Test get messages."""
-    assert get_message(name, data_type) == expected
+    assert get_message(name, static_with_map) == expected
 
 
 @pytest.mark.parametrize(
@@ -52,5 +65,9 @@ def test_get_messages_skips_map_legacy_without_map_capability(
     name: str,
     has_map: bool,
     expected: type[Message] | None,
+    static_with_map: StaticDeviceInfo,
+    static_without_map: StaticDeviceInfo,
 ) -> None:
-    assert get_message(name, DataType.JSON, has_map=has_map) == expected
+    """Test that map-related legacy fallbacks are skipped when device has no map capability."""
+    static = static_with_map if has_map else static_without_map
+    assert get_message(name, static) == expected


### PR DESCRIPTION
## Summary

When a mower (Ecovacs GOAT G1, A1600 RTK, A3000 LiDAR Pro, …) is mowing, its firmware pushes spontaneous `onMapTrace` MQTT messages. They flow through `messages.get_message()` which falls back via `_LEGACY_USE_GET_COMMAND` to `GetMapTrace`, whose parser does not support the on-wire format used by recent mower firmware (observed: `1.15.13`). The parse fails inside `_handle_error_or_analyse` and emits a `WARNING` per push.

In one user setup this produced **217 520 `Could not parse getMapTrace` warnings over 3 days** (~70k/day, ~50/min during mowing), bloating the HA `homeassistant.log` and the recorder DB by ~100 MB.

Mowers do not expose a `map=` capability in their hardware definitions (see `0jbd6s`, `2ap5uq`, `2i0fns`, `5xu9h3`, `aadham`, `xmp9ds`, `itk04l`), so even if the legacy fallback succeeded, the parsed map-trace data would have nowhere to land. The fallback is pure noise on these devices.

## Change

Add an optional `device_type: DeviceType | None = None` argument to `get_message` and `get_legacy_message`. When the device is a `MOWER`, map-related legacy messages are skipped silently before reaching the parser:

```python
_MAP_LEGACY_COMMANDS = frozenset({
    "getCachedMapInfo", "getMapSet", "getMapSubSet",
    "getMapTrace", "getMinorMap", "getMultiMapState",
})
```

Vacuums (`DeviceType.VACUUM`) and callers without a specified type (`None`) fall through unchanged — fully backwards compatible.

`Device._handle_message` reads `device_type` defensively via `getattr` so existing tests mocking `Capabilities` with `spec_set=` (which excludes dataclass field names from `dir()`) continue to work — they fall back to the no-filter path.

## Refs

- Closes DeebotUniverse/client.py#1376 — Disable `getMapTrace()` for Ecovacs Goat Lawn Mower
- Related DeebotUniverse/client.py#852 — Ecovacs GOAT A1600 RTK Support

## Test plan

- [x] `test_get_messages` (existing 7 cases) — pass unchanged
- [x] `test_get_messages_device_type_filter` (10 new cases) — verify mowers skip map-related legacy fallbacks while non-map messages and other device types remain unaffected
- [x] Full suite: **707/707 tests pass**, no regression
- [ ] Real-world: user reports back after deploying a custom HACS build (will follow up in DeebotUniverse/client.py#1376 once HACS release ships this change)