### PR TITLE
Renew portal credentials from stored account credentials without password

### DIFF
--- a/deebot_client/authentication.py
+++ b/deebot_client/authentication.py
@@ -25,7 +25,7 @@ from .exceptions import (
     InvalidVerificationCodeError,
 )
 from .logging_filter import get_logger
-from .models import Credentials
+from .models import AccountCredentials, Credentials
 from .util import cancel, create_task, md5
 from .util.continents import get_continent_url_postfix
 from .util.countries import get_ecovacs_country
@@ -107,10 +107,13 @@ class _AuthClient:
         config: RestConfiguration,
         account_id: str,
         password_hash: str,
+        *,
+        on_account_credentials: Callable[[AccountCredentials], None] | None = None,
     ) -> None:
         self._config = config
         self._account_id = account_id
         self._password_hash = password_hash
+        self._on_account_credentials = on_account_credentials
 
         self._meta: dict[str, str] = {
             **_META,
@@ -161,12 +164,20 @@ class _AuthClient:
         """Complete login using the Ecovacs user credentials of the response."""
         data = self.__expect_dict(response, error)
         try:
-            user_id = str(data["uid"])
-            access_token = str(data["accessToken"])
+            account = AccountCredentials(
+                access_token=str(data["accessToken"]), user_id=str(data["uid"])
+            )
         except KeyError as ex:
             raise AuthenticationError(error) from ex
 
-        auth_code = await self.__call_auth_api(access_token, user_id)
+        if self._on_account_credentials is not None:
+            self._on_account_credentials(account)
+        return await self.login_with_account(account)
+
+    async def login_with_account(self, account: AccountCredentials) -> Credentials:
+        """Mint portal credentials from account credentials, without the password."""
+        user_id = account.user_id
+        auth_code = await self.__call_auth_api(account.access_token, user_id)
 
         login_token_resp = await self.__call_login_by_it_token(user_id, auth_code)
         if login_token_resp["userId"] != user_id:
@@ -472,31 +483,61 @@ class Authenticator:
         config: RestConfiguration,
         account_id: str,
         password_hash: str,
+        *,
+        account_credentials: AccountCredentials | None = None,
     ) -> None:
         self._auth_client = _AuthClient(
             config,
             account_id,
             password_hash,
+            on_account_credentials=self._set_account_credentials,
         )
 
         self._lock = asyncio.Lock()
         self._on_credentials_changed: set[
             Callable[[Credentials], Coroutine[Any, Any, None]]
         ] = set()
+        self._on_account_credentials_changed: set[
+            Callable[[AccountCredentials], Coroutine[Any, Any, None]]
+        ] = set()
         self._credentials: Credentials | None = None
+        self._account_credentials = account_credentials
         self._refresh_handle: asyncio.TimerHandle | None = None
         self._tasks: set[asyncio.Future[Any]] = set()
+
+    @property
+    def account_credentials(self) -> AccountCredentials | None:
+        """Return the account credentials, if some are known."""
+        return self._account_credentials
 
     async def authenticate(self, *, force: bool = False) -> Credentials:
         """Authenticate on ecovacs servers."""
         async with self._lock:
             credentials = self._credentials
             if credentials is None or force or credentials.expires_at < time.time():
-                _LOGGER.debug("Performing login")
-                credentials = await self._auth_client.login()
+                credentials = await self._login()
                 self._set_credentials(credentials)
 
             return credentials
+
+    async def _login(self) -> Credentials:
+        """Login, preferring the password-free token based renewal.
+
+        The password login endpoint rejects some accounts with code 1013
+        ("Please update to the latest version to continue"), while portal
+        credentials can still be minted from the stored account credentials.
+        """
+        if (account := self._account_credentials) is not None:
+            _LOGGER.debug("Performing token based login")
+            try:
+                return await self._auth_client.login_with_account(account)
+            except AuthenticationError:
+                _LOGGER.debug(
+                    "Token based login failed, falling back to password login",
+                    exc_info=True,
+                )
+        _LOGGER.debug("Performing login")
+        return await self._auth_client.login()
 
     async def request_device_verification_code(self) -> None:
         """Request a one-time email code to verify the configured device ID."""
@@ -518,6 +559,15 @@ class Authenticator:
         for on_changed in self._on_credentials_changed:
             create_task(self._tasks, on_changed(credentials))
 
+    def _set_account_credentials(self, account: AccountCredentials) -> None:
+        """Store account credentials received during a login."""
+        if account == self._account_credentials:
+            return
+        self._account_credentials = account
+
+        for on_account_changed in self._on_account_credentials_changed:
+            create_task(self._tasks, on_account_changed(account))
+
     def subscribe(
         self, callback: Callable[[Credentials], Coroutine[Any, Any, None]]
     ) -> Callable[[], None]:
@@ -527,6 +577,17 @@ class Authenticator:
             self._on_credentials_changed.remove(callback)
 
         self._on_credentials_changed.add(callback)
+        return unsubscribe
+
+    def subscribe_account_credentials(
+        self, callback: Callable[[AccountCredentials], Coroutine[Any, Any, None]]
+    ) -> Callable[[], None]:
+        """Add callback on new account credentials and return unsubscribe callback."""
+
+        def unsubscribe() -> None:
+            self._on_account_credentials_changed.remove(callback)
+
+        self._on_account_credentials_changed.add(callback)
         return unsubscribe
 
     async def post_authenticated(

--- a/deebot_client/models.py
+++ b/deebot_client/models.py
@@ -91,3 +91,14 @@ class Credentials:
     token: str
     user_id: str
     expires_at: int = 0
+
+
+@dataclass(frozen=True)
+class AccountCredentials:
+    """Account credentials as returned by the login or device verification api.
+
+    The access token can mint new portal credentials without the password.
+    """
+
+    access_token: str
+    user_id: str

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -22,7 +22,7 @@ from deebot_client.exceptions import (
     InvalidAuthenticationError,
     InvalidVerificationCodeError,
 )
-from deebot_client.models import Credentials
+from deebot_client.models import AccountCredentials, Credentials
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -499,3 +499,80 @@ async def test_request_device_verification_skips_invalid_duplicate_config(
     await auth.request_device_verification_code()
 
     assert len(api.requests["sendEmailVerifyCode"]) == 1
+
+
+async def test_authenticate_prefers_token_based_renewal(
+    session: ClientSession, api: _FakeEcovacsApi
+) -> None:
+    """A seeded access token mints portal credentials without a password login."""
+    authenticator = Authenticator(
+        create_rest_config(
+            session=session,
+            device_id=_DEVICE_ID,
+            alpha_2_country="US",
+            override_rest_url=api.url,
+        ),
+        _ACCOUNT_ID,
+        _PASSWORD_HASH,
+        account_credentials=AccountCredentials(
+            access_token="access-token",  # noqa: S106
+            user_id="user-id",
+        ),
+    )
+    try:
+        credentials = await authenticator.authenticate()
+
+        assert credentials.token == "portal-token"  # noqa: S105
+        assert credentials.user_id == "user-id"
+        assert "login" not in api.requests
+        assert api.requests["getAuthCode"][0].query["accessToken"] == "access-token"
+        assert api.requests["user.do"][0].json is not None
+    finally:
+        await authenticator.teardown()
+
+
+async def test_authenticate_falls_back_to_password_login(
+    rest_config: RestConfiguration,
+) -> None:
+    """An expired access token falls back to the password login."""
+    with patch("deebot_client.authentication._AuthClient", spec_set=True) as api_client:
+        login_with_account_mock: AsyncMock = api_client.return_value.login_with_account
+        login_with_account_mock.side_effect = AuthenticationError("token expired")
+        login_mock: AsyncMock = api_client.return_value.login
+        login_mock.return_value = Credentials(
+            "token", "user_id", int(time.time() + 123456789)
+        )
+        account = AccountCredentials(access_token="expired", user_id="user_id")  # noqa: S106
+        authenticator = Authenticator(
+            rest_config, "test", "test", account_credentials=account
+        )
+
+        assert (await authenticator.authenticate()) == login_mock.return_value
+        login_with_account_mock.assert_awaited_once_with(account)
+        login_mock.assert_awaited_once()
+
+
+async def test_login_stores_and_notifies_account_credentials(
+    auth: Authenticator,
+) -> None:
+    """A password login stores the account credentials and notifies subscribers."""
+    changed: asyncio.Queue[AccountCredentials] = asyncio.Queue()
+    auth.subscribe_account_credentials(changed.put)
+    assert auth.account_credentials is None
+
+    await auth.authenticate()
+
+    account = AccountCredentials(access_token="access-token", user_id="user-id")  # noqa: S106
+    assert auth.account_credentials == account
+    async with asyncio.timeout(0.1):
+        assert await changed.get() == account
+
+
+async def test_verify_device_stores_account_credentials(auth: Authenticator) -> None:
+    """A device verification stores the account credentials for later renewals."""
+    await auth.verify_device("123456")
+
+    assert auth.account_credentials == AccountCredentials(
+        access_token="access-token",  # noqa: S106
+        user_id="user-id",
+    )


### PR DESCRIPTION
## Problem

The password login endpoint (`user/login`) rejects some accounts with code **1013 "Please update to the latest version to continue"**, even on the current `appVersion` and **even for a verified device ID** (see the UK data point in #1705). The device-verification flow added in #1706 authenticates fine end-to-end, but:

- On the next `Authenticator` instance (e.g. Home Assistant reloading the config entry right after the flow), `authenticate()` starts from scratch with the password login → 1013 → `DeviceVerificationRequiredError` → the consumer immediately asks for verification again. This is the reauth loop reported in home-assistant/core#177870 (verification succeeds, setup fails a second later).
- Even within one instance, the scheduled refresh re-runs the full password `login()`, so affected accounts fall back into needing an email code roughly weekly.

## Fix

The `uid` + `accessToken` returned by both `user/login` and `user/verifyDevice` can mint fresh portal credentials via `getAuthCode` + `loginByItToken` — neither call needs the password (confirmed working well after verification in the #1705 thread).

- New frozen dataclass `AccountCredentials` (`access_token`, `user_id`).
- `_AuthClient.login_with_account()`: mints portal credentials from account credentials (extracted from the tail of `__complete_login`).
- `Authenticator` stores the account credentials whenever a login/verification returns them, prefers the password-free renewal in `authenticate()`, and falls back to the password login if it fails.
- `Authenticator(account_credentials=...)` seed + `account_credentials` property + `subscribe_account_credentials()`, so consumers (the Home Assistant integration) can persist them across restarts and reloads.

Behavior is unchanged for accounts where the password login still works: first-ever login uses the password, everything after prefers the token path.

**Persisting `account_credentials` across restarts is not enough on its own** -- the consumer's `device_id` (passed into `RestConfiguration`/`create_rest_config()`) must also stay the same one used when those credentials were obtained. If a consumer generates a fresh random `device_id` on every restart, `loginByItToken` fails with a *different* error (`0004`, "user login expired") that gives no hint device_id is the cause -- confirmed by [@ivanx519](https://github.com/DeebotUniverse/client.py/pull/1743#issuecomment-5457632179) below. This isn't new behavior from this PR (device_id has always had to be stable for the account to work at all), but it's easy to hit for the first time here since token-based renewal is what finally makes restarts survive without a password/email code.

## Testing

- 4 new tests: token-based renewal skips `user/login`, fallback to password login, account credentials stored + subscribers notified on login and on device verification.
- `pytest tests/test_authentication.py`: 37 passed. `mypy deebot_client/`: clean. `ruff check`/`format`: no new findings.

Fixes the renewal half of #1705; a follow-up in home-assistant/core will seed the authenticator from the config entry to close home-assistant/core#177870.

