### PR TITLE
Add support for Ecovacs T80s Pro (9jc32i)

### DIFF
--- a/deebot_client/hardware/9jc32i.py
+++ b/deebot_client/hardware/9jc32i.py
@@ -154,7 +154,7 @@ def get_device_info() -> StaticDeviceInfo:
                     types=(
                         WorkMode.VACUUM_AND_MOP,
                         WorkMode.VACUUM,
-                        WorkMode.MOP,           # App UI 隐藏但固件实测支持
+                        WorkMode.MOP,
                         WorkMode.MOP_AFTER_VACUUM,
                     ),
                 ),
@@ -258,8 +258,6 @@ def get_device_info() -> StaticDeviceInfo:
                     event=AutoEmptyEvent,
                     get=[GetAutoEmpty()],
                     set=SetAutoEmpty,
-                    # App shows "标准" / "高频"; actual JSON values need packet-capture
-                    # verification. AUTO / SMART are the closest existing enum values.
                     types=(
                         auto_empty.Frequency.AUTO,
                         auto_empty.Frequency.SMART,

--- a/deebot_client/hardware/9jc32i.py
+++ b/deebot_client/hardware/9jc32i.py
@@ -1,0 +1,288 @@
+"""Deebot DEEBOT T80s Pro Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityExecuteTypes,
+    CapabilityLifeSpan,
+    CapabilityMap,
+    CapabilityNumber,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStation,
+    CapabilityStats,
+    CapabilityWater,
+    DeviceType,
+)
+from deebot_client.commands import StationAction
+from deebot_client.commands.json import station_action
+from deebot_client.commands.json.auto_empty import GetAutoEmpty, SetAutoEmpty
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.carpet import (
+    GetCarpetAutoFanBoost,
+    SetCarpetAutoFanBoost,
+)
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
+from deebot_client.commands.json.clean import (
+    CleanAreaV2,
+    CleanV2,
+    GetCleanInfoV2,
+)
+from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
+from deebot_client.commands.json.clean_logs import GetCleanLogs
+from deebot_client.commands.json.clean_preference import (
+    GetCleanPreference,
+    SetCleanPreference,
+)
+from deebot_client.commands.json.continuous_cleaning import (
+    GetContinuousCleaning,
+    SetContinuousCleaning,
+)
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import (
+    GetCachedMapInfo,
+    GetMajorMap,
+    GetMapInfoV2,
+    GetMapSetV2,
+    GetMapTrace,
+    GetMinorMap,
+    SetMajorMap,
+)
+from deebot_client.commands.json.multimap_state import (
+    GetMultimapState,
+    SetMultimapState,
+)
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.ota import GetOta, SetOta
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
+from deebot_client.commands.json.relocation import SetRelocationState
+from deebot_client.commands.json.station_state import GetStationState
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.sweep_mode import GetSweepMode, SetSweepMode
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.voice_assistant_state import (
+    GetVoiceAssistantState,
+    SetVoiceAssistantState,
+)
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.commands.json.work_mode import GetWorkMode, SetWorkMode
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AvailabilityEvent,
+    BatteryEvent,
+    CachedMapInfoEvent,
+    CarpetAutoFanBoostEvent,
+    ChildLockEvent,
+    CleanCountEvent,
+    CleanLogEvent,
+    CleanPreferenceEvent,
+    ContinuousCleaningEvent,
+    CustomCommandEvent,
+    ErrorEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    LifeSpan,
+    LifeSpanEvent,
+    MajorMapEvent,
+    MapChangedEvent,
+    MapTraceEvent,
+    MultimapStateEvent,
+    NetworkInfoEvent,
+    OtaEvent,
+    PositionsEvent,
+    ReportStatsEvent,
+    RoomsEvent,
+    StateEvent,
+    StationEvent,
+    StatsEvent,
+    SweepModeEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VoiceAssistantStateEvent,
+    VolumeEvent,
+    WorkMode,
+    WorkModeEvent,
+    auto_empty,
+    water_info,
+)
+from deebot_client.events.auto_empty import AutoEmptyEvent
+from deebot_client.models import StaticDeviceInfo
+
+
+def get_device_info() -> StaticDeviceInfo:
+    """Get device info for this model."""
+    return StaticDeviceInfo(
+        DataType.JSON,
+        Capabilities(
+            device_type=DeviceType.VACUUM,
+            availability=CapabilityEvent(
+                AvailabilityEvent, [GetBattery(is_available_check=True)]
+            ),
+            battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+            charge=CapabilityExecute(Charge),
+            clean=CapabilityClean(
+                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaV2),
+                continuous=CapabilitySetEnable(
+                    ContinuousCleaningEvent,
+                    [GetContinuousCleaning()],
+                    SetContinuousCleaning,
+                ),
+                count=CapabilitySet(CleanCountEvent, [GetCleanCount()], SetCleanCount),
+                log=CapabilityEvent(CleanLogEvent, [GetCleanLogs()]),
+                preference=CapabilitySetEnable(
+                    CleanPreferenceEvent, [GetCleanPreference()], SetCleanPreference
+                ),
+                work_mode=CapabilitySetTypes(
+                    event=WorkModeEvent,
+                    get=[GetWorkMode()],
+                    set=SetWorkMode,
+                    types=(
+                        WorkMode.VACUUM_AND_MOP,
+                        WorkMode.VACUUM,
+                        WorkMode.MOP,           # App UI 隐藏但固件实测支持
+                        WorkMode.MOP_AFTER_VACUUM,
+                    ),
+                ),
+            ),
+            custom=CapabilityCustomCommand(
+                event=CustomCommandEvent, get=[], set=CustomCommand
+            ),
+            error=CapabilityEvent(ErrorEvent, [GetError()]),
+            fan_speed=CapabilitySetTypes(
+                event=FanSpeedEvent,
+                get=[GetFanSpeed()],
+                set=SetFanSpeed,
+                types=(
+                    FanSpeedLevel.QUIET,
+                    FanSpeedLevel.NORMAL,
+                    FanSpeedLevel.MAX,
+                    FanSpeedLevel.MAX_PLUS,
+                ),
+            ),
+            life_span=CapabilityLifeSpan(
+                types=(
+                    LifeSpan.FILTER,
+                    LifeSpan.ROUND_MOP,
+                    LifeSpan.SIDE_BRUSH,
+                    LifeSpan.BRUSH,
+                    LifeSpan.DUST_BAG,
+                    LifeSpan.CLEANING_SOLUTION,
+                    LifeSpan.UNIT_CARE,
+                    LifeSpan.SEWAGE_BOX,
+                    LifeSpan.WATER_SINK,
+                ),
+                event=LifeSpanEvent,
+                get=[
+                    GetLifeSpan(
+                        [
+                            LifeSpan.FILTER,
+                            LifeSpan.ROUND_MOP,
+                            LifeSpan.SIDE_BRUSH,
+                            LifeSpan.BRUSH,
+                            LifeSpan.DUST_BAG,
+                            LifeSpan.CLEANING_SOLUTION,
+                            LifeSpan.UNIT_CARE,
+                            LifeSpan.SEWAGE_BOX,
+                            LifeSpan.WATER_SINK,
+                        ]
+                    )
+                ],
+                reset=ResetLifeSpan,
+            ),
+            map=CapabilityMap(
+                cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo()]),
+                changed=CapabilityEvent(MapChangedEvent, []),
+                info=CapabilityExecute(GetMapInfoV2),
+                major=CapabilitySet(MajorMapEvent, [GetMajorMap()], SetMajorMap),
+                minor=CapabilityExecute(GetMinorMap),
+                multi_state=CapabilitySetEnable(
+                    MultimapStateEvent, [GetMultimapState()], SetMultimapState
+                ),
+                position=CapabilityEvent(PositionsEvent, [GetPos()]),
+                relocation=CapabilityExecute(SetRelocationState),
+                rooms=CapabilityEvent(RoomsEvent, [GetCachedMapInfo()]),
+                set=CapabilityExecute(GetMapSetV2),
+                trace=CapabilityEvent(MapTraceEvent, [GetMapTrace()]),
+            ),
+            network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+            play_sound=CapabilityExecute(PlaySound),
+            settings=CapabilitySettings(
+                carpet_auto_fan_boost=CapabilitySetEnable(
+                    CarpetAutoFanBoostEvent,
+                    [GetCarpetAutoFanBoost()],
+                    SetCarpetAutoFanBoost,
+                ),
+                child_lock=CapabilitySetEnable(
+                    ChildLockEvent, [GetChildLock()], SetChildLock
+                ),
+                ota=CapabilitySetEnable(OtaEvent, [GetOta()], SetOta),
+                sweep_mode=CapabilitySetEnable(
+                    SweepModeEvent, [GetSweepMode()], SetSweepMode
+                ),
+                true_detect=CapabilitySetEnable(
+                    TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+                ),
+                voice_assistant=CapabilitySetEnable(
+                    VoiceAssistantStateEvent,
+                    [GetVoiceAssistantState()],
+                    SetVoiceAssistantState,
+                ),
+                volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+            ),
+            state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfoV2()]),
+            station=CapabilityStation(
+                action=CapabilityExecuteTypes(
+                    station_action.StationAction,
+                    types=(
+                        StationAction.EMPTY_DUSTBIN,
+                        StationAction.WASH_MOP,
+                        StationAction.DRY_MOP,
+                    ),
+                ),
+                auto_empty=CapabilitySetTypes(
+                    event=AutoEmptyEvent,
+                    get=[GetAutoEmpty()],
+                    set=SetAutoEmpty,
+                    # App shows "标准" / "高频"; actual JSON values need packet-capture
+                    # verification. AUTO / SMART are the closest existing enum values.
+                    types=(
+                        auto_empty.Frequency.AUTO,
+                        auto_empty.Frequency.SMART,
+                    ),
+                ),
+                state=CapabilityEvent(StationEvent, [GetStationState()]),
+            ),
+            stats=CapabilityStats(
+                clean=CapabilityEvent(StatsEvent, [GetStats()]),
+                report=CapabilityEvent(ReportStatsEvent, []),
+                total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+            ),
+            water=CapabilityWater(
+                amount=CapabilityNumber(
+                    event=water_info.WaterCustomAmountEvent,
+                    get=[GetWaterInfo()],
+                    set=lambda custom_amount: SetWaterInfo(custom_amount=custom_amount),
+                    min=1,
+                    max=50,
+                ),
+                mop_attached=CapabilityEvent(
+                    water_info.MopAttachedEvent, [GetWaterInfo()]
+                ),
+            ),
+        ),
+    )


### PR DESCRIPTION
## Summary
Adds hardware capabilities for the Ecovacs DEEBOT T80s Pro (device class `9jc32i`).

## Device Information
- **Model**: Ecovacs DEEBOT T80s Pro
- **Device Class**: `9jc32i`
- **Firmware**: 1.51.0

## Supported Capabilities
- **Cleaning**: `CleanV2` / `CleanAreaV2` with 4 work modes (vacuum, mop, vacuum+mop, mop-only)
- **Fan speed**: 4 levels (silent / standard / strong / max)
- **Water amount**: continuous 1–50 (`customAmount`)
- **Clean count**: 1× / 2×
- **Station actions**: dust collection, mop wash, mop dry
- **Auto empty**: standard / smart frequency
- **Life span**: 9 components (brush, filter, side brush, round mop, dust bag,
  cleaning solution, unit care, sewage box, water sink)
- **Map**: V2 protocol (major map, map set, map trace)
- **Other**: volume, child lock, AIVI, voice assistant, continuous cleaning, etc.

## Notes
- `getCleanInfoV2` returns `rcp not support`; device pushes state via MQTT instead.
- `getMapSubSet` returns `rcp not support`; custom zone editing not available.
- Work mode 2 (mop-only) is supported by firmware but not exposed in the official app.