### PR TITLE
Add Yeedi auth domain support and Yeedi M12 Pro+ (hdi1rf) hardware def

### DIFF
--- a/deebot_client/authentication.py
+++ b/deebot_client/authentication.py
@@ -64,6 +64,7 @@ def create_rest_config(
     device_id: str,
     alpha_2_country: str,
     override_rest_url: str | None = None,
+    auth_domain: str = "ecovacs.com",
 ) -> RestConfiguration:
     """Create configuration."""
     continent_postfix = get_continent_url_postfix(alpha_2_country)
@@ -74,8 +75,8 @@ def create_rest_config(
         portal_url = f"https://portal{continent_postfix}.ecouser.net"
         country_url = country.lower()
         tld = "com" if alpha_2_country != COUNTRY_CHINA else country_url
-        login_url = f"https://gl-{country_url}-api.ecovacs.{tld}"
-        auth_code_url = f"https://gl-{country_url}-openapi.ecovacs.{tld}"
+        login_url = f"https://gl-{country_url}-api.{auth_domain}"
+        auth_code_url = f"https://gl-{country_url}-openapi.{auth_domain}"
 
     return RestConfiguration(
         session=session,

--- a/deebot_client/authentication.py
+++ b/deebot_client/authentication.py
@@ -34,6 +34,13 @@ _CLIENT_KEY = "1520391301804"
 _CLIENT_SECRET = "6c319b2a5cd3e66e39159c2e28f2fce9"  # noqa: S105
 _AUTH_CLIENT_KEY = "1520391491841"
 _AUTH_CLIENT_SECRET = "77ef58ce3afbe337da74aa8c5ab963a9"  # noqa: S105
+
+# Yeedi uses different signing keys and app metadata
+_CLIENT_KEY_YD = "1581917520081"
+_CLIENT_SECRET_YD = "ed5b3dd9a0253de7d90305d077eb5fee"  # noqa: S105
+_AUTH_CLIENT_KEY_YD = "1581923437995"
+_AUTH_CLIENT_SECRET_YD = "304a71592690995b2bb304e66b5ddee6"  # noqa: S105
+
 _USER_LOGIN_PATH_FORMAT = "/v1/private/{country}/{lang}/{deviceId}/{appCode}/{appVersion}/{channel}/{deviceType}/user/login"
 _GLOBAL_AUTHCODE_PATH = "/v1/global/auth/getAuthCode"
 _META = {
@@ -56,6 +63,13 @@ class RestConfiguration:
     portal_url: str
     login_url: str
     auth_code_url: str
+    auth_domain: str = "ecovacs.com"
+    client_key: str = _CLIENT_KEY
+    client_secret: str = _CLIENT_SECRET
+    auth_client_key: str = _AUTH_CLIENT_KEY
+    auth_client_secret: str = _AUTH_CLIENT_SECRET
+    app_code: str = "global_e"
+    app_version: str = "1.6.3"
 
 
 def create_rest_config(
@@ -74,10 +88,16 @@ def create_rest_config(
     else:
         portal_url = f"https://portal{continent_postfix}.ecouser.net"
         country_url = country.lower()
-        tld = "com" if alpha_2_country != COUNTRY_CHINA else country_url
-        login_url = f"https://gl-{country_url}-api.{auth_domain}"
-        auth_code_url = f"https://gl-{country_url}-openapi.{auth_domain}"
+        # Chinese Ecovacs accounts use ecovacs.cn; other domains (e.g. yeedi.com) are used as-is
+        effective_domain = (
+            f"ecovacs.{country_url}"
+            if alpha_2_country == COUNTRY_CHINA and auth_domain == "ecovacs.com"
+            else auth_domain
+        )
+        login_url = f"https://gl-{country_url}-api.{effective_domain}"
+        auth_code_url = f"https://gl-{country_url}-openapi.{effective_domain}"
 
+    is_yeedi = auth_domain == "yeedi.com"
     return RestConfiguration(
         session=session,
         device_id=device_id,
@@ -85,6 +105,13 @@ def create_rest_config(
         portal_url=portal_url,
         login_url=login_url,
         auth_code_url=auth_code_url,
+        auth_domain=auth_domain,
+        client_key=_CLIENT_KEY_YD if is_yeedi else _CLIENT_KEY,
+        client_secret=_CLIENT_SECRET_YD if is_yeedi else _CLIENT_SECRET,
+        auth_client_key=_AUTH_CLIENT_KEY_YD if is_yeedi else _AUTH_CLIENT_KEY,
+        auth_client_secret=_AUTH_CLIENT_SECRET_YD if is_yeedi else _AUTH_CLIENT_SECRET,
+        app_code="yd_global_e" if is_yeedi else "global_e",
+        app_version="1.3.0" if is_yeedi else "1.6.3",
     )
 
 
@@ -106,6 +133,8 @@ class _AuthClient:
 
         self._meta: dict[str, str] = {
             **_META,
+            "appCode": self._config.app_code,
+            "appVersion": self._config.app_version,
             "country": self._config.country.lower(),
             "deviceId": self._config.device_id,
         }
@@ -185,7 +214,7 @@ class _AuthClient:
             url += "CheckMobile"
 
         return await self.__do_auth_response(
-            url, self.__sign(params, self._meta, _CLIENT_KEY, _CLIENT_SECRET)
+            url, self.__sign(params, self._meta, self._config.client_key, self._config.client_secret)
         )
 
     @staticmethod
@@ -220,7 +249,7 @@ class _AuthClient:
         res = await self.__do_auth_response(
             url,
             self.__sign(
-                params, {"openId": "global"}, _AUTH_CLIENT_KEY, _AUTH_CLIENT_SECRET
+                params, {"openId": "global"}, self._config.auth_client_key, self._config.auth_client_secret
             ),
         )
         return str(res["authCode"])
@@ -234,7 +263,15 @@ class _AuthClient:
             "token": auth_code,
             "realm": REALM,
             "resource": self._config.device_id,
-            "org": "ECOWW" if self._config.country != COUNTRY_CHINA else "ECOCN",
+            "org": (
+                "ECOYDWW"
+                if self._config.auth_domain == "yeedi.com" and self._config.country != COUNTRY_CHINA
+                else "ECOYDCN"
+                if self._config.auth_domain == "yeedi.com"
+                else "ECOWW"
+                if self._config.country != COUNTRY_CHINA
+                else "ECOCN"
+            ),
             "last": "",
             "country": self._config.country
             if self._config.country != COUNTRY_CHINA

--- a/deebot_client/hardware/hdi1rf.py
+++ b/deebot_client/hardware/hdi1rf.py
@@ -1,0 +1,1 @@
+viq3mw.py

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -59,38 +59,63 @@ async def test_authenticator_authenticate(rest_config: RestConfiguration) -> Non
     (
         "country",
         "override_rest_url",
+        "auth_domain",
         "expected_portal_url",
         "expected_login_url",
         "expected_auth_code_url",
+        "expected_client_key",
+        "expected_app_code",
     ),
     [
         (
             "CN",
             "http://example.com",
+            "ecovacs.com",
             "http://example.com",
             "http://example.com",
             "http://example.com",
+            "1520391301804",
+            "global_e",
         ),
         (
             "CN",
             None,
+            "ecovacs.com",
             "https://portal.ecouser.net",
             "https://gl-cn-api.ecovacs.cn",
             "https://gl-cn-openapi.ecovacs.cn",
+            "1520391301804",
+            "global_e",
         ),
         (
             "IT",
             "http://example.com",
+            "ecovacs.com",
             "http://example.com",
             "http://example.com",
             "http://example.com",
+            "1520391301804",
+            "global_e",
         ),
         (
             "IT",
             None,
+            "ecovacs.com",
             "https://portal-eu.ecouser.net",
             "https://gl-it-api.ecovacs.com",
             "https://gl-it-openapi.ecovacs.com",
+            "1520391301804",
+            "global_e",
+        ),
+        (
+            "US",
+            None,
+            "yeedi.com",
+            "https://portal-na.ecouser.net",
+            "https://gl-us-api.yeedi.com",
+            "https://gl-us-openapi.yeedi.com",
+            "1581917520081",
+            "yd_global_e",
         ),
     ],
 )
@@ -98,9 +123,12 @@ def test_config_override_rest_url(
     session: ClientSession,
     country: str,
     override_rest_url: str | None,
+    auth_domain: str,
     expected_portal_url: str,
     expected_login_url: str,
     expected_auth_code_url: str,
+    expected_client_key: str,
+    expected_app_code: str,
 ) -> None:
     """Test rest configuration."""
     config = create_rest_config(
@@ -108,7 +136,10 @@ def test_config_override_rest_url(
         device_id="123",
         alpha_2_country=country,
         override_rest_url=override_rest_url,
+        auth_domain=auth_domain,
     )
     assert config.portal_url == expected_portal_url
     assert config.login_url == expected_login_url
     assert config.auth_code_url == expected_auth_code_url
+    assert config.client_key == expected_client_key
+    assert config.app_code == expected_app_code


### PR DESCRIPTION
Add Yeedi auth support and Yeedi M12 Pro+ (hdi1rf) hardware definition

Summary

Yeedi is a sister brand to Ecovacs that shares the same underlying API infrastructure but uses a distinct auth domain, signing keys, app metadata, and org identifier. This PR wires up full Yeedi login support and adds a hardware definition for the Yeedi M12 Pro+.

Changes

deebot_client/authentication.py

- Add auth_domain parameter to create_rest_config() (default: "ecovacs.com", backward compatible)
- Add auth_domain, client_key, client_secret, auth_client_key, auth_client_secret, app_code, app_version fields to RestConfiguration
- When auth_domain="yeedi.com", create_rest_config() automatically selects:
  - Yeedi signing keys (1581917520081 / 1581923437995)
  - App metadata yd_global_e / 1.3.0
- _AuthClient uses config-supplied keys instead of module-level constants
- loginByItToken sends org="ECOYDWW" for Yeedi (Ecovacs uses "ECOWW"); the portal rejects Yeedi auth codes if the wrong org is sent
- Preserve existing ecovacs.cn URL behavior for Chinese Ecovacs accounts

deebot_client/hardware/hdi1rf.py

- Symlink to viq3mw.py (T30C Gen2 capabilities) as a starting baseline
- Tested against a live M12 Pro+ (class: hdi1rf, MQTT: jmq-ngiot-na.dc.ww.ecouser.net) — 20+ capability events fire correctly
- Known differences from the symlink target worth a follow-up: efficiency_mode not observed on M12 Pro+; water control uses discrete levels rather than a numeric range

tests/test_authentication.py

- Extend test_config_override_rest_url to also assert client_key and app_code selection
- Add Yeedi US test case covering URL, key, and app metadata

Testing

Authenticated against a live Yeedi account and Yeedi M12 Pro+ device. All 537 existing tests pass; 1 error in tests/rs/test_util.py is pre-existing (missing pytest-benchmark).

Caller usage

rest_config = create_rest_config(
    session,
    device_id=device_id,
    alpha_2_country="US",
    auth_domain="yeedi.com",  # omit for Ecovacs (default)
)

---