### PR TITLE
fix: use freeClean for T90 PRO OMNI room cleaning

### DIFF
--- a/deebot_client/hardware/twunby.py
+++ b/deebot_client/hardware/twunby.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from deebot_client.capabilities import (
     Capabilities,
     CapabilityClean,
@@ -30,8 +32,8 @@ from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
 from deebot_client.commands.json.clean import (
-    Clean,
-    CleanArea,
+    CleanAreaV2,
+    CleanV2,
 )
 from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
 from deebot_client.commands.json.clean_logs import GetCleanLogs
@@ -106,7 +108,17 @@ from deebot_client.events import (
 )
 from deebot_client.events.auto_empty import AutoEmptyEvent
 from deebot_client.events.mop_auto_wash_frequency import MopAutoWashFrequencyEvent
-from deebot_client.models import StaticDeviceInfo
+from deebot_client.models import CleanMode, StaticDeviceInfo
+
+if TYPE_CHECKING:
+    from deebot_client.command import Command
+
+
+def _get_free_clean_area(
+    _mode: CleanMode, area: list[int | float], cleanings: int = 1
+) -> Command:
+    """Clean selected T90 rooms using the V2 freeClean command shape."""
+    return CleanAreaV2(CleanMode.FREE_CLEAN, area, cleanings)
 
 
 def get_device_info() -> StaticDeviceInfo:
@@ -121,7 +133,10 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=Clean, area=CleanArea),
+                action=CapabilityCleanAction(
+                    command=CleanV2,
+                    area=_get_free_clean_area,
+                ),
                 continuous=CapabilitySetEnable(
                     ContinuousCleaningEvent,
                     [GetContinuousCleaning()],

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -17,7 +17,12 @@ from deebot_client.commands.json.border_switch import GetBorderSwitch
 from deebot_client.commands.json.carpet import GetCarpetAutoFanBoost
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock
-from deebot_client.commands.json.clean import GetCleanInfo, GetCleanInfoV2
+from deebot_client.commands.json.clean import (
+    CleanAreaV2,
+    CleanV2,
+    GetCleanInfo,
+    GetCleanInfoV2,
+)
 from deebot_client.commands.json.clean_count import GetCleanCount
 from deebot_client.commands.json.clean_logs import GetCleanLogs
 from deebot_client.commands.json.clean_preference import GetCleanPreference
@@ -86,7 +91,7 @@ from deebot_client.events.map import (
 from deebot_client.events.network import NetworkInfoEvent
 from deebot_client.events.water_info import MopAttachedEvent, WaterAmountEvent
 from deebot_client.hardware.yna5xi import get_device_info as get_yna5xi_info
-from deebot_client.models import StaticDeviceInfo
+from deebot_client.models import CleanMode, StaticDeviceInfo
 
 if TYPE_CHECKING:
     from deebot_client.command import Command
@@ -277,3 +282,21 @@ async def test_all_models_loaded() -> None:
         assert isinstance(device_info, StaticDeviceInfo), (
             f"Failed to load device info for {module_name}"
         )
+
+
+async def test_twunby_uses_free_clean_for_room_cleaning() -> None:
+    """Test T90 PRO OMNI serializes room clean commands as freeClean."""
+    info = await hardware.get_static_device_info("twunby")
+    assert info is not None
+
+    capabilities = info.capabilities
+    assert capabilities.clean.action.command is CleanV2
+    assert capabilities.clean.action.area is not None
+
+    area_command = capabilities.clean.action.area(CleanMode.SPOT_AREA, [5], 1)
+    assert isinstance(area_command, CleanAreaV2)
+    assert area_command.NAME == "clean_V2"
+    assert area_command._args == {
+        "act": "start",
+        "content": {"type": "freeClean", "value": "1,5"},
+    }


### PR DESCRIPTION
This PR now contains only the remaining T90 PRO OMNI room-clean command fix.

Map support and the 12-field T90 room parser were merged independently in #1757, so this branch has been rebased onto current dev and deliberately drops the overlapping map/capability work.

The remaining change makes T90 room cleaning serialize through clean_V2 with content.type = freeClean, which is the command shape verified against a real T90 PRO OMNI.

Validation:
- focused freeClean payload regression test
- Ruff and mypy on changed files
- full suite: 751 passed; 4 snapshots passed