### PR TITLE
fix(ilt3k8): use freeClean V2 area command for DEEBOT X9 PRO OMNI

### DIFF
--- a/deebot_client/hardware/ilt3k8.py
+++ b/deebot_client/hardware/ilt3k8.py
@@ -127,8 +127,17 @@ from deebot_client.models import StaticDeviceInfo, CleanMode
 def _get_free_clean_area(
     _mode: CleanMode, area: list[int | float], cleanings: int = 1
 ) -> Command:
-    """Clean selected X9 PRO OMNI rooms using the V2 freeClean command shape."""
-    return CleanAreaV2(CleanMode.FREE_CLEAN, area, cleanings)
+    """Clean selected X9 PRO OMNI rooms using the V2 freeClean command shape.
+
+    NOTE on pass counts: the number of cleaning passes must be set with the
+    separate setCleanCount command (clean.count capability), exactly like the
+    Ecovacs app does. Putting the count inside the freeClean value ("2,3")
+    makes the X9 read "2" as a NON-EXISTENT area id and it fails with
+    "selected area not found". The first value field is a fixed flag, so we
+    always build value = "1,<id1>,<id2>". Tested on a real X9 PRO OMNI:
+    setCleanCount(2) + value="1,3" starts a 2-pass room clean correctly.
+    """
+    return CleanAreaV2(CleanMode.FREE_CLEAN, area, 1)
 
 
 def get_device_info() -> StaticDeviceInfo:

--- a/deebot_client/hardware/ilt3k8.py
+++ b/deebot_client/hardware/ilt3k8.py
@@ -37,7 +37,7 @@ from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
 from deebot_client.commands.json.clean import (
-    CleanArea,
+    CleanAreaV2,
     CleanV2,
 )
 from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
@@ -121,7 +121,14 @@ from deebot_client.events.map import (
     PositionsEvent,
 )
 from deebot_client.events.mop_auto_wash_frequency import MopAutoWashFrequencyEvent
-from deebot_client.models import StaticDeviceInfo
+from deebot_client.models import StaticDeviceInfo, CleanMode
+
+
+def _get_free_clean_area(
+    _mode: CleanMode, area: list[int | float], cleanings: int = 1
+) -> Command:
+    """Clean selected X9 PRO OMNI rooms using the V2 freeClean command shape."""
+    return CleanAreaV2(CleanMode.FREE_CLEAN, area, cleanings)
 
 
 def get_device_info() -> StaticDeviceInfo:
@@ -136,7 +143,7 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=CleanV2, area=CleanArea),
+                action=CapabilityCleanAction(command=CleanV2, area=_get_free_clean_area),
                 continuous=CapabilitySetEnable(
                     ContinuousCleaningEvent,
                     [GetContinuousCleaning()],


### PR DESCRIPTION
## Summary

The DEEBOT X9 PRO OMNI (`ilt3k8`) rejects the legacy area clean command with `20003: rcp not support` (see #1477). The profile already used `CleanV2` for the base action, but area cleaning still used the legacy `CleanArea` command (`clean` + `spotArea`).

This PR switches the area capability to the V2 **freeClean** command shape, mirroring the approach already validated for the T90 PRO OMNI (PR #1710).

### Pass-count fix (commit 2)

The X9 reads the **first** freeClean value field as an *area id*, not as the pass count:
- `value="2,3"` fails with `selected area not found` (area `2` does not exist)
- `value="1,3"` used to start only by accident, because `1` happens to be the bathroom area id

Pass count must be set with the separate `setCleanCount` command (`clean.count` capability), exactly like the Ecovacs app does. The freeClean value is therefore always built as `"1,<id1>,<id2>"` (first field is a fixed flag).

**Tested on a real X9 PRO OMNI**: `setCleanCount(2)` + `value="1,3"` starts a 2-pass laundry-room clean correctly. The Home Assistant integration should send `setCleanCount(N)` before `spot_area` when `N > 1` (already handled by the ecovacs HA custom component calling `clean.count.set()`).

## Checklist

- [x] Code changes
- [x] Tested on real hardware (DEEBOT X9 PRO OMNI)
- [x] No API changes required
