### PR TITLE
Configure CleanAreaV2 on the 4 mower models

### DIFF
--- a/deebot_client/hardware/300lc5.py
+++ b/deebot_client/hardware/300lc5.py
@@ -34,7 +34,7 @@ from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvanc
 from deebot_client.commands.json.battery import GetBattery
 from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
-from deebot_client.commands.json.clean import CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.clean import CleanAreaV2, CleanV2, GetCleanInfoV2
 from deebot_client.commands.json.custom import CustomCommand
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
@@ -81,7 +81,7 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=CleanV2),
+                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaV2),
             ),
             custom=CapabilityCustomCommand(
                 event=CustomCommandEvent, get=[], set=CustomCommand

--- a/deebot_client/hardware/51rcxt.py
+++ b/deebot_client/hardware/51rcxt.py
@@ -34,7 +34,7 @@ from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvanc
 from deebot_client.commands.json.battery import GetBattery
 from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
-from deebot_client.commands.json.clean import CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.clean import CleanAreaV2, CleanV2, GetCleanInfoV2
 from deebot_client.commands.json.custom import CustomCommand
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
@@ -81,7 +81,7 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=CleanV2),
+                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaV2),
             ),
             custom=CapabilityCustomCommand(
                 event=CustomCommandEvent, get=[], set=CustomCommand

--- a/deebot_client/hardware/5xu9h3.py
+++ b/deebot_client/hardware/5xu9h3.py
@@ -34,7 +34,7 @@ from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvanc
 from deebot_client.commands.json.battery import GetBattery
 from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
-from deebot_client.commands.json.clean import CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.clean import CleanAreaV2, CleanV2, GetCleanInfoV2
 from deebot_client.commands.json.custom import CustomCommand
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
@@ -81,7 +81,7 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=CleanV2),
+                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaV2),
             ),
             custom=CapabilityCustomCommand(
                 event=CustomCommandEvent, get=[], set=CustomCommand

--- a/deebot_client/hardware/xmp9ds.py
+++ b/deebot_client/hardware/xmp9ds.py
@@ -34,7 +34,7 @@ from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvanc
 from deebot_client.commands.json.battery import GetBattery
 from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
-from deebot_client.commands.json.clean import CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.clean import CleanAreaV2, CleanV2, GetCleanInfoV2
 from deebot_client.commands.json.custom import CustomCommand
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
@@ -81,7 +81,7 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=CleanV2),
+                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaV2),
             ),
             custom=CapabilityCustomCommand(
                 event=CustomCommandEvent, get=[], set=CustomCommand


### PR DESCRIPTION
## Summary

Adds `area=CleanAreaV2` to `CapabilityCleanAction` for the 4 mower hardware models — `xmp9ds` (GOAT A1600 RTK), `5xu9h3` (GOAT G1), `51rcxt` (GOAT A3000 LiDAR Pro), `300lc5` (GOAT O500 Panorama).

Before this change the mower `CapabilityCleanAction` had only `command=CleanV2` and consumers could not launch a specific zone — they had to fall back to the full-map action.

## Why

Mowers accept the exact same `clean_V2` payload shape as vacuums for spot-area cleaning:

```json
{"act":"s","content":{"type":"spotArea","value":"<zone_id>"}}
```

Verified on a real GOAT A1600 (FW 1.15.13) by MQTT sniff while the official app launched zone "Trampo":

- The mower's `getCleanInfo` response reported `cleanState.content = {"type":"spotArea","value":"1"}` confirming the same envelope as the existing vacuum CleanAreaV2 implementation produces.
- The complementary `getAreaSet type:"ar"` exposes the named zones with stable numeric IDs (LZMA+base64 encoded in `subsets`), giving consumers a `name → id` lookup table at runtime.

So the lib already had the right command (`CleanAreaV2`) — only the hardware capability declarations needed updating.

## What changed

- `deebot_client/hardware/xmp9ds.py`
- `deebot_client/hardware/5xu9h3.py`
- `deebot_client/hardware/51rcxt.py`
- `deebot_client/hardware/300lc5.py`

Each file gets `CleanAreaV2` added to the `from deebot_client.commands.json.clean import …` and `area=CleanAreaV2` attached to the existing `CapabilityCleanAction(command=CleanV2, …)`.

8 lines changed total (4 imports + 4 area parameters).

## Tests

- `pytest tests/hardware/` → 7 passed
- `pytest tests/commands/json/test_clean.py` → 27 passed
- The `CleanAreaV2` class itself is already covered by the vacuum-side suite; this PR just wires its existing behavior to the mower capability so no new test logic is needed for the command itself.

## Notes

- `CleanV2` (start/stop/pause/resume) is unchanged — area is an additive capability, not a replacement.
- Other mower-specific PRs in flight (#1567 OnMapTrace, #1587 getRTK, #1588 Position) are independent and don't conflict with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)