### PR TITLE
Add NGIOT transport and SST authenticationNgiot transport auth

### DIFF
--- a/deebot_client/authentication.py
+++ b/deebot_client/authentication.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from dataclasses import dataclass
 from http import HTTPStatus
 import time
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from aiohttp import ClientResponseError, ClientSession, ClientTimeout, hdrs
 
@@ -20,12 +21,16 @@ from .exceptions import (
 )
 from .logging_filter import get_logger
 from .models import Credentials
+from .ngiot_client import NgiotClient, NgiotClientConfiguration
+from .sst_authentication import SstAuthenticator
 from .util import cancel, create_task, md5
 from .util.continents import get_continent_url_postfix
 from .util.countries import get_ecovacs_country
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Mapping
+    from collections.abc import Callable, Coroutine
+
+    from .models import ApiDeviceInfo
 
 
 _LOGGER = get_logger(__name__)
@@ -44,6 +49,7 @@ _META = {
     "deviceType": "1",
 }
 MAX_RETRIES = 3
+_NGIOT_BASE_URL_TEMPLATE = "https://api-base.dc-{region}.ww.ecouser.net"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -56,6 +62,21 @@ class RestConfiguration:
     portal_url: str
     login_url: str
     auth_code_url: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class NgiotConfiguration:
+    """Optional overrides and defaults for NGIOT-backed devices."""
+
+    base_url: str | None = None
+    region: str | None = None
+    user_agent: str = "okhttp/4.9.1"
+    channel: str = "Android"
+    protocol_version: str = "0.0.22"
+    timezone_name: str = "UTC"
+    timezone_offset_minutes: int = 0
+    requested_ttl: int = 600
+    refresh_skew: int = 60
 
 
 def create_rest_config(
@@ -127,9 +148,6 @@ class _AuthClient:
             user_id = login_token_resp["userId"]
 
         user_access_token = login_token_resp["token"]
-        # last is validity in milliseconds. Usually 7 days
-        # we set the expiry at 99% of the validity
-        # 604800 = 7 days
         expires_at = int(
             time.time() + int(login_token_resp.get("last", 604800)) / 1000 * 0.99
         )
@@ -149,11 +167,9 @@ class _AuthClient:
         ) as res:
             res.raise_for_status()
 
-            # ecovacs returns a json but content_type header is set to text
             content_type = res.headers.get(hdrs.CONTENT_TYPE, "").lower()
             json = await res.json(content_type=content_type)
             _LOGGER.debug("got %s", json)
-            # TODO better error handling
             if json["code"] == "0000":
                 data: dict[str, Any] = json["data"]
                 return data
@@ -246,7 +262,6 @@ class _AuthClient:
             if resp["result"] == "ok":
                 return resp
             if resp["result"] == "fail" and resp["error"] == "set token error.":
-                # If it is a set token error try again
                 _LOGGER.warning("loginByItToken set token error, attempt %d/3", i + 2)
                 continue
 
@@ -348,6 +363,7 @@ class Authenticator:
         account_id: str,
         password_hash: str,
     ) -> None:
+        self._config = config
         self._auth_client = _AuthClient(
             config,
             account_id,
@@ -361,6 +377,37 @@ class Authenticator:
         self._credentials: Credentials | None = None
         self._refresh_handle: asyncio.TimerHandle | None = None
         self._tasks: set[asyncio.Future[Any]] = set()
+        self._ngiot_config = NgiotConfiguration()
+        self._ngiot_base_url: str | None = None
+        self.sst_authenticator: SstAuthenticator | None = None
+        self.ngiot_client: NgiotClient | None = None
+
+    def configure_ngiot(self, config: NgiotConfiguration | None = None) -> None:
+        """Store NGIOT defaults and optional region/base-url overrides."""
+        self._ngiot_config = self._normalize_ngiot_configuration(
+            config or NgiotConfiguration()
+        )
+
+    def attach_ngiot(self, config: NgiotConfiguration | None = None) -> None:
+        """Attach NGIOT helpers using an explicit base URL or region."""
+        if config is not None:
+            self.configure_ngiot(config)
+
+        resolved_base_url = self._resolve_configured_ngiot_base_url()
+        if resolved_base_url is None:
+            msg = "attach_ngiot() requires a configured NGIOT base_url or region."
+            raise ApiError(msg)
+
+        if self.ngiot_client is not None:
+            if self._ngiot_base_url == resolved_base_url:
+                return
+            msg = (
+                "NGIOT transport already attached with a different base URL. "
+                "Call teardown() before attaching a different NGIOT base URL."
+            )
+            raise ApiError(msg)
+
+        self._create_ngiot_stack(resolved_base_url)
 
     async def authenticate(self, *, force: bool = False) -> Credentials:
         """Authenticate on ecovacs servers."""
@@ -411,6 +458,11 @@ class Authenticator:
     async def teardown(self) -> None:
         """Teardown authenticator."""
         self._cancel_refresh_task()
+        if self.sst_authenticator is not None:
+            await self.sst_authenticator.teardown()
+            self.sst_authenticator = None
+        self.ngiot_client = None
+        self._ngiot_base_url = None
         await cancel(self._tasks)
 
     def _cancel_refresh_task(self) -> None:
@@ -418,7 +470,6 @@ class Authenticator:
             self._refresh_handle.cancel()
 
     def _create_refresh_task(self, credentials: Credentials) -> None:
-        # refresh at 99% of validity
         def refresh() -> None:
             _LOGGER.debug("Refresh token")
 
@@ -432,5 +483,105 @@ class Authenticator:
             self._refresh_handle = None
 
         validity = (credentials.expires_at - time.time()) * 0.99
+        self._refresh_handle = asyncio.get_running_loop().call_later(validity, refresh)
 
-        self._refresh_handle = asyncio.get_event_loop().call_later(validity, refresh)
+    def _create_ngiot_stack(self, base_url: str) -> None:
+        normalized_base_url = self._normalize_base_url(base_url)
+        self.sst_authenticator = SstAuthenticator(
+            self._config.session,
+            self,
+            base_url=normalized_base_url,
+            requested_ttl=self._ngiot_config.requested_ttl,
+            refresh_skew=self._ngiot_config.refresh_skew,
+        )
+        self.ngiot_client = NgiotClient(
+            self._config.session,
+            self.sst_authenticator,
+            config=NgiotClientConfiguration(
+                user_agent=self._ngiot_config.user_agent,
+                channel=self._ngiot_config.channel,
+                protocol_version=self._ngiot_config.protocol_version,
+                timezone_name=self._ngiot_config.timezone_name,
+                timezone_offset_minutes=self._ngiot_config.timezone_offset_minutes,
+            ),
+        )
+        self._ngiot_base_url = normalized_base_url
+
+    @classmethod
+    def _normalize_ngiot_configuration(
+        cls, config: NgiotConfiguration
+    ) -> NgiotConfiguration:
+        return NgiotConfiguration(
+            base_url=(
+                cls._normalize_base_url(config.base_url)
+                if config.base_url is not None
+                else None
+            ),
+            region=(
+                cls._normalize_region(config.region)
+                if config.region is not None
+                else None
+            ),
+            user_agent=config.user_agent,
+            channel=config.channel,
+            protocol_version=config.protocol_version,
+            timezone_name=config.timezone_name,
+            timezone_offset_minutes=config.timezone_offset_minutes,
+            requested_ttl=config.requested_ttl,
+            refresh_skew=config.refresh_skew,
+        )
+
+    def _resolve_configured_ngiot_base_url(self) -> str | None:
+        if self._ngiot_config.base_url is not None:
+            return self._ngiot_config.base_url
+        if self._ngiot_config.region is not None:
+            return self._format_ngiot_base_url(self._ngiot_config.region)
+        return None
+
+    def _resolve_ngiot_base_url(self, device_info: ApiDeviceInfo) -> str:
+        configured_base_url = self._resolve_configured_ngiot_base_url()
+        if configured_base_url is not None:
+            return configured_base_url
+
+        service = device_info.get("service")
+        if isinstance(service, Mapping):
+            mqs_host = service.get("mqs")
+            if isinstance(mqs_host, str) and mqs_host:
+                return self._derive_ngiot_base_url_from_mqs(mqs_host)
+
+        msg = (
+            f'Could not resolve NGIOT base URL for device class "{device_info["class"]}". '
+            "Configure an explicit region or base_url before device bootstrap."
+        )
+        raise ApiError(msg)
+
+    @staticmethod
+    def _normalize_base_url(base_url: str) -> str:
+        parsed = urlparse(base_url)
+        host = parsed.netloc if parsed.scheme and parsed.netloc else base_url
+        return f"https://{host.strip().rstrip('/')}"
+
+    @staticmethod
+    def _normalize_region(region: str) -> str:
+        return region.strip().lower().removeprefix("dc-")
+
+    @classmethod
+    def _format_ngiot_base_url(cls, region: str) -> str:
+        return _NGIOT_BASE_URL_TEMPLATE.format(region=cls._normalize_region(region))
+
+    @classmethod
+    def _derive_ngiot_base_url_from_mqs(cls, mqs_host: str) -> str:
+        parsed = urlparse(mqs_host)
+        host = parsed.netloc or parsed.path
+        host = host.strip().rstrip("/")
+        if not host:
+            msg = f'Could not derive NGIOT base URL from mqs host "{mqs_host}"'
+            raise ApiError(msg)
+        if host.startswith("api-base."):
+            return cls._normalize_base_url(host)
+        if host.startswith("api-ngiot."):
+            return cls._normalize_base_url("api-base." + host.split(".", 1)[1])
+        if "." in host:
+            return cls._normalize_base_url("api-base." + host.split(".", 1)[1])
+        msg = f'Could not derive NGIOT base URL from mqs host "{mqs_host}"'
+        raise ApiError(msg)

--- a/deebot_client/authentication.py
+++ b/deebot_client/authentication.py
@@ -148,6 +148,9 @@ class _AuthClient:
             user_id = login_token_resp["userId"]
 
         user_access_token = login_token_resp["token"]
+        # last is validity in milliseconds. Usually 7 days
+        # we set the expiry at 99% of the validity
+        # 604800 = 7 days
         expires_at = int(
             time.time() + int(login_token_resp.get("last", 604800)) / 1000 * 0.99
         )
@@ -166,10 +169,11 @@ class _AuthClient:
             url, params=params, timeout=_TIMEOUT
         ) as res:
             res.raise_for_status()
-
+           # ecovacs returns a json but content_type header is set to text
             content_type = res.headers.get(hdrs.CONTENT_TYPE, "").lower()
             json = await res.json(content_type=content_type)
             _LOGGER.debug("got %s", json)
+           # TODO better error handling
             if json["code"] == "0000":
                 data: dict[str, Any] = json["data"]
                 return data
@@ -262,6 +266,7 @@ class _AuthClient:
             if resp["result"] == "ok":
                 return resp
             if resp["result"] == "fail" and resp["error"] == "set token error.":
+                # If it is a set token error try again
                 _LOGGER.warning("loginByItToken set token error, attempt %d/3", i + 2)
                 continue
 
@@ -470,6 +475,7 @@ class Authenticator:
             self._refresh_handle.cancel()
 
     def _create_refresh_task(self, credentials: Credentials) -> None:
+        # refresh at 99% of validity
         def refresh() -> None:
             _LOGGER.debug("Refresh token")
 

--- a/deebot_client/ngiot_client.py
+++ b/deebot_client/ngiot_client.py
@@ -1,0 +1,476 @@
+"""NGIOT endpoint-control transport client."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import string
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
+
+import orjson
+from aiohttp import ClientResponseError, ClientSession, ClientTimeout, hdrs
+
+from .exceptions import ApiError, ApiTimeoutError, AuthenticationError
+from .logging_filter import get_logger
+from .sst_authentication import SstAuthenticator
+
+if TYPE_CHECKING:
+    from .models import ApiDeviceInfo, DeviceInfo
+
+_LOGGER = get_logger(__name__)
+
+_TIMEOUT = ClientTimeout(60)
+
+_PATH_ENDPOINT_CONTROL = "/api/iot/endpoint/control"
+_DEFAULT_FMT = "j"
+_DEFAULT_CT = "q"
+
+# Some devices transiently return "cmd busy" while state is changing.
+_TRANSIENT_RESPONSE_CODES = {1}
+_TRANSIENT_RESPONSE_MESSAGES = {"cmd busy"}
+
+
+@dataclass(frozen=True, kw_only=True)
+class NgiotClientConfiguration:
+    """Transport-level defaults for NGIOT endpoint-control calls."""
+
+    user_agent: str = "okhttp/4.9.1"
+    channel: str = "Android"
+    protocol_version: str = "0.0.22"
+    timezone_name: str = "UTC"
+    timezone_offset_minutes: int = 0
+    override_control_host: str | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class NgiotRequest:
+    """A single NGIOT endpoint-control request."""
+
+    apn: str | int
+    body_data: Mapping[str, Any] | Sequence[Any]
+    fmt: str = _DEFAULT_FMT
+    ct: str = _DEFAULT_CT
+    force_sst_refresh: bool = False
+
+
+@dataclass(frozen=True)
+class NgiotDeviceIdentity:
+    """Normalized NGIOT device identity."""
+
+    did: str
+    class_id: str
+    resource: str
+    control_host: str
+    fallback_control_host: str | None = None
+
+    @property
+    def key(self) -> str:
+        """Return stable cache key."""
+        return f"{self.class_id}:{self.did}:{self.resource}"
+
+    @property
+    def base_url(self) -> str:
+        """Return normalized HTTPS base URL for NGIOT control."""
+        if self.control_host.startswith(("http://", "https://")):
+            return self.control_host.rstrip("/")
+        return f"https://{self.control_host}".rstrip("/")
+
+
+class NgiotClient:
+    """Thin client for generic NGIOT endpoint-control reads and writes."""
+
+    def __init__(
+        self,
+        session: ClientSession,
+        sst_authenticator: SstAuthenticator,
+        config: NgiotClientConfiguration | None = None,
+    ) -> None:
+        self._session = session
+        self._sst_authenticator = sst_authenticator
+        self._config = config or NgiotClientConfiguration()
+
+    async def request(
+        self,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+        request: NgiotRequest,
+    ) -> dict[str, Any]:
+        """Execute a single NGIOT endpoint-control request."""
+        identity = self._normalize_device(device)
+        return await self._request_with_fallback(identity, device, request)
+
+    async def query_fields(
+        self,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+        *,
+        apn: str | int,
+        fields: Sequence[str],
+        map_id: str | int | None = None,
+    ) -> Any:
+        """Query a field-based NGIOT surface and return ``body.data``."""
+        body_data: dict[str, Any] = {"fields": list(fields)}
+        if map_id is not None:
+            body_data["mapId"] = str(map_id)
+
+        response = await self.request(
+            device,
+            NgiotRequest(apn=apn, body_data=body_data),
+        )
+        return self._extract_body_data(response)
+
+    async def write_data(
+        self,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+        *,
+        apn: str | int,
+        data: Mapping[str, Any],
+    ) -> Any:
+        """Send a direct key/value NGIOT payload and return ``body.data``."""
+        response = await self.request(
+            device,
+            NgiotRequest(apn=apn, body_data=dict(data)),
+        )
+        return self._extract_body_data(response)
+
+    async def _request_with_fallback(
+        self,
+        identity: NgiotDeviceIdentity,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+        request: NgiotRequest,
+    ) -> dict[str, Any]:
+        """Execute an NGIOT request and fall back to ``service.mqs`` on 404."""
+        try:
+            return await self._request_once(identity, device, request)
+        except ClientResponseError as ex:
+            if not self._should_retry_with_fallback(identity, ex):
+                raise ApiError from ex
+
+            fallback_identity = NgiotDeviceIdentity(
+                did=identity.did,
+                class_id=identity.class_id,
+                resource=identity.resource,
+                control_host=str(identity.fallback_control_host),
+                fallback_control_host=None,
+            )
+            _LOGGER.info(
+                "NGIOT endpoint-control returned 404 on %s for %s; retrying with %s",
+                identity.base_url,
+                identity.key,
+                fallback_identity.base_url,
+            )
+            try:
+                return await self._request_once(fallback_identity, device, request)
+            except ClientResponseError as fallback_ex:
+                raise ApiError from fallback_ex
+
+    async def _request_once(
+        self,
+        identity: NgiotDeviceIdentity,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+        request: NgiotRequest,
+    ) -> dict[str, Any]:
+        """Execute one endpoint-control request against one control host."""
+        url = urljoin(identity.base_url + "/", _PATH_ENDPOINT_CONTROL.lstrip("/"))
+        request_id = self._new_request_id()
+        payload = {
+            "body": {"data": self._build_payload(request.body_data)},
+            "header": self._create_body_header(self._new_body_reqid()),
+        }
+        query_params = self._query_params(identity, request, request_id)
+        headers = await self._headers(identity, request, request_id)
+        logger_request_params = {
+            "url": url,
+            "query_params": query_params,
+            "payload": payload,
+            "device_key": identity.key,
+        }
+
+        try:
+            _LOGGER.debug("Calling NGIOT api: %s", logger_request_params)
+
+            async with self._session.post(
+                url,
+                params=query_params,
+                data=orjson.dumps(payload),
+                headers=headers,
+                timeout=_TIMEOUT,
+            ) as res:
+                res.raise_for_status()
+                response_data = self._parse_response_body(await res.read())
+
+            _LOGGER.debug(
+                "Success calling NGIOT api %s, response=%s",
+                logger_request_params,
+                response_data,
+            )
+
+            validation = self._classify_response(response_data)
+            if validation == "retry_busy":
+                _LOGGER.debug(
+                    "NGIOT request returned transient busy for %s apn=%s; retrying once",
+                    identity.key,
+                    request.apn,
+                )
+                await asyncio.sleep(1)
+                return await self._request_retry_after_busy(identity, device, request)
+
+            return response_data
+
+        except TimeoutError as ex:
+            raise ApiTimeoutError(path=_PATH_ENDPOINT_CONTROL, timeout=_TIMEOUT) from ex
+        except ClientResponseError as ex:
+            if self._should_retry_with_fresh_sst(request, ex):
+                _LOGGER.info(
+                    "NGIOT request unauthorized for %s. Invalidating SST and retrying once.",
+                    identity.key,
+                )
+                await self._sst_authenticator.invalidate(self._device_mapping(identity))
+                refreshed_request = NgiotRequest(
+                    apn=request.apn,
+                    body_data=request.body_data,
+                    fmt=request.fmt,
+                    ct=request.ct,
+                    force_sst_refresh=True,
+                )
+                return await self._request_with_fallback(
+                    identity,
+                    device,
+                    refreshed_request,
+                )
+
+            if ex.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+                raise AuthenticationError(
+                    "NGIOT endpoint-control request was not authorized"
+                ) from ex
+
+            if ex.status == HTTPStatus.NOT_FOUND:
+                raise
+
+            _LOGGER.debug("NGIOT request failed: %s", logger_request_params, exc_info=True)
+            raise ApiError from ex
+
+    async def _request_retry_after_busy(
+        self,
+        identity: NgiotDeviceIdentity,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+        request: NgiotRequest,
+    ) -> dict[str, Any]:
+        """Retry once after a transient busy response."""
+        retry_response = await self._request_with_fallback(identity, device, request)
+        self._validate_response(retry_response)
+        return retry_response
+
+    def _normalize_device(
+        self,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+    ) -> NgiotDeviceIdentity:
+        """Normalize raw API device payload into NGIOT routing fields."""
+        raw_device = device.api if hasattr(device, "api") else device
+
+        if not isinstance(raw_device, Mapping):
+            msg = f"Unsupported device type for NGIOT client: {type(device)!r}"
+            raise TypeError(msg)
+
+        service_mqs_host = self._service_mqs_host(raw_device)
+        control_host = self._config.override_control_host or service_mqs_host
+
+        if not control_host:
+            msg = "Missing NGIOT control host in device service binding"
+            raise ApiError(msg)
+
+        try:
+            return NgiotDeviceIdentity(
+                did=str(raw_device["did"]),
+                class_id=str(raw_device["class"]),
+                resource=str(raw_device["resource"]),
+                control_host=str(control_host),
+                fallback_control_host=(
+                    service_mqs_host
+                    if service_mqs_host and service_mqs_host != str(control_host)
+                    else None
+                ),
+            )
+        except KeyError as ex:
+            msg = f"Missing required NGIOT device field: {ex.args[0]}"
+            raise ApiError(msg) from ex
+
+    def _query_params(
+        self,
+        identity: NgiotDeviceIdentity,
+        request: NgiotRequest,
+        request_id: str,
+    ) -> dict[str, str]:
+        return {
+            "si": request_id,
+            "ct": request.ct,
+            "eid": identity.did,
+            "et": identity.class_id,
+            "er": identity.resource,
+            "apn": str(request.apn),
+            "fmt": request.fmt,
+        }
+
+    async def _headers(
+        self,
+        identity: NgiotDeviceIdentity,
+        request: NgiotRequest,
+        request_id: str,
+    ) -> dict[str, str]:
+        token = await self._sst_authenticator.get_token(
+            self._device_mapping(identity),
+            force=request.force_sst_refresh,
+        )
+        return {
+            hdrs.AUTHORIZATION: f"Bearer {token}",
+            "x-eco-request-id": request_id,
+            hdrs.CONTENT_TYPE: "application/octet-stream",
+            hdrs.USER_AGENT: self._config.user_agent,
+        }
+
+    def _create_body_header(self, reqid: str) -> dict[str, Any]:
+        """Create request body header matching the observed mobile shape."""
+        return {
+            "channel": self._config.channel,
+            "m": "request",
+            "pri": 2,
+            "reqid": reqid,
+            "ts": str(int(time.time() * 1000)),
+            "tzc": self._config.timezone_name,
+            "tzm": self._config.timezone_offset_minutes,
+            "ver": self._config.protocol_version,
+        }
+
+    @staticmethod
+    def _build_payload(
+        body_data: Mapping[str, Any] | Sequence[Any],
+    ) -> Mapping[str, Any] | Sequence[Any]:
+        """Return a copy of mapping payloads without command-specific mutation."""
+        if isinstance(body_data, Mapping):
+            return dict(body_data)
+        return body_data
+
+    @staticmethod
+    def _extract_body_data(response: Mapping[str, Any]) -> Any:
+        """Return body.data, defaulting ACK-only responses to an empty dict."""
+        body = response.get("body")
+        if not isinstance(body, Mapping):
+            return {}
+        return body.get("data", {})
+
+    @classmethod
+    def _classify_response(cls, response: Mapping[str, Any] | None) -> str:
+        """Classify NGIOT envelope and support ACK-only or transient-busy replies."""
+        if response is None:
+            _LOGGER.debug("Empty NGIOT response body returned by server")
+            return "ok"
+
+        body = response.get("body")
+        if not isinstance(body, Mapping):
+            _LOGGER.debug("NGIOT response omitted body; treating as ACK-only success")
+            return "ok"
+
+        code = body.get("code", 0)
+        msg = str(body.get("msg", "")).strip().lower()
+
+        if code in (0, "0000", None):
+            return "ok"
+
+        if code in _TRANSIENT_RESPONSE_CODES and msg in _TRANSIENT_RESPONSE_MESSAGES:
+            return "retry_busy"
+
+        raise ApiError(
+            f"NGIOT request failed with code {code} ({body.get('msg', 'unknown error')}) "
+            f"for {_PATH_ENDPOINT_CONTROL}"
+        )
+
+    @staticmethod
+    def _validate_response(response: Mapping[str, Any] | None) -> None:
+        """Validate NGIOT envelope and raise ApiError on device-side failures."""
+        if response is None:
+            _LOGGER.debug("Empty NGIOT response body returned by server")
+            return
+
+        if not isinstance(response, Mapping):
+            raise ApiError("Invalid NGIOT response: missing body")
+
+        body = response.get("body")
+        if body is None:
+            if isinstance(response.get("header"), Mapping):
+                _LOGGER.debug("NGIOT ACK-only response without body: %s", response)
+                return
+            raise ApiError("Invalid NGIOT response: missing body")
+
+        if not isinstance(body, Mapping):
+            raise ApiError("Invalid NGIOT response: missing body")
+
+        code = body.get("code", 0)
+        if code not in (0, "0000", None):
+            msg = body.get("msg", "unknown error")
+            raise ApiError(
+                f"NGIOT request failed with code {code} ({msg}) for {_PATH_ENDPOINT_CONTROL}"
+            )
+
+    @staticmethod
+    def _parse_response_body(body: bytes) -> dict[str, Any]:
+        """Parse an endpoint-control JSON response body."""
+        if not body:
+            return {}
+        response = orjson.loads(body)
+        if not isinstance(response, dict):
+            raise ApiError("Invalid NGIOT response: expected JSON object")
+        return response
+
+    @staticmethod
+    def _should_retry_with_fallback(
+        identity: NgiotDeviceIdentity,
+        ex: ClientResponseError,
+    ) -> bool:
+        return (
+            ex.status == HTTPStatus.NOT_FOUND
+            and identity.fallback_control_host is not None
+            and identity.fallback_control_host != identity.control_host
+        )
+
+    @staticmethod
+    def _should_retry_with_fresh_sst(
+        request: NgiotRequest,
+        ex: ClientResponseError,
+    ) -> bool:
+        return (
+            ex.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN)
+            and not request.force_sst_refresh
+        )
+
+    @staticmethod
+    def _service_mqs_host(raw_device: Mapping[str, Any]) -> str | None:
+        service = raw_device.get("service", {})
+        if isinstance(service, Mapping):
+            candidate = service.get("mqs")
+            if isinstance(candidate, str) and candidate:
+                return candidate
+        return None
+
+    @staticmethod
+    def _new_request_id() -> str:
+        """Generate request ID for query/header transport fields."""
+        return secrets.token_hex(16)
+
+    @staticmethod
+    def _new_body_reqid(length: int = 6) -> str:
+        """Generate short request ID for the NGIOT body header."""
+        alphabet = string.ascii_letters + string.digits
+        return "".join(secrets.choice(alphabet) for _ in range(length))
+
+    @staticmethod
+    def _device_mapping(identity: NgiotDeviceIdentity) -> dict[str, Any]:
+        """Convert identity into a mapping accepted by SstAuthenticator."""
+        return {
+            "did": identity.did,
+            "class": identity.class_id,
+            "resource": identity.resource,
+            "service": {"mqs": identity.control_host},
+        }

--- a/deebot_client/ngiot_client.py
+++ b/deebot_client/ngiot_client.py
@@ -3,24 +3,24 @@
 from __future__ import annotations
 
 import asyncio
-import secrets
-import string
-import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from http import HTTPStatus
+import secrets
+import string
+import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
-import orjson
 from aiohttp import ClientResponseError, ClientSession, ClientTimeout, hdrs
+import orjson
 
 from .exceptions import ApiError, ApiTimeoutError, AuthenticationError
 from .logging_filter import get_logger
-from .sst_authentication import SstAuthenticator
 
 if TYPE_CHECKING:
     from .models import ApiDeviceInfo, DeviceInfo
+    from .sst_authentication import SstAuthenticator
 
 _LOGGER = get_logger(__name__)
 
@@ -202,24 +202,6 @@ class NgiotClient:
                 res.raise_for_status()
                 response_data = self._parse_response_body(await res.read())
 
-            _LOGGER.debug(
-                "Success calling NGIOT api %s, response=%s",
-                logger_request_params,
-                response_data,
-            )
-
-            validation = self._classify_response(response_data)
-            if validation == "retry_busy":
-                _LOGGER.debug(
-                    "NGIOT request returned transient busy for %s apn=%s; retrying once",
-                    identity.key,
-                    request.apn,
-                )
-                await asyncio.sleep(1)
-                return await self._request_retry_after_busy(identity, device, request)
-
-            return response_data
-
         except TimeoutError as ex:
             raise ApiTimeoutError(path=_PATH_ENDPOINT_CONTROL, timeout=_TIMEOUT) from ex
         except ClientResponseError as ex:
@@ -250,8 +232,27 @@ class NgiotClient:
             if ex.status == HTTPStatus.NOT_FOUND:
                 raise
 
-            _LOGGER.debug("NGIOT request failed: %s", logger_request_params, exc_info=True)
+            _LOGGER.debug(
+                "NGIOT request failed: %s", logger_request_params, exc_info=True
+            )
             raise ApiError from ex
+        else:
+            _LOGGER.debug(
+                "Success calling NGIOT api %s, response=%s",
+                logger_request_params,
+                response_data,
+            )
+
+            validation = self._classify_response(response_data)
+            if validation == "retry_busy":
+                _LOGGER.debug(
+                    "NGIOT request returned transient busy for %s apn=%s; retrying once",
+                    identity.key,
+                    request.apn,
+                )
+                await asyncio.sleep(1)
+                return await self._request_retry_after_busy(identity, device, request)
+            return response_data
 
     async def _request_retry_after_busy(
         self,
@@ -269,11 +270,14 @@ class NgiotClient:
         device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
     ) -> NgiotDeviceIdentity:
         """Normalize raw API device payload into NGIOT routing fields."""
-        raw_device = device.api if hasattr(device, "api") else device
-
-        if not isinstance(raw_device, Mapping):
-            msg = f"Unsupported device type for NGIOT client: {type(device)!r}"
-            raise TypeError(msg)
+        if isinstance(device, Mapping):
+            raw_device: Mapping[str, Any] = device
+        else:
+            raw_device_obj = getattr(device, "api", None)
+            if not isinstance(raw_device_obj, Mapping):
+                msg = f"Unsupported device type for NGIOT client: {type(device)!r}"
+                raise TypeError(msg)
+            raw_device = raw_device_obj
 
         service_mqs_host = self._service_mqs_host(raw_device)
         control_host = self._config.override_control_host or service_mqs_host
@@ -382,10 +386,11 @@ class NgiotClient:
         if code in _TRANSIENT_RESPONSE_CODES and msg in _TRANSIENT_RESPONSE_MESSAGES:
             return "retry_busy"
 
-        raise ApiError(
+        msg_0 = (
             f"NGIOT request failed with code {code} ({body.get('msg', 'unknown error')}) "
             f"for {_PATH_ENDPOINT_CONTROL}"
         )
+        raise ApiError(msg_0)
 
     @staticmethod
     def _validate_response(response: Mapping[str, Any] | None) -> None:
@@ -410,9 +415,8 @@ class NgiotClient:
         code = body.get("code", 0)
         if code not in (0, "0000", None):
             msg = body.get("msg", "unknown error")
-            raise ApiError(
-                f"NGIOT request failed with code {code} ({msg}) for {_PATH_ENDPOINT_CONTROL}"
-            )
+            msg_0 = f"NGIOT request failed with code {code} ({msg}) for {_PATH_ENDPOINT_CONTROL}"
+            raise ApiError(msg_0)
 
     @staticmethod
     def _parse_response_body(body: bytes) -> dict[str, Any]:

--- a/deebot_client/sst_authentication.py
+++ b/deebot_client/sst_authentication.py
@@ -1,0 +1,326 @@
+"""SST authentication module for NGIOT endpoint-control devices."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
+
+import orjson
+from aiohttp import ClientResponseError, ClientSession, ClientTimeout, hdrs
+
+from .exceptions import ApiError, ApiTimeoutError, AuthenticationError
+from .logging_filter import get_logger
+from .util import cancel, create_task
+
+if TYPE_CHECKING:
+    from .authentication import Authenticator
+    from .models import ApiDeviceInfo, DeviceInfo
+
+_LOGGER = get_logger(__name__)
+
+_TIMEOUT = ClientTimeout(60)
+_SST_ISSUE_PATH = "/api/new-perm/token/sst/issue"
+_SST_SERVICE = "dim"
+_SST_PERMISSION = "Control"
+
+
+@dataclass(frozen=True)
+class SstCredentials:
+    """Short-lived NGIOT SST credentials."""
+
+    token: str
+    expires_at: int
+    device_key: str
+
+
+@dataclass(frozen=True)
+class SstDeviceIdentity:
+    """Normalized device identity needed for SST minting."""
+
+    did: str
+    class_id: str
+    resource: str
+
+    @property
+    def endpoint(self) -> str:
+        """Return DIM ACL endpoint identifier."""
+        return f"Endpoint:{self.class_id}:{self.did}"
+
+    @property
+    def key(self) -> str:
+        """Return stable cache key."""
+        return f"{self.class_id}:{self.did}:{self.resource}"
+
+
+class SstAuthenticator:
+    """Mint, cache, and refresh short-lived SST credentials per device."""
+
+    def __init__(
+        self,
+        session: ClientSession,
+        authenticator: Authenticator,
+        *,
+        base_url: str,
+        requested_ttl: int = 600,
+        refresh_skew: int = 60,
+    ) -> None:
+        self._session = session
+        self._authenticator = authenticator
+        self._base_url = base_url.rstrip("/")
+        self._requested_ttl = requested_ttl
+        self._refresh_skew = refresh_skew
+
+        self._lock = asyncio.Lock()
+        self._credentials: dict[str, SstCredentials] = {}
+        self._devices: dict[str, SstDeviceIdentity] = {}
+        self._refresh_handles: dict[str, asyncio.TimerHandle] = {}
+        self._tasks: set[asyncio.Future[Any]] = set()
+
+    async def get_credentials(
+        self,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+        *,
+        force: bool = False,
+    ) -> SstCredentials:
+        """Return cached SST credentials for a device, refreshing if needed."""
+        identity = self._normalize_device(device)
+
+        async with self._lock:
+            cached = self._credentials.get(identity.key)
+            now = int(time.time())
+
+            if (
+                not force
+                and cached is not None
+                and cached.expires_at > now + self._refresh_skew
+            ):
+                return cached
+
+            credentials = await self._issue_sst(identity)
+            self._devices[identity.key] = identity
+            self._credentials[identity.key] = credentials
+
+            self._cancel_refresh_task(identity.key)
+            self._create_refresh_task(identity, credentials)
+
+            return credentials
+
+    async def get_token(
+        self,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+        *,
+        force: bool = False,
+    ) -> str:
+        """Return SST bearer token for a device."""
+        return (await self.get_credentials(device, force=force)).token
+
+    async def invalidate(
+        self,
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any] | str,
+    ) -> None:
+        """Invalidate cached SST for a device or cache key."""
+        key = device if isinstance(device, str) else self._normalize_device(device).key
+
+        async with self._lock:
+            self._credentials.pop(key, None)
+            self._devices.pop(key, None)
+            self._cancel_refresh_task(key)
+
+    async def teardown(self) -> None:
+        """Teardown authenticator and cancel outstanding refresh tasks."""
+        for key in list(self._refresh_handles):
+            self._cancel_refresh_task(key)
+
+        self._credentials.clear()
+        self._devices.clear()
+        await cancel(self._tasks)
+
+    async def _issue_sst(self, identity: SstDeviceIdentity) -> SstCredentials:
+        """Mint a fresh SST for the given device."""
+        account_credentials = await self._authenticator.authenticate()
+
+        headers = {
+            hdrs.AUTHORIZATION: f"Bearer {account_credentials.token}",
+            hdrs.CONTENT_TYPE: "application/json; charset=utf-8",
+        }
+        payload = {
+            "acl": [
+                {
+                    "policy": [
+                        {
+                            "obj": [identity.endpoint],
+                            "perms": [_SST_PERMISSION],
+                        }
+                    ],
+                    "svc": _SST_SERVICE,
+                }
+            ],
+            "exp": self._requested_ttl,
+            "sub": account_credentials.user_id,
+        }
+
+        url = urljoin(self._base_url, _SST_ISSUE_PATH)
+        logger_request_params = {
+            "url": url,
+            "device_key": identity.key,
+        }
+
+        try:
+            _LOGGER.debug("Calling SST issue endpoint: %s", logger_request_params)
+
+            async with self._session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=_TIMEOUT,
+            ) as res:
+                res.raise_for_status()
+                response_data = self._parse_response_body(await res.read())
+
+            _LOGGER.debug(
+                "SST issue response for %s returned code=%s",
+                identity.key,
+                response_data.get("code"),
+            )
+
+            if response_data.get("code") not in (0, "0000"):
+                msg = (
+                    f"failure code {response_data.get('code')} "
+                    f"({response_data.get('msg')}) for call {_SST_ISSUE_PATH}"
+                )
+                raise AuthenticationError(msg)
+
+            token = self._extract_token(response_data)
+            expires_at = self._decode_exp(token)
+            if expires_at is None:
+                # Fallback if the token format changes or exp is absent.
+                expires_at = int(time.time()) + max(60, int(self._requested_ttl * 0.9))
+
+            return SstCredentials(
+                token=token,
+                expires_at=expires_at,
+                device_key=identity.key,
+            )
+
+        except TimeoutError as ex:
+            raise ApiTimeoutError(path=_SST_ISSUE_PATH, timeout=_TIMEOUT) from ex
+        except ClientResponseError as ex:
+            if ex.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+                raise AuthenticationError("SST issue request was not authorized") from ex
+            raise ApiError from ex
+
+    def _create_refresh_task(
+        self,
+        identity: SstDeviceIdentity,
+        credentials: SstCredentials,
+    ) -> None:
+        """Create refresh task for a given SST credential."""
+
+        def refresh() -> None:
+            _LOGGER.debug("Refreshing SST for %s", identity.key)
+
+            async def async_refresh() -> None:
+                try:
+                    await self.get_credentials(identity_as_mapping(identity), force=True)
+                except Exception:
+                    _LOGGER.exception(
+                        "An exception occurred during SST refresh for %s",
+                        identity.key,
+                    )
+
+            create_task(self._tasks, async_refresh())
+            self._refresh_handles.pop(identity.key, None)
+
+        seconds_until_refresh = max(
+            5,
+            credentials.expires_at - int(time.time()) - self._refresh_skew,
+        )
+        self._refresh_handles[identity.key] = asyncio.get_running_loop().call_later(
+            seconds_until_refresh,
+            refresh,
+        )
+
+    def _cancel_refresh_task(self, key: str) -> None:
+        """Cancel refresh timer for a cache key."""
+        handle = self._refresh_handles.pop(key, None)
+        if handle and not handle.cancelled():
+            handle.cancel()
+
+    @staticmethod
+    def _decode_exp(token: str) -> int | None:
+        """Decode exp claim from SST token without signature validation."""
+        try:
+            parts = token.split(".")
+            if len(parts) == 4 and parts[0] == "SST":
+                payload_segment = parts[2]
+            elif len(parts) == 3:
+                payload_segment = parts[1]
+            else:
+                return None
+
+            padded = payload_segment + "=" * (-len(payload_segment) % 4)
+            payload = orjson.loads(base64.urlsafe_b64decode(padded))
+            exp = payload.get("exp")
+
+            return int(exp) if exp is not None else None
+        except Exception:
+            _LOGGER.debug("Failed to decode SST token expiry", exc_info=True)
+            return None
+
+    @staticmethod
+    def _extract_token(response_data: Mapping[str, Any]) -> str:
+        """Extract SST token from the issue response."""
+        try:
+            token = response_data["data"]["data"]["token"]
+        except (KeyError, TypeError) as ex:
+            msg = "SST issue response did not contain a token"
+            raise AuthenticationError(msg) from ex
+        return str(token)
+
+    @staticmethod
+    def _parse_response_body(body: bytes) -> dict[str, Any]:
+        """Parse an SST issue response body."""
+        if not body:
+            msg = "SST issue response was empty"
+            raise AuthenticationError(msg)
+        response = orjson.loads(body)
+        if not isinstance(response, dict):
+            msg = "SST issue response was not a JSON object"
+            raise AuthenticationError(msg)
+        return response
+
+    @staticmethod
+    def _normalize_device(
+        device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
+    ) -> SstDeviceIdentity:
+        """Normalize a device object into the fields required for SST issuance."""
+        raw_device = device.api if hasattr(device, "api") else device
+
+        if not isinstance(raw_device, Mapping):
+            msg = f"Unsupported device type for SST authentication: {type(device)!r}"
+            raise TypeError(msg)
+
+        try:
+            return SstDeviceIdentity(
+                did=str(raw_device["did"]),
+                class_id=str(raw_device["class"]),
+                resource=str(raw_device["resource"]),
+            )
+        except KeyError as ex:
+            msg = f"Missing required SST device field: {ex.args[0]}"
+            raise ApiError(msg) from ex
+
+
+def identity_as_mapping(identity: SstDeviceIdentity) -> dict[str, str]:
+    """Convert normalized identity back to a mapping accepted by get_credentials."""
+    return {
+        "did": identity.did,
+        "class": identity.class_id,
+        "resource": identity.resource,
+    }

--- a/deebot_client/sst_authentication.py
+++ b/deebot_client/sst_authentication.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from http import HTTPStatus
+import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
-import orjson
 from aiohttp import ClientResponseError, ClientSession, ClientTimeout, hdrs
+import orjson
 
 from .exceptions import ApiError, ApiTimeoutError, AuthenticationError
 from .logging_filter import get_logger
@@ -212,7 +212,9 @@ class SstAuthenticator:
             raise ApiTimeoutError(path=_SST_ISSUE_PATH, timeout=_TIMEOUT) from ex
         except ClientResponseError as ex:
             if ex.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
-                raise AuthenticationError("SST issue request was not authorized") from ex
+                raise AuthenticationError(
+                    "SST issue request was not authorized"
+                ) from ex
             raise ApiError from ex
 
     def _create_refresh_task(
@@ -227,7 +229,9 @@ class SstAuthenticator:
 
             async def async_refresh() -> None:
                 try:
-                    await self.get_credentials(identity_as_mapping(identity), force=True)
+                    await self.get_credentials(
+                        identity_as_mapping(identity), force=True
+                    )
                 except Exception:
                     _LOGGER.exception(
                         "An exception occurred during SST refresh for %s",
@@ -300,11 +304,16 @@ class SstAuthenticator:
         device: ApiDeviceInfo | DeviceInfo | Mapping[str, Any],
     ) -> SstDeviceIdentity:
         """Normalize a device object into the fields required for SST issuance."""
-        raw_device = device.api if hasattr(device, "api") else device
-
-        if not isinstance(raw_device, Mapping):
-            msg = f"Unsupported device type for SST authentication: {type(device)!r}"
-            raise TypeError(msg)
+        if isinstance(device, Mapping):
+            raw_device: Mapping[str, Any] = device
+        else:
+            raw_device_obj = getattr(device, "api", None)
+            if not isinstance(raw_device_obj, Mapping):
+                msg = (
+                    f"Unsupported device type for SST authentication: {type(device)!r}"
+                )
+                raise TypeError(msg)
+            raw_device = raw_device_obj
 
         try:
             return SstDeviceIdentity(

--- a/tests/test_authentication_ngiot.py
+++ b/tests/test_authentication_ngiot.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deebot_client.authentication import Authenticator, NgiotConfiguration
+from deebot_client.exceptions import ApiError
+from deebot_client.ngiot_client import NgiotClient
+from deebot_client.sst_authentication import SstAuthenticator
+
+if TYPE_CHECKING:
+    from deebot_client.authentication import RestConfiguration
+
+
+def test_configure_ngiot_normalizes_base_url_and_region(
+    rest_config: RestConfiguration,
+) -> None:
+    authenticator = Authenticator(rest_config, "account", "password")
+
+    authenticator.configure_ngiot(
+        NgiotConfiguration(
+            base_url="api-base.dc-na.ww.ecouser.net/",
+            region="dc-eu",
+            user_agent="test-agent",
+            timezone_name="Australia/Brisbane",
+            timezone_offset_minutes=600,
+            requested_ttl=300,
+            refresh_skew=30,
+        )
+    )
+
+    assert authenticator._ngiot_config.base_url == (
+        "https://api-base.dc-na.ww.ecouser.net"
+    )
+    assert authenticator._ngiot_config.region == "eu"
+    assert authenticator._ngiot_config.user_agent == "test-agent"
+    assert authenticator._ngiot_config.timezone_name == "Australia/Brisbane"
+    assert authenticator._ngiot_config.timezone_offset_minutes == 600
+    assert authenticator._ngiot_config.requested_ttl == 300
+    assert authenticator._ngiot_config.refresh_skew == 30
+
+
+def test_attach_ngiot_requires_configured_base_url_or_region(
+    rest_config: RestConfiguration,
+) -> None:
+    authenticator = Authenticator(rest_config, "account", "password")
+
+    with pytest.raises(ApiError, match="requires a configured NGIOT base_url or region"):
+        authenticator.attach_ngiot()
+
+
+def test_attach_ngiot_creates_transport_stack(rest_config: RestConfiguration) -> None:
+    authenticator = Authenticator(rest_config, "account", "password")
+
+    authenticator.attach_ngiot(
+        NgiotConfiguration(
+            region="dc-na",
+            user_agent="test-agent",
+            channel="Android",
+            protocol_version="0.0.22",
+            timezone_name="Australia/Brisbane",
+            timezone_offset_minutes=600,
+            requested_ttl=300,
+            refresh_skew=30,
+        )
+    )
+
+    assert authenticator._ngiot_base_url == "https://api-base.dc-na.ww.ecouser.net"
+    assert isinstance(authenticator.sst_authenticator, SstAuthenticator)
+    assert isinstance(authenticator.ngiot_client, NgiotClient)
+    assert authenticator.sst_authenticator._base_url == (
+        "https://api-base.dc-na.ww.ecouser.net"
+    )
+    assert authenticator.sst_authenticator._requested_ttl == 300
+    assert authenticator.sst_authenticator._refresh_skew == 30
+    assert authenticator.ngiot_client._config.user_agent == "test-agent"
+    assert authenticator.ngiot_client._config.channel == "Android"
+    assert authenticator.ngiot_client._config.protocol_version == "0.0.22"
+    assert authenticator.ngiot_client._config.timezone_name == "Australia/Brisbane"
+    assert authenticator.ngiot_client._config.timezone_offset_minutes == 600
+
+
+def test_attach_ngiot_is_idempotent_for_same_base_url(
+    rest_config: RestConfiguration,
+) -> None:
+    authenticator = Authenticator(rest_config, "account", "password")
+
+    authenticator.attach_ngiot(NgiotConfiguration(region="na"))
+    first_sst_authenticator = authenticator.sst_authenticator
+    first_ngiot_client = authenticator.ngiot_client
+    authenticator.attach_ngiot(NgiotConfiguration(region="dc-na"))
+
+    assert authenticator.sst_authenticator is first_sst_authenticator
+    assert authenticator.ngiot_client is first_ngiot_client
+
+
+def test_attach_ngiot_rejects_different_base_url_when_already_attached(
+    rest_config: RestConfiguration,
+) -> None:
+    authenticator = Authenticator(rest_config, "account", "password")
+
+    authenticator.attach_ngiot(NgiotConfiguration(region="na"))
+
+    with pytest.raises(ApiError, match="already attached with a different base URL"):
+        authenticator.attach_ngiot(NgiotConfiguration(region="eu"))
+
+
+async def test_teardown_clears_ngiot_transport(rest_config: RestConfiguration) -> None:
+    authenticator = Authenticator(rest_config, "account", "password")
+    sst_authenticator = AsyncMock(spec_set=SstAuthenticator)
+    authenticator.sst_authenticator = cast("SstAuthenticator", sst_authenticator)
+    authenticator.ngiot_client = cast("NgiotClient", object())
+    authenticator._ngiot_base_url = "https://api-base.dc-na.ww.ecouser.net"
+
+    await authenticator.teardown()
+
+    sst_authenticator.teardown.assert_awaited_once()
+    assert authenticator.sst_authenticator is None
+    assert authenticator.ngiot_client is None
+    assert authenticator._ngiot_base_url is None
+
+
+@pytest.mark.parametrize(
+    ("mqs_host", "expected"),
+    [
+        (
+            "api-ngiot.dc-na.ww.ecouser.net",
+            "https://api-base.dc-na.ww.ecouser.net",
+        ),
+        (
+            "https://api-ngiot.dc-eu.ww.ecouser.net",
+            "https://api-base.dc-eu.ww.ecouser.net",
+        ),
+        (
+            "api-base.dc-ap.ww.ecouser.net",
+            "https://api-base.dc-ap.ww.ecouser.net",
+        ),
+    ],
+)
+def test_derive_ngiot_base_url_from_mqs(mqs_host: str, expected: str) -> None:
+    assert Authenticator._derive_ngiot_base_url_from_mqs(mqs_host) == expected
+
+
+@pytest.mark.parametrize("mqs_host", ["", "localhost"])
+def test_derive_ngiot_base_url_from_invalid_mqs_raises(mqs_host: str) -> None:
+    with pytest.raises(ApiError):
+        Authenticator._derive_ngiot_base_url_from_mqs(mqs_host)

--- a/tests/test_authentication_ngiot.py
+++ b/tests/test_authentication_ngiot.py
@@ -47,7 +47,9 @@ def test_attach_ngiot_requires_configured_base_url_or_region(
 ) -> None:
     authenticator = Authenticator(rest_config, "account", "password")
 
-    with pytest.raises(ApiError, match="requires a configured NGIOT base_url or region"):
+    with pytest.raises(
+        ApiError, match="requires a configured NGIOT base_url or region"
+    ):
         authenticator.attach_ngiot()
 
 
@@ -117,8 +119,9 @@ async def test_teardown_clears_ngiot_transport(rest_config: RestConfiguration) -
     await authenticator.teardown()
 
     sst_authenticator.teardown.assert_awaited_once()
-    assert authenticator.sst_authenticator is None
-    assert authenticator.ngiot_client is None
+    authenticator_state = vars(authenticator)
+    assert authenticator_state["sst_authenticator"] is None
+    assert authenticator_state["ngiot_client"] is None
     assert authenticator._ngiot_base_url is None
 
 

--- a/tests/test_ngiot_client.py
+++ b/tests/test_ngiot_client.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from http import HTTPStatus
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+from aiohttp import ClientResponseError, RequestInfo, hdrs
+from multidict import CIMultiDict, CIMultiDictProxy
+import orjson
+import pytest
+from yarl import URL
+
+from deebot_client.exceptions import ApiError, AuthenticationError
+from deebot_client.ngiot_client import (
+    NgiotClient,
+    NgiotClientConfiguration,
+    NgiotDeviceIdentity,
+    NgiotRequest,
+)
+
+
+def _request_info() -> RequestInfo:
+    return RequestInfo(
+        url=URL("https://api.example.com/api/iot/endpoint/control"),
+        method="POST",
+        headers=CIMultiDictProxy(CIMultiDict()),
+        real_url=URL("https://api.example.com/api/iot/endpoint/control"),
+    )
+
+
+class _FakeResponse:
+    def __init__(self, body: Mapping[str, Any], *, status: int = HTTPStatus.OK) -> None:
+        self._body = body
+        self.status = status
+        self.request_info = _request_info()
+        self.history: tuple[()] = ()
+        self.headers = CIMultiDictProxy(CIMultiDict({"content-type": "application/json"}))
+        self.reason = "OK" if status == HTTPStatus.OK else "error"
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        pass
+
+    def raise_for_status(self) -> None:
+        if self.status >= HTTPStatus.BAD_REQUEST:
+            raise ClientResponseError(
+                request_info=self.request_info,
+                history=self.history,
+                status=self.status,
+                message=self.reason,
+                headers=self.headers,
+            )
+
+    async def read(self) -> bytes:
+        return orjson.dumps(self._body)
+
+
+class _FakeSession:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = responses
+        self.post_calls: list[dict[str, Any]] = []
+
+    def post(
+        self,
+        url: str,
+        *,
+        params: dict[str, str],
+        data: bytes,
+        headers: dict[str, str],
+        timeout: object,
+    ) -> _FakeResponse:
+        self.post_calls.append(
+            {
+                "url": url,
+                "params": params,
+                "data": data,
+                "headers": CIMultiDict(headers),
+                "timeout": timeout,
+            }
+        )
+        return self._responses.pop(0)
+
+
+@pytest.fixture
+def sst_authenticator() -> AsyncMock:
+    authenticator = AsyncMock()
+    authenticator.get_token.return_value = "sst-token"
+    return authenticator
+
+
+@pytest.fixture
+def ngiot_client(sst_authenticator: AsyncMock) -> NgiotClient:
+    return NgiotClient(Mock(), sst_authenticator)
+
+
+@pytest.fixture
+def api_device() -> dict[str, Any]:
+    return {
+        "did": "did-1",
+        "class": "eyfj07",
+        "resource": "res-1",
+        "service": {"mqs": "service.example.com"},
+    }
+
+
+def test_normalize_device_uses_override_host_and_keeps_service_host_as_fallback(
+    sst_authenticator: AsyncMock,
+    api_device: dict[str, Any],
+) -> None:
+    client = NgiotClient(
+        Mock(),
+        sst_authenticator,
+        NgiotClientConfiguration(override_control_host="override.example.com"),
+    )
+
+    identity = client._normalize_device(api_device)
+
+    assert identity == NgiotDeviceIdentity(
+        did="did-1",
+        class_id="eyfj07",
+        resource="res-1",
+        control_host="override.example.com",
+        fallback_control_host="service.example.com",
+    )
+    assert identity.base_url == "https://override.example.com"
+
+
+def test_normalize_device_requires_control_host(ngiot_client: NgiotClient) -> None:
+    with pytest.raises(ApiError, match="Missing NGIOT control host"):
+        ngiot_client._normalize_device(
+            {
+                "did": "did-1",
+                "class": "eyfj07",
+                "resource": "res-1",
+            }
+        )
+
+
+def test_build_payload_does_not_add_command_specific_defaults(
+    ngiot_client: NgiotClient,
+) -> None:
+    payload = ngiot_client._build_payload({"fields": ["battery"]})
+
+    assert isinstance(payload, Mapping)
+    assert payload == {"fields": ["battery"]}
+
+
+async def test_request_posts_endpoint_control_payload_and_returns_response_data(
+    sst_authenticator: AsyncMock,
+    api_device: dict[str, Any],
+) -> None:
+    session = _FakeSession(
+        [_FakeResponse({"body": {"code": 0, "data": {"battery": 100}}})]
+    )
+    client = NgiotClient(
+        session,
+        sst_authenticator,
+        NgiotClientConfiguration(
+            user_agent="test-agent",
+            channel="Android",
+            protocol_version="0.0.22",
+            timezone_name="Australia/Brisbane",
+            timezone_offset_minutes=600,
+        ),
+    )
+
+    response = await client.request(
+        api_device,
+        NgiotRequest(apn="10001", body_data={"fields": ["battery"]}),
+    )
+
+    assert response == {"body": {"code": 0, "data": {"battery": 100}}}
+    assert len(session.post_calls) == 1
+    call = session.post_calls[0]
+    assert call["url"] == "https://service.example.com/api/iot/endpoint/control"
+    assert call["params"] == {
+        "si": call["params"]["si"],
+        "ct": "q",
+        "eid": "did-1",
+        "et": "eyfj07",
+        "er": "res-1",
+        "apn": "10001",
+        "fmt": "j",
+    }
+    assert len(call["params"]["si"]) == 32
+    assert call["headers"][hdrs.AUTHORIZATION] == "Bearer sst-token"
+    assert call["headers"][hdrs.CONTENT_TYPE] == "application/octet-stream"
+    assert call["headers"][hdrs.USER_AGENT] == "test-agent"
+
+    payload = orjson.loads(call["data"])
+    assert payload["body"] == {"data": {"fields": ["battery"]}}
+    assert payload["header"]["channel"] == "Android"
+    assert payload["header"]["m"] == "request"
+    assert payload["header"]["pri"] == 2
+    assert payload["header"]["reqid"]
+    assert payload["header"]["ts"]
+    assert payload["header"]["tzc"] == "Australia/Brisbane"
+    assert payload["header"]["tzm"] == 600
+    assert payload["header"]["ver"] == "0.0.22"
+
+    sst_authenticator.get_token.assert_awaited_once_with(
+        {
+            "did": "did-1",
+            "class": "eyfj07",
+            "resource": "res-1",
+            "service": {"mqs": "service.example.com"},
+        },
+        force=False,
+    )
+
+
+async def test_query_fields_adds_fields_and_optional_map_id(
+    ngiot_client: NgiotClient,
+    api_device: dict[str, Any],
+) -> None:
+    ngiot_client.request = AsyncMock(
+        return_value={"body": {"code": 0, "data": {"ok": True}}}
+    )
+
+    response = await ngiot_client.query_fields(
+        api_device,
+        apn="30001",
+        fields=["mapData"],
+        map_id="2",
+    )
+
+    assert response == {"ok": True}
+    ngiot_client.request.assert_awaited_once_with(
+        api_device,
+        NgiotRequest(
+            apn="30001",
+            body_data={"fields": ["mapData"], "mapId": "2"},
+        ),
+    )
+
+
+async def test_write_data_sends_direct_mapping_payload(
+    ngiot_client: NgiotClient,
+    api_device: dict[str, Any],
+) -> None:
+    ngiot_client.request = AsyncMock(return_value={"body": {"code": 0}})
+
+    response = await ngiot_client.write_data(
+        api_device,
+        apn="40009",
+        data={"pauseSwitch": True},
+    )
+
+    assert response == {}
+    ngiot_client.request.assert_awaited_once_with(
+        api_device,
+        NgiotRequest(apn="40009", body_data={"pauseSwitch": True}),
+    )
+
+
+async def test_request_with_fallback_retries_on_404() -> None:
+    client = NgiotClient(Mock(), AsyncMock())
+    identity = NgiotDeviceIdentity(
+        did="did-1",
+        class_id="eyfj07",
+        resource="res-1",
+        control_host="api.example.com",
+        fallback_control_host="service.example.com",
+    )
+    response_error = ClientResponseError(
+        request_info=_request_info(),
+        history=(),
+        status=HTTPStatus.NOT_FOUND,
+        message="not found",
+    )
+    client._request_once = AsyncMock(
+        side_effect=[response_error, {"body": {"code": 0, "data": {"ok": True}}}]
+    )
+
+    response = await client._request_with_fallback(
+        identity,
+        {"did": "did-1", "class": "eyfj07", "resource": "res-1"},
+        NgiotRequest(apn="30001", body_data={"fields": ["mapData"]}),
+    )
+
+    assert response == {"body": {"code": 0, "data": {"ok": True}}}
+    assert client._request_once.await_count == 2
+    first_identity = client._request_once.await_args_list[0].args[0]
+    second_identity = client._request_once.await_args_list[1].args[0]
+    assert first_identity.control_host == "api.example.com"
+    assert second_identity.control_host == "service.example.com"
+    assert second_identity.fallback_control_host is None
+
+
+async def test_request_invalidates_sst_and_retries_once_after_unauthorized(
+    sst_authenticator: AsyncMock,
+    api_device: dict[str, Any],
+) -> None:
+    session = _FakeSession(
+        [
+            _FakeResponse({}, status=HTTPStatus.UNAUTHORIZED),
+            _FakeResponse({"body": {"code": 0, "data": {"ok": True}}}),
+        ]
+    )
+    client = NgiotClient(session, sst_authenticator)
+
+    response = await client.request(
+        api_device,
+        NgiotRequest(apn="10001", body_data={"fields": ["battery"]}),
+    )
+
+    assert response == {"body": {"code": 0, "data": {"ok": True}}}
+    assert len(session.post_calls) == 2
+    assert sst_authenticator.invalidate.await_count == 1
+    assert sst_authenticator.get_token.await_args_list[0].kwargs == {"force": False}
+    assert sst_authenticator.get_token.await_args_list[1].kwargs == {"force": True}
+
+
+async def test_request_raises_authentication_error_after_second_unauthorized(
+    sst_authenticator: AsyncMock,
+    api_device: dict[str, Any],
+) -> None:
+    session = _FakeSession(
+        [
+            _FakeResponse({}, status=HTTPStatus.UNAUTHORIZED),
+            _FakeResponse({}, status=HTTPStatus.UNAUTHORIZED),
+        ]
+    )
+    client = NgiotClient(session, sst_authenticator)
+
+    with pytest.raises(AuthenticationError):
+        await client.request(
+            api_device,
+            NgiotRequest(apn="10001", body_data={"fields": ["battery"]}),
+        )
+
+    assert len(session.post_calls) == 2
+    assert sst_authenticator.invalidate.await_count == 1
+
+
+async def test_request_retries_transient_busy_once(
+    sst_authenticator: AsyncMock,
+    api_device: dict[str, Any],
+) -> None:
+    session = _FakeSession(
+        [
+            _FakeResponse({"body": {"code": 1, "msg": "cmd busy"}}),
+            _FakeResponse({"body": {"code": 0, "data": {"ok": True}}}),
+        ]
+    )
+    client = NgiotClient(session, sst_authenticator)
+
+    with patch("deebot_client.ngiot_client.asyncio.sleep", new=AsyncMock()):
+        response = await client.request(
+            api_device,
+            NgiotRequest(apn="10001", body_data={"fields": ["battery"]}),
+        )
+
+    assert response == {"body": {"code": 0, "data": {"ok": True}}}
+    assert len(session.post_calls) == 2
+
+
+@pytest.mark.parametrize(
+    ("response", "classification"),
+    [
+        ({"body": {"code": 0}}, "ok"),
+        ({"body": {"code": "0000"}}, "ok"),
+        ({"body": {"code": None}}, "ok"),
+        ({"body": {"code": 1, "msg": "cmd busy"}}, "retry_busy"),
+        ({}, "ok"),
+    ],
+)
+def test_classify_response(
+    response: dict[str, object],
+    classification: str,
+) -> None:
+    assert NgiotClient._classify_response(response) == classification
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"body": {"code": 500, "msg": "fail"}},
+        {"body": "invalid"},
+        {},
+    ],
+)
+def test_validate_response_raises_on_invalid_response(
+    response: dict[str, object],
+) -> None:
+    with pytest.raises(ApiError):
+        NgiotClient._validate_response(response)

--- a/tests/test_ngiot_client.py
+++ b/tests/test_ngiot_client.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from http import HTTPStatus
-from typing import Any
+from typing import Any, Self, cast
 from unittest.mock import AsyncMock, Mock, patch
 
-from aiohttp import ClientResponseError, RequestInfo, hdrs
+from aiohttp import ClientResponseError, ClientSession, RequestInfo, hdrs
 from multidict import CIMultiDict, CIMultiDictProxy
 import orjson
 import pytest
@@ -35,10 +35,12 @@ class _FakeResponse:
         self.status = status
         self.request_info = _request_info()
         self.history: tuple[()] = ()
-        self.headers = CIMultiDictProxy(CIMultiDict({"content-type": "application/json"}))
+        self.headers = CIMultiDictProxy(
+            CIMultiDict({"content-type": "application/json"})
+        )
         self.reason = "OK" if status == HTTPStatus.OK else "error"
 
-    async def __aenter__(self) -> _FakeResponse:
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(
@@ -87,6 +89,10 @@ class _FakeSession:
             }
         )
         return self._responses.pop(0)
+
+
+def _as_client_session(session: _FakeSession) -> ClientSession:
+    return cast("ClientSession", session)
 
 
 @pytest.fixture
@@ -161,7 +167,7 @@ async def test_request_posts_endpoint_control_payload_and_returns_response_data(
         [_FakeResponse({"body": {"code": 0, "data": {"battery": 100}}})]
     )
     client = NgiotClient(
-        session,
+        _as_client_session(session),
         sst_authenticator,
         NgiotClientConfiguration(
             user_agent="test-agent",
@@ -221,19 +227,17 @@ async def test_query_fields_adds_fields_and_optional_map_id(
     ngiot_client: NgiotClient,
     api_device: dict[str, Any],
 ) -> None:
-    ngiot_client.request = AsyncMock(
-        return_value={"body": {"code": 0, "data": {"ok": True}}}
-    )
-
-    response = await ngiot_client.query_fields(
-        api_device,
-        apn="30001",
-        fields=["mapData"],
-        map_id="2",
-    )
+    request = AsyncMock(return_value={"body": {"code": 0, "data": {"ok": True}}})
+    with patch.object(ngiot_client, "request", new=request):
+        response = await ngiot_client.query_fields(
+            api_device,
+            apn="30001",
+            fields=["mapData"],
+            map_id="2",
+        )
 
     assert response == {"ok": True}
-    ngiot_client.request.assert_awaited_once_with(
+    request.assert_awaited_once_with(
         api_device,
         NgiotRequest(
             apn="30001",
@@ -246,16 +250,16 @@ async def test_write_data_sends_direct_mapping_payload(
     ngiot_client: NgiotClient,
     api_device: dict[str, Any],
 ) -> None:
-    ngiot_client.request = AsyncMock(return_value={"body": {"code": 0}})
-
-    response = await ngiot_client.write_data(
-        api_device,
-        apn="40009",
-        data={"pauseSwitch": True},
-    )
+    request = AsyncMock(return_value={"body": {"code": 0}})
+    with patch.object(ngiot_client, "request", new=request):
+        response = await ngiot_client.write_data(
+            api_device,
+            apn="40009",
+            data={"pauseSwitch": True},
+        )
 
     assert response == {}
-    ngiot_client.request.assert_awaited_once_with(
+    request.assert_awaited_once_with(
         api_device,
         NgiotRequest(apn="40009", body_data={"pauseSwitch": True}),
     )
@@ -276,20 +280,20 @@ async def test_request_with_fallback_retries_on_404() -> None:
         status=HTTPStatus.NOT_FOUND,
         message="not found",
     )
-    client._request_once = AsyncMock(
+    request_once = AsyncMock(
         side_effect=[response_error, {"body": {"code": 0, "data": {"ok": True}}}]
     )
-
-    response = await client._request_with_fallback(
-        identity,
-        {"did": "did-1", "class": "eyfj07", "resource": "res-1"},
-        NgiotRequest(apn="30001", body_data={"fields": ["mapData"]}),
-    )
+    with patch.object(client, "_request_once", new=request_once):
+        response = await client._request_with_fallback(
+            identity,
+            {"did": "did-1", "class": "eyfj07", "resource": "res-1"},
+            NgiotRequest(apn="30001", body_data={"fields": ["mapData"]}),
+        )
 
     assert response == {"body": {"code": 0, "data": {"ok": True}}}
-    assert client._request_once.await_count == 2
-    first_identity = client._request_once.await_args_list[0].args[0]
-    second_identity = client._request_once.await_args_list[1].args[0]
+    assert request_once.await_count == 2
+    first_identity = request_once.await_args_list[0].args[0]
+    second_identity = request_once.await_args_list[1].args[0]
     assert first_identity.control_host == "api.example.com"
     assert second_identity.control_host == "service.example.com"
     assert second_identity.fallback_control_host is None
@@ -305,7 +309,7 @@ async def test_request_invalidates_sst_and_retries_once_after_unauthorized(
             _FakeResponse({"body": {"code": 0, "data": {"ok": True}}}),
         ]
     )
-    client = NgiotClient(session, sst_authenticator)
+    client = NgiotClient(_as_client_session(session), sst_authenticator)
 
     response = await client.request(
         api_device,
@@ -329,7 +333,7 @@ async def test_request_raises_authentication_error_after_second_unauthorized(
             _FakeResponse({}, status=HTTPStatus.UNAUTHORIZED),
         ]
     )
-    client = NgiotClient(session, sst_authenticator)
+    client = NgiotClient(_as_client_session(session), sst_authenticator)
 
     with pytest.raises(AuthenticationError):
         await client.request(
@@ -351,7 +355,7 @@ async def test_request_retries_transient_busy_once(
             _FakeResponse({"body": {"code": 0, "data": {"ok": True}}}),
         ]
     )
-    client = NgiotClient(session, sst_authenticator)
+    client = NgiotClient(_as_client_session(session), sst_authenticator)
 
     with patch("deebot_client.ngiot_client.asyncio.sleep", new=AsyncMock()):
         response = await client.request(

--- a/tests/test_sst_authentication.py
+++ b/tests/test_sst_authentication.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Mapping
 from http import HTTPStatus
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any, Self, cast
 from unittest.mock import AsyncMock
 
-from aiohttp import ClientResponseError, RequestInfo
+from aiohttp import ClientResponseError, ClientSession, RequestInfo
 from multidict import CIMultiDict, CIMultiDictProxy
 import orjson
 import pytest
@@ -22,6 +21,9 @@ from deebot_client.sst_authentication import (
     identity_as_mapping,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 
 def _request_info() -> RequestInfo:
     return RequestInfo(
@@ -30,6 +32,10 @@ def _request_info() -> RequestInfo:
         headers=CIMultiDictProxy(CIMultiDict()),
         real_url=URL("https://api-base.example.com/api/new-perm/token/sst/issue"),
     )
+
+
+def _account_token() -> str:
+    return "account-token"
 
 
 def _token_with_exp(expires_at: int) -> str:
@@ -44,10 +50,12 @@ class _FakeResponse:
         self.status = status
         self.request_info = _request_info()
         self.history: tuple[()] = ()
-        self.headers = CIMultiDictProxy(CIMultiDict({"content-type": "application/json"}))
+        self.headers = CIMultiDictProxy(
+            CIMultiDict({"content-type": "application/json"})
+        )
         self.reason = "OK" if status == HTTPStatus.OK else "error"
 
-    async def __aenter__(self) -> _FakeResponse:
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(
@@ -96,6 +104,10 @@ class _FakeSession:
         return self._responses.pop(0)
 
 
+def _as_client_session(session: _FakeSession) -> ClientSession:
+    return cast("ClientSession", session)
+
+
 @pytest.fixture
 def api_device() -> dict[str, str]:
     return {
@@ -109,7 +121,7 @@ def api_device() -> dict[str, str]:
 def authenticator() -> AsyncMock:
     auth = AsyncMock()
     auth.authenticate.return_value = Credentials(
-        token="account-token",
+        token=_account_token(),
         user_id="user-1",
         expires_at=int(time.time()) + 3600,
     )
@@ -151,7 +163,7 @@ async def test_get_credentials_issues_sst_and_uses_cache(
         ]
     )
     sst_authenticator = SstAuthenticator(
-        session,
+        _as_client_session(session),
         authenticator,
         base_url="https://api-base.example.com",
     )
@@ -169,7 +181,10 @@ async def test_get_credentials_issues_sst_and_uses_cache(
     assert session.post_calls[0]["url"] == (
         "https://api-base.example.com/api/new-perm/token/sst/issue"
     )
-    assert session.post_calls[0]["headers"]["Authorization"] == "Bearer account-token"
+    assert (
+        session.post_calls[0]["headers"]["Authorization"]
+        == f"Bearer {_account_token()}"
+    )
     assert session.post_calls[0]["json"] == {
         "acl": [
             {
@@ -203,7 +218,7 @@ async def test_get_credentials_force_refresh_issues_new_token(
         ]
     )
     sst_authenticator = SstAuthenticator(
-        session,
+        _as_client_session(session),
         authenticator,
         base_url="https://api-base.example.com",
     )
@@ -227,7 +242,7 @@ async def test_invalidate_removes_cached_credentials(
         [_FakeResponse({"code": 0, "data": {"data": {"token": token}}})]
     )
     sst_authenticator = SstAuthenticator(
-        session,
+        _as_client_session(session),
         authenticator,
         base_url="https://api-base.example.com",
     )
@@ -249,7 +264,7 @@ async def test_issue_sst_rejects_error_response(
 ) -> None:
     session = _FakeSession([_FakeResponse({"code": 500, "msg": "failed"})])
     sst_authenticator = SstAuthenticator(
-        session,
+        _as_client_session(session),
         authenticator,
         base_url="https://api-base.example.com",
     )
@@ -264,7 +279,7 @@ async def test_issue_sst_rejects_missing_token(
 ) -> None:
     session = _FakeSession([_FakeResponse({"code": 0, "data": {"data": {}}})])
     sst_authenticator = SstAuthenticator(
-        session,
+        _as_client_session(session),
         authenticator,
         base_url="https://api-base.example.com",
     )
@@ -279,7 +294,7 @@ async def test_issue_sst_raises_authentication_error_on_unauthorized(
 ) -> None:
     session = _FakeSession([_FakeResponse({}, status=HTTPStatus.UNAUTHORIZED)])
     sst_authenticator = SstAuthenticator(
-        session,
+        _as_client_session(session),
         authenticator,
         base_url="https://api-base.example.com",
     )
@@ -294,7 +309,7 @@ async def test_issue_sst_raises_api_error_on_other_http_error(
 ) -> None:
     session = _FakeSession([_FakeResponse({}, status=HTTPStatus.INTERNAL_SERVER_ERROR)])
     sst_authenticator = SstAuthenticator(
-        session,
+        _as_client_session(session),
         authenticator,
         base_url="https://api-base.example.com",
     )

--- a/tests/test_sst_authentication.py
+++ b/tests/test_sst_authentication.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+from http import HTTPStatus
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+from aiohttp import ClientResponseError, RequestInfo
+from multidict import CIMultiDict, CIMultiDictProxy
+import orjson
+import pytest
+from yarl import URL
+
+from deebot_client.exceptions import ApiError, AuthenticationError
+from deebot_client.models import Credentials
+from deebot_client.sst_authentication import (
+    SstAuthenticator,
+    SstCredentials,
+    SstDeviceIdentity,
+    identity_as_mapping,
+)
+
+
+def _request_info() -> RequestInfo:
+    return RequestInfo(
+        url=URL("https://api-base.example.com/api/new-perm/token/sst/issue"),
+        method="POST",
+        headers=CIMultiDictProxy(CIMultiDict()),
+        real_url=URL("https://api-base.example.com/api/new-perm/token/sst/issue"),
+    )
+
+
+def _token_with_exp(expires_at: int) -> str:
+    header = base64.urlsafe_b64encode(orjson.dumps({"alg": "none"})).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(orjson.dumps({"exp": expires_at})).rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.signature"
+
+
+class _FakeResponse:
+    def __init__(self, body: Mapping[str, Any], *, status: int = HTTPStatus.OK) -> None:
+        self._body = body
+        self.status = status
+        self.request_info = _request_info()
+        self.history: tuple[()] = ()
+        self.headers = CIMultiDictProxy(CIMultiDict({"content-type": "application/json"}))
+        self.reason = "OK" if status == HTTPStatus.OK else "error"
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        pass
+
+    def raise_for_status(self) -> None:
+        if self.status >= HTTPStatus.BAD_REQUEST:
+            raise ClientResponseError(
+                request_info=self.request_info,
+                history=self.history,
+                status=self.status,
+                message=self.reason,
+                headers=self.headers,
+            )
+
+    async def read(self) -> bytes:
+        return orjson.dumps(self._body)
+
+
+class _FakeSession:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = responses
+        self.post_calls: list[dict[str, Any]] = []
+
+    def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str],
+        timeout: object,
+    ) -> _FakeResponse:
+        self.post_calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return self._responses.pop(0)
+
+
+@pytest.fixture
+def api_device() -> dict[str, str]:
+    return {
+        "did": "did-1",
+        "class": "eyfj07",
+        "resource": "res-1",
+    }
+
+
+@pytest.fixture
+def authenticator() -> AsyncMock:
+    auth = AsyncMock()
+    auth.authenticate.return_value = Credentials(
+        token="account-token",
+        user_id="user-1",
+        expires_at=int(time.time()) + 3600,
+    )
+    return auth
+
+
+def test_identity_endpoint_and_cache_key() -> None:
+    identity = SstDeviceIdentity(did="did-1", class_id="eyfj07", resource="res-1")
+
+    assert identity.endpoint == "Endpoint:eyfj07:did-1"
+    assert identity.key == "eyfj07:did-1:res-1"
+    assert identity_as_mapping(identity) == {
+        "did": "did-1",
+        "class": "eyfj07",
+        "resource": "res-1",
+    }
+
+
+def test_decode_exp_supports_jwt_and_sst_prefixed_tokens() -> None:
+    expires_at = int(time.time()) + 600
+    jwt = _token_with_exp(expires_at)
+    sst = f"SST.prefix.{jwt.split('.')[1]}.signature"
+
+    assert SstAuthenticator._decode_exp(jwt) == expires_at
+    assert SstAuthenticator._decode_exp(sst) == expires_at
+
+
+async def test_get_credentials_issues_sst_and_uses_cache(
+    authenticator: AsyncMock,
+    api_device: dict[str, str],
+) -> None:
+    expires_at = int(time.time()) + 600
+    token = _token_with_exp(expires_at)
+    session = _FakeSession(
+        [
+            _FakeResponse(
+                {"code": 0, "data": {"data": {"token": token}}},
+            )
+        ]
+    )
+    sst_authenticator = SstAuthenticator(
+        session,
+        authenticator,
+        base_url="https://api-base.example.com",
+    )
+
+    credentials = await sst_authenticator.get_credentials(api_device)
+    cached_credentials = await sst_authenticator.get_credentials(api_device)
+
+    assert credentials == SstCredentials(
+        token=token,
+        expires_at=expires_at,
+        device_key="eyfj07:did-1:res-1",
+    )
+    assert cached_credentials == credentials
+    assert len(session.post_calls) == 1
+    assert session.post_calls[0]["url"] == (
+        "https://api-base.example.com/api/new-perm/token/sst/issue"
+    )
+    assert session.post_calls[0]["headers"]["Authorization"] == "Bearer account-token"
+    assert session.post_calls[0]["json"] == {
+        "acl": [
+            {
+                "policy": [
+                    {
+                        "obj": ["Endpoint:eyfj07:did-1"],
+                        "perms": ["Control"],
+                    }
+                ],
+                "svc": "dim",
+            }
+        ],
+        "exp": 600,
+        "sub": "user-1",
+    }
+    authenticator.authenticate.assert_awaited_once()
+
+    await sst_authenticator.teardown()
+
+
+async def test_get_credentials_force_refresh_issues_new_token(
+    authenticator: AsyncMock,
+    api_device: dict[str, str],
+) -> None:
+    first_token = _token_with_exp(int(time.time()) + 600)
+    second_token = _token_with_exp(int(time.time()) + 900)
+    session = _FakeSession(
+        [
+            _FakeResponse({"code": 0, "data": {"data": {"token": first_token}}}),
+            _FakeResponse({"code": 0, "data": {"data": {"token": second_token}}}),
+        ]
+    )
+    sst_authenticator = SstAuthenticator(
+        session,
+        authenticator,
+        base_url="https://api-base.example.com",
+    )
+
+    first = await sst_authenticator.get_credentials(api_device)
+    second = await sst_authenticator.get_credentials(api_device, force=True)
+
+    assert first.token == first_token
+    assert second.token == second_token
+    assert len(session.post_calls) == 2
+
+    await sst_authenticator.teardown()
+
+
+async def test_invalidate_removes_cached_credentials(
+    authenticator: AsyncMock,
+    api_device: dict[str, str],
+) -> None:
+    token = _token_with_exp(int(time.time()) + 600)
+    session = _FakeSession(
+        [_FakeResponse({"code": 0, "data": {"data": {"token": token}}})]
+    )
+    sst_authenticator = SstAuthenticator(
+        session,
+        authenticator,
+        base_url="https://api-base.example.com",
+    )
+
+    credentials = await sst_authenticator.get_credentials(api_device)
+    assert credentials.device_key in sst_authenticator._credentials
+
+    await sst_authenticator.invalidate(api_device)
+
+    assert credentials.device_key not in sst_authenticator._credentials
+    assert credentials.device_key not in sst_authenticator._refresh_handles
+
+    await sst_authenticator.teardown()
+
+
+async def test_issue_sst_rejects_error_response(
+    authenticator: AsyncMock,
+    api_device: dict[str, str],
+) -> None:
+    session = _FakeSession([_FakeResponse({"code": 500, "msg": "failed"})])
+    sst_authenticator = SstAuthenticator(
+        session,
+        authenticator,
+        base_url="https://api-base.example.com",
+    )
+
+    with pytest.raises(AuthenticationError, match="failure code 500"):
+        await sst_authenticator.get_credentials(api_device)
+
+
+async def test_issue_sst_rejects_missing_token(
+    authenticator: AsyncMock,
+    api_device: dict[str, str],
+) -> None:
+    session = _FakeSession([_FakeResponse({"code": 0, "data": {"data": {}}})])
+    sst_authenticator = SstAuthenticator(
+        session,
+        authenticator,
+        base_url="https://api-base.example.com",
+    )
+
+    with pytest.raises(AuthenticationError, match="did not contain a token"):
+        await sst_authenticator.get_credentials(api_device)
+
+
+async def test_issue_sst_raises_authentication_error_on_unauthorized(
+    authenticator: AsyncMock,
+    api_device: dict[str, str],
+) -> None:
+    session = _FakeSession([_FakeResponse({}, status=HTTPStatus.UNAUTHORIZED)])
+    sst_authenticator = SstAuthenticator(
+        session,
+        authenticator,
+        base_url="https://api-base.example.com",
+    )
+
+    with pytest.raises(AuthenticationError, match="not authorized"):
+        await sst_authenticator.get_credentials(api_device)
+
+
+async def test_issue_sst_raises_api_error_on_other_http_error(
+    authenticator: AsyncMock,
+    api_device: dict[str, str],
+) -> None:
+    session = _FakeSession([_FakeResponse({}, status=HTTPStatus.INTERNAL_SERVER_ERROR)])
+    sst_authenticator = SstAuthenticator(
+        session,
+        authenticator,
+        base_url="https://api-base.example.com",
+    )
+
+    with pytest.raises(ApiError):
+        await sst_authenticator.get_credentials(api_device)


### PR DESCRIPTION
This PR adds the core NGIOT transport and SST authentication plumbing.

It is the first PR in a staged NGIOT implementation split. The intent is to keep the change reviewable and release-safe before adding command handling, MQTT numeric-topic routing, hardware profile support, or map support.

## In scope

- Add SST authentication support for NGIOT requests.
- Add a thin NGIOT endpoint-control client.
- Add minimal authentication integration needed to attach the NGIOT stack.
- Add unit coverage for NGIOT client behaviour.
- Add unit coverage for SST authentication behaviour.
- Add unit coverage for authentication teardown/integration behaviour.

## Out of scope

- NGIOT command abstractions.
- Individual NGIOT commands.
- MQTT numeric-topic routing.
- `eyfj07` hardware profile enablement.
- Map parser/state handling.
- Rust/LZ4/raster rendering.
- Any user-facing NGIOT device support.

## Overall goal

The end goal is to add support for NGIOT-based devices, including the `eyfj07` printer, in a staged and reviewable way.

Planned sequence:

1. NGIOT transport and SST authentication
2. NGIOT command base
3. Core NGIOT commands
4. MQTT numeric topic routing
5. `eyfj07` hardware profile without map support
6. NGIOT map parser/state handling
7. Rust LZ4/raster rendering support
8. NGIOT map commands and map enablement

## Release safety

This PR keeps `main` releasable because it only adds internal transport/authentication plumbing.

It does not expose a new hardware profile, does not route NGIOT MQTT messages, does not add NGIOT commands, and does not enable map support.

## Testing

- [x] `uv run --python 3.14 pytest tests/test_ngiot_client.py tests/test_sst_authentication.py tests/test_authentication_ngiot.py`
- [x] `uv run --python 3.14 mypy deebot_client/ngiot_client.py deebot_client/sst_authentication.py tests/test_ngiot_client.py tests/test_sst_authentication.py tests/test_authentication_ngiot.py`
- [x] `uv run --python 3.14 prek run ruff-check --files deebot_client/ngiot_client.py deebot_client/sst_authentication.py tests/test_ngiot_client.py tests/test_sst_authentication.py tests/test_authentication_ngiot.py`
- [x] `uv run --python 3.14 prek run ruff-format --files deebot_client/ngiot_client.py deebot_client/sst_authentication.py tests/test_ngiot_client.py tests/test_sst_authentication.py tests/test_authentication_ngiot.py`
- [x] `uv run --python 3.14 prek run --all-files` except unrelated existing mypy baseline failures

Known unrelated full-prek mypy baseline failures:

- `tests/rs/test_map.py`
- `tests/test_mqtt_client.py`
- `tests/test_device.py`
- `tests/commands/xml/test_life_span.py`