### PR TITLE
fix(auth): update Ecovacs login client version

### DIFF
--- a/deebot_client/authentication.py
+++ b/deebot_client/authentication.py
@@ -39,7 +39,7 @@ _GLOBAL_AUTHCODE_PATH = "/v1/global/auth/getAuthCode"
 _META = {
     "lang": "EN",
     "appCode": "global_e",
-    "appVersion": "1.6.3",
+    "appVersion": "3.14.0",
     "channel": "google_play",
     "deviceType": "1",
 }

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,19 +1,82 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from deebot_client.authentication import Authenticator, create_rest_config
+from deebot_client.authentication import (
+    Authenticator,
+    RestConfiguration,
+    _AuthClient,
+    create_rest_config,
+)
 from deebot_client.models import Credentials
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
 
-    from deebot_client.authentication import RestConfiguration
+
+async def test_login_uses_current_app_version_in_url_and_signature() -> None:
+    config = RestConfiguration(
+        session=cast("ClientSession", AsyncMock()),
+        device_id="test-device",
+        country="IT",
+        portal_url="https://portal.example",
+        login_url="https://login.example",
+        auth_code_url="https://auth.example",
+    )
+    auth_client = _AuthClient(config, "test-account", "test-password-hash")
+    timestamp = 1_700_000_000.125
+
+    with (
+        patch("deebot_client.authentication.time.time", return_value=timestamp),
+        patch.object(
+            auth_client, "_AuthClient__do_auth_response", new_callable=AsyncMock
+        ) as response_mock,
+    ):
+        await auth_client._AuthClient__call_login_api(  # type: ignore[attr-defined]
+            "test-account", "test-password-hash"
+        )
+
+    call_args = response_mock.await_args
+    assert call_args is not None
+    url, params = call_args.args
+    expected_sign_data = {
+        "account": "test-account",
+        "appCode": "global_e",
+        "appVersion": "3.14.0",
+        "authTimespan": int(timestamp * 1000),
+        "authTimeZone": "GMT-8",
+        "channel": "google_play",
+        "country": "it",
+        "deviceId": "test-device",
+        "deviceType": "1",
+        "lang": "EN",
+        "password": "test-password-hash",
+        "requestId": hashlib.md5(
+            str(timestamp).encode(), usedforsecurity=False
+        ).hexdigest(),
+    }
+    sign_on_text = (
+        "1520391301804"
+        + "".join(
+            f"{key}={expected_sign_data[key]}" for key in sorted(expected_sign_data)
+        )
+        + "6c319b2a5cd3e66e39159c2e28f2fce9"
+    )
+    expected_auth_sign = hashlib.md5(
+        sign_on_text.encode(), usedforsecurity=False
+    ).hexdigest()
+
+    assert url == (
+        "https://login.example/v1/private/it/EN/test-device/"
+        "global_e/3.14.0/google_play/1/user/login"
+    )
+    assert params["authSign"] == expected_auth_sign
 
 
 async def test_authenticator_authenticate(rest_config: RestConfiguration) -> None:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -17,66 +17,78 @@ from deebot_client.authentication import (
 from deebot_client.models import Credentials
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from aiohttp import ClientSession
 
 
-async def test_login_uses_current_app_version_in_url_and_signature() -> None:
-    config = RestConfiguration(
-        session=cast("ClientSession", AsyncMock()),
+@pytest.mark.parametrize(
+    ("country", "expected_host", "expected_path"),
+    [
+        pytest.param(
+            "IT",
+            "gl-it-api.ecovacs.com",
+            "/v1/private/it/EN/test-device/global_e/3.14.0/google_play/1/user/login",
+            id="global",
+        ),
+        pytest.param(
+            "CN",
+            "gl-cn-api.ecovacs.cn",
+            "/v1/private/cn/EN/test-device/global_e/3.14.0/google_play/1/user/loginCheckMobile",
+            id="china",
+        ),
+    ],
+)
+async def test_ecovacs_home_3_14_0_app_metadata_is_used_for_login(
+    session: ClientSession,
+    country: str,
+    expected_host: str,
+    expected_path: str,
+) -> None:
+    config = create_rest_config(
+        session,
         device_id="test-device",
-        country="IT",
-        portal_url="https://portal.example",
-        login_url="https://login.example",
-        auth_code_url="https://auth.example",
+        alpha_2_country=country,
     )
-    auth_client = _AuthClient(config, "test-account", "test-password-hash")
-    timestamp = 1_700_000_000.125
+    captured_sign_metadata: list[Mapping[str, str | int]] = []
+
+    def capture_sign_metadata(
+        params: dict[str, str | int],
+        additional_sign_params: Mapping[str, str | int],
+        *_signing_material: str,
+    ) -> dict[str, str | int]:
+        captured_sign_metadata.append(additional_sign_params)
+        return params
 
     with (
-        patch("deebot_client.authentication.time.time", return_value=timestamp),
         patch.object(
-            auth_client, "_AuthClient__do_auth_response", new_callable=AsyncMock
-        ) as response_mock,
+            session,
+            "get",
+            side_effect=RuntimeError("login request captured"),
+        ) as get_mock,
+        patch.object(
+            _AuthClient,
+            "_AuthClient__sign",
+            new=staticmethod(capture_sign_metadata),
+        ),
+        patch("deebot_client.authentication.time.time", return_value=1_700_000_000),
     ):
-        await auth_client._AuthClient__call_login_api(  # type: ignore[attr-defined]
-            "test-account", "test-password-hash"
-        )
+        authenticator = Authenticator(config, "test-account", "test-password-hash")
+        with pytest.raises(RuntimeError, match="login request captured"):
+            await authenticator.authenticate()
 
-    call_args = response_mock.await_args
-    assert call_args is not None
-    url, params = call_args.args
-    expected_sign_data = {
-        "account": "test-account",
+    login_url = urlsplit(get_mock.call_args_list[0].args[0])
+    assert login_url.netloc == expected_host
+    assert login_url.path == expected_path
+    assert {
+        "lang": "EN",
         "appCode": "global_e",
         "appVersion": "3.14.0",
-        "authTimespan": int(timestamp * 1000),
-        "authTimeZone": "GMT-8",
         "channel": "google_play",
-        "country": "it",
-        "deviceId": "test-device",
         "deviceType": "1",
-        "lang": "EN",
-        "password": "test-password-hash",
-        "requestId": hashlib.md5(
-            str(timestamp).encode(), usedforsecurity=False
-        ).hexdigest(),
-    }
-    sign_on_text = (
-        "1520391301804"
-        + "".join(
-            f"{key}={expected_sign_data[key]}" for key in sorted(expected_sign_data)
-        )
-        + "6c319b2a5cd3e66e39159c2e28f2fce9"
-    )
-    expected_auth_sign = hashlib.md5(
-        sign_on_text.encode(), usedforsecurity=False
-    ).hexdigest()
-
-    assert url == (
-        "https://login.example/v1/private/it/EN/test-device/"
-        "global_e/3.14.0/google_play/1/user/login"
-    )
-    assert params["authSign"] == expected_auth_sign
+        "country": country.lower(),
+        "deviceId": "test-device",
+    }.items() <= captured_sign_metadata[0].items()
 
 
 async def test_authenticator_authenticate(rest_config: RestConfiguration) -> None:


### PR DESCRIPTION
## Summary
- update the Ecovacs login client metadata from `1.6.3` to `3.14.0`
- cover the configured app metadata in the login URL and signing inputs for both global and China (`CheckMobile`) routes

Ecovacs began rejecting the old client metadata with authentication error `1013` (`Please update to the latest version to continue.`).

## Metadata evidence
Current ECOVACS HOME Android package `com.eco.global.app` is listed as version **3.14.0** (build 137) by:
- [Google Play](https://play.google.com/store/apps/details?id=com.eco.global.app)
- [APKPure version history](https://apkpure.net/ecovacs-home/com.eco.global.app/versions)

The unit tests verify request construction; they cannot prove the vendor accepts this metadata. Live login confirmation is still needed from a maintainer/user account, without publishing credentials or tokens.

Fixes #1702.

## Verification
- `uv run pytest tests/test_authentication.py` → 7 passed
- `uv run ruff check deebot_client/authentication.py tests/test_authentication.py`
- `uv run ruff format --check deebot_client/authentication.py tests/test_authentication.py`
- `uv run mypy deebot_client/authentication.py tests/test_authentication.py`

No account credentials, tokens, or device-specific data are included.