### PR TITLE
Remove MAX_PLUS fan speed level for OZMO 920

### DIFF
--- a/deebot_client/hardware/yna5xi.py
+++ b/deebot_client/hardware/yna5xi.py
@@ -1,4 +1,4 @@
-"""Deebot Ozmo 920/950 Capabilities."""
+"""DEEBOT OZMO 920 Capabilities."""
 
 from __future__ import annotations
 
@@ -123,7 +123,6 @@ def get_device_info() -> StaticDeviceInfo:
                     FanSpeedLevel.QUIET,
                     FanSpeedLevel.NORMAL,
                     FanSpeedLevel.MAX,
-                    FanSpeedLevel.MAX_PLUS,
                 ),
             ),
             life_span=CapabilityLifeSpan(


### PR DESCRIPTION
- The Deebot OZMO 920 has only three suction levels.
- The class 'yna5xi' refers to the Deebot OZMO 920 (only).