### PR TITLE
feat: add optional position capability for mowers

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -276,6 +276,7 @@ class Capabilities(ABC):
     map: CapabilityMap | None = None
     network: CapabilityEvent[NetworkInfoEvent]
     play_sound: CapabilityExecute[[]]
+    position: CapabilityEvent[PositionsEvent] | None = None
     settings: CapabilitySettings
     state: CapabilityEvent[StateEvent]
     station: CapabilityStation | None = None

--- a/deebot_client/hardware/xmp9ds.py
+++ b/deebot_client/hardware/xmp9ds.py
@@ -40,6 +40,7 @@ from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
 from deebot_client.commands.json.network import GetNetInfo
 from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
 from deebot_client.commands.json.stats import GetStats, GetTotalStats
 from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
 from deebot_client.commands.json.volume import GetVolume, SetVolume
@@ -58,6 +59,7 @@ from deebot_client.events import (
     LifeSpanEvent,
     MoveUpWarningEvent,
     NetworkInfoEvent,
+    PositionsEvent,
     ReportStatsEvent,
     SafeProtectEvent,
     StateEvent,
@@ -102,6 +104,7 @@ def get_device_info() -> StaticDeviceInfo:
             ),
             network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
             play_sound=CapabilityExecute(PlaySound),
+            position=CapabilityEvent(PositionsEvent, [GetPos()]),
             settings=CapabilitySettings(
                 advanced_mode=CapabilitySetEnable(
                     AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode


### PR DESCRIPTION
## Summary

Adds \`Capabilities.position\` as an optional \`CapabilityEvent[PositionsEvent]\` so devices that don't expose the full map capability (e.g. mowers like the Ecovacs GOAT family) can still report their position to consumers.

Today \`PositionsEvent\` is only fired through \`CapabilityMap.position\`, but mowers don't have a \`map\` capability, so the event never reaches subscribers even though \`getPos\` works fine on the device. Adding a top-level optional \`position\` capability lets mowers wire \`GetPos\` directly without forcing a fake \`map\` capability.

## Changes

- \`deebot_client/capabilities.py\` — \`Capabilities.position: CapabilityEvent[PositionsEvent] | None = None\`
- \`deebot_client/hardware/xmp9ds.py\` — wires \`position=CapabilityEvent(PositionsEvent, [GetPos()])\` on the GOAT A1600 RTK

Other devices stay unaffected (\`position\` defaults to \`None\`; vacuums keep using \`CapabilityMap.position\`).

## Test

\`uv run pytest tests/\` — 703 passed.