### PR TITLE
Implement ECOVACS GOAT O600 Start Mowing in 6n9pcz.py

### DIFF
--- a/deebot_client/hardware/6n9pcz.py
+++ b/deebot_client/hardware/6n9pcz.py
@@ -1,1 +1,152 @@
-9bts2s.py
+"""DEEBOT GOAT G1 Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityLifeSpan,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilityStats,
+    DeviceType,
+)
+from deebot_client.commands.json import (
+    GetBorderSwitch,
+    GetChildLock,
+    GetCrossMapBorderWarning,
+    GetCutDirection,
+    GetMoveUpWarning,
+    GetSafeProtect,
+    SetBorderSwitch,
+    SetChildLock,
+    SetCrossMapBorderWarning,
+    SetCutDirection,
+    SetMoveUpWarning,
+    SetSafeProtect,
+)
+from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.clean import CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AdvancedModeEvent,
+    AvailabilityEvent,
+    BatteryEvent,
+    BorderSwitchEvent,
+    ChildLockEvent,
+    CrossMapBorderWarningEvent,
+    CustomCommandEvent,
+    CutDirectionEvent,
+    ErrorEvent,
+    LifeSpan,
+    LifeSpanEvent,
+    MoveUpWarningEvent,
+    NetworkInfoEvent,
+    ReportStatsEvent,
+    SafeProtectEvent,
+    StateEvent,
+    StatsEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VolumeEvent,
+)
+from deebot_client.models import StaticDeviceInfo
+from deebot_client.commands.json.clean import Clean
+from deebot_client.models import CleanAction, CleanMode
+from typing import Any
+
+class GoatClean(Clean):
+    """Spezifischer Startbefehl fuer den GOAT O600."""
+    def _get_args(self, action: CleanAction) -> dict[str, Any]:
+        args = {"act": action.value}
+        if action == CleanAction.START:
+            args["content"] = {"type": "auto"}
+        return args
+
+
+def get_device_info() -> StaticDeviceInfo:
+    """Get device info for this model."""
+    return StaticDeviceInfo(
+        DataType.JSON,
+        Capabilities(
+            device_type=DeviceType.MOWER,
+            availability=CapabilityEvent(
+                AvailabilityEvent, [GetBattery(is_available_check=True)]
+            ),
+            battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+            charge=CapabilityExecute(Charge),
+            clean=CapabilityClean(
+                action=CapabilityCleanAction(command=GoatClean),
+            ),
+            custom=CapabilityCustomCommand(
+                event=CustomCommandEvent, get=[], set=CustomCommand
+            ),
+            error=CapabilityEvent(ErrorEvent, [GetError()]),
+            life_span=CapabilityLifeSpan(
+                types=(LifeSpan.BLADE, LifeSpan.LENS_BRUSH),
+                event=LifeSpanEvent,
+                get=[
+                    GetLifeSpan(
+                        [
+                            LifeSpan.BLADE,
+                            LifeSpan.LENS_BRUSH,
+                        ]
+                    )
+                ],
+                reset=ResetLifeSpan,
+            ),
+            network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+            play_sound=CapabilityExecute(PlaySound),
+            settings=CapabilitySettings(
+                advanced_mode=CapabilitySetEnable(
+                    AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
+                ),
+                border_switch=CapabilitySetEnable(
+                    BorderSwitchEvent, [GetBorderSwitch()], SetBorderSwitch
+                ),
+                cut_direction=CapabilitySet(
+                    CutDirectionEvent, [GetCutDirection()], SetCutDirection
+                ),
+                child_lock=CapabilitySetEnable(
+                    ChildLockEvent, [GetChildLock()], SetChildLock
+                ),
+                moveup_warning=CapabilitySetEnable(
+                    MoveUpWarningEvent, [GetMoveUpWarning()], SetMoveUpWarning
+                ),
+                cross_map_border_warning=CapabilitySetEnable(
+                    CrossMapBorderWarningEvent,
+                    [GetCrossMapBorderWarning()],
+                    SetCrossMapBorderWarning,
+                ),
+                safe_protect=CapabilitySetEnable(
+                    SafeProtectEvent, [GetSafeProtect()], SetSafeProtect
+                ),
+                true_detect=CapabilitySetEnable(
+                    TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+                ),
+                volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+            ),
+            state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfoV2()]),
+            stats=CapabilityStats(
+                clean=CapabilityEvent(StatsEvent, [GetStats()]),
+                report=CapabilityEvent(ReportStatsEvent, []),
+                total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+            ),
+        ),
+    )


### PR DESCRIPTION
### Description

This PR replaces the symbolic link for the device class `6n9pcz` (GOAT O600 RTK) with a dedicated hardware profile and fixes the start/mowing command. 

### Why this is needed:
Previously, `6n9pcz` was linked to `9bts2s.py`, which utilizes `CleanV2`. However, network traffic analysis via mitmproxy showed that the **GOAT O600** completely rejects `CleanV2` commands, resulting in a silent timeout (`No response received for command "clean_V2"`).

When falling back to the standard `Clean` command, the mower's firmware throws a `20003: unknow type` error because it strictly requires the parameter `"content": {"type": "auto"}` inside the payload data block to successfully trigger.

### Solution:
1. Removed the symlink for `6n9pcz.py` to create an isolated profile, ensuring no breaking changes or regressions occur for other devices sharing `9bts2s.py`.
2. Implemented a dedicated `GoatClean` class that inherits from `Clean` but overrides `_get_args()` to explicitly inject `{"type": "auto"}` when the `START` action is triggered.

### Verification & Testing:
- Successfully tested directly inside a live Home Assistant container with a physical **GOAT O600 RTK** mower. 
- The integration now initializes flawlessly, and clicking the "Start" button instantly triggers the mowing process without any timeouts or API errors.