### PR TITLE
Restore map capability for twunby (T90 PRO OMNI)

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -180,8 +180,6 @@ class CapabilityMap:
     changed: CapabilityEvent[MapChangedEvent]
     clear: CapabilityExecute[[]] | None = None
     info: CapabilityExecute[[str]] | None = None
-    # Newer devices (e.g. T90 PRO OMNI) don't support the major/minor map
-    # commands and send the whole map outline in the MapInfo_V2 message instead.
     major: (
         CapabilityEvent[MajorMapEvent] | CapabilitySet[MajorMapEvent, [str]] | None
     ) = None

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -180,8 +180,12 @@ class CapabilityMap:
     changed: CapabilityEvent[MapChangedEvent]
     clear: CapabilityExecute[[]] | None = None
     info: CapabilityExecute[[str]] | None = None
-    major: CapabilityEvent[MajorMapEvent] | CapabilitySet[MajorMapEvent, [str]]
-    minor: CapabilityExecute[[int, str]]
+    # Newer devices (e.g. T90 PRO OMNI) don't support the major/minor map
+    # commands and send the whole map outline in the MapInfo_V2 message instead.
+    major: (
+        CapabilityEvent[MajorMapEvent] | CapabilitySet[MajorMapEvent, [str]] | None
+    ) = None
+    minor: CapabilityExecute[[int, str]] | None = None
     multi_state: CapabilitySetEnable[MultimapStateEvent] | None = None
     position: CapabilityEvent[PositionsEvent]
     relocation: CapabilityExecute[[]] | None = None

--- a/deebot_client/commands/json/map/__init__.py
+++ b/deebot_client/commands/json/map/__init__.py
@@ -272,10 +272,11 @@ class GetMapSetV2(GetMapSet):
         subsets: list[list[str]],
         map_id: str,
     ) -> HandlingResult:
-        # There are currently two known room subset formats:
+        # There are currently three known room subset formats:
         # - 10 fields: standard V2 format
         # - 11 fields: newer models (e.g. X11) with an extra trailing field
-        if subsets and len(subsets[0]) in (10, 11):
+        # - 12 fields: newer models (e.g. T90 PRO OMNI) with a second extra trailing field
+        if subsets and len(subsets[0]) in (10, 11, 12):
             # subset values
             # 1 -> id
             # 2 -> name
@@ -288,6 +289,7 @@ class GetMapSetV2(GetMapSet):
             # 9 -> unknown
             # 10 -> floor type
             # 11 -> heavy soiled area's flag (1 = Dirty/Heavy Soil, 0 = Standard) (seen on newer models, e.g. X11)
+            # 12 -> unknown (seen on newer models, e.g. T90 PRO OMNI)
 
             # coordinates are sent in the MapInfo_V2 message
             event_bus.notify(

--- a/deebot_client/hardware/twunby.py
+++ b/deebot_client/hardware/twunby.py
@@ -192,10 +192,6 @@ def get_device_info() -> StaticDeviceInfo:
                 ],
                 reset=ResetLifeSpan,
             ),
-            # getMajorMap, getMinorMap and getMapSubSet all return code 20003
-            # ("rcp not support") on this device. The map outline is sent
-            # compressed in the MapInfo_V2 message instead, so major/minor are
-            # omitted.
             map=CapabilityMap(
                 cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo()]),
                 changed=CapabilityEvent(MapChangedEvent, []),

--- a/deebot_client/hardware/twunby.py
+++ b/deebot_client/hardware/twunby.py
@@ -11,6 +11,7 @@ from deebot_client.capabilities import (
     CapabilityExecute,
     CapabilityExecuteTypes,
     CapabilityLifeSpan,
+    CapabilityMap,
     CapabilityNumber,
     CapabilitySet,
     CapabilitySetEnable,
@@ -42,6 +43,12 @@ from deebot_client.commands.json.custom import CustomCommand
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
 from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import (
+    GetCachedMapInfo,
+    GetMapInfoV2,
+    GetMapSetV2,
+    GetMapTrace,
+)
 from deebot_client.commands.json.mop_auto_wash_frequency import (
     GetMopAutoWashFrequency,
     SetMopAutoWashFrequency,
@@ -49,6 +56,8 @@ from deebot_client.commands.json.mop_auto_wash_frequency import (
 from deebot_client.commands.json.network import GetNetInfo
 from deebot_client.commands.json.ota import GetOta, SetOta
 from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
+from deebot_client.commands.json.relocation import SetRelocationState
 from deebot_client.commands.json.stats import GetStats, GetTotalStats
 from deebot_client.commands.json.sweep_mode import GetSweepMode, SetSweepMode
 from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
@@ -64,6 +73,7 @@ from deebot_client.const import DataType
 from deebot_client.events import (
     AvailabilityEvent,
     BatteryEvent,
+    CachedMapInfoEvent,
     ChildLockEvent,
     CleanCountEvent,
     CleanLogEvent,
@@ -74,9 +84,13 @@ from deebot_client.events import (
     FanSpeedLevel,
     LifeSpan,
     LifeSpanEvent,
+    MapChangedEvent,
+    MapTraceEvent,
     NetworkInfoEvent,
     OtaEvent,
+    PositionsEvent,
     ReportStatsEvent,
+    RoomsEvent,
     StateEvent,
     StationEvent,
     StatsEvent,
@@ -177,6 +191,20 @@ def get_device_info() -> StaticDeviceInfo:
                     )
                 ],
                 reset=ResetLifeSpan,
+            ),
+            # getMajorMap, getMinorMap and getMapSubSet all return code 20003
+            # ("rcp not support") on this device. The map outline is sent
+            # compressed in the MapInfo_V2 message instead, so major/minor are
+            # omitted.
+            map=CapabilityMap(
+                cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo()]),
+                changed=CapabilityEvent(MapChangedEvent, []),
+                info=CapabilityExecute(GetMapInfoV2),
+                position=CapabilityEvent(PositionsEvent, [GetPos()]),
+                relocation=CapabilityExecute(SetRelocationState),
+                rooms=CapabilityEvent(RoomsEvent, [GetCachedMapInfo()]),
+                set=CapabilityExecute(GetMapSetV2),
+                trace=CapabilityEvent(MapTraceEvent, [GetMapTrace()]),
             ),
             network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
             play_sound=CapabilityExecute(PlaySound),

--- a/deebot_client/map.py
+++ b/deebot_client/map.py
@@ -88,6 +88,11 @@ class Map:
     # ---------------------------- METHODS ----------------------------
 
     async def _subscribe_minor_major_map_events(self) -> list[Callable[[], None]]:
+        if (minor := self._capabilities.minor) is None:
+            # Device sends the whole map outline in the MapInfo_V2 message and
+            # doesn't support requesting it piece by piece.
+            return []
+
         async def on_major_map(event: MajorMapEvent) -> None:
             async with asyncio.TaskGroup() as tg:
                 for idx, value in enumerate(event.values):
@@ -96,9 +101,7 @@ class Map:
                         and event.requested
                     ):
                         tg.create_task(
-                            self._execute_command(
-                                self._capabilities.minor.execute(idx, event.map_id)
-                            )
+                            self._execute_command(minor.execute(idx, event.map_id))
                         )
 
         async def on_minor_map(event: MinorMapEvent) -> None:
@@ -152,10 +155,13 @@ class Map:
             raise MapError("Please enable the map first")
 
         # TODO make it nice
+        # CachedMapInfoEvent also triggers MapInfo_V2, which carries the map
+        # outline for devices without major/minor map support.
         self._event_bus.request_refresh(CachedMapInfoEvent)
         self._event_bus.request_refresh(PositionsEvent)
         self._event_bus.request_refresh(MapTraceEvent)
-        self._event_bus.request_refresh(MajorMapEvent)
+        if self._capabilities.major is not None:
+            self._event_bus.request_refresh(MajorMapEvent)
 
     def get_svg_map(self) -> str | None:
         """Return map as SVG string."""

--- a/tests/commands/json/map/test_init.py
+++ b/tests/commands/json/map/test_init.py
@@ -517,6 +517,57 @@ async def test_getMapSetV2_rooms_v2_with_extra_fields() -> None:
     )
 
 
+async def test_getMapSetV2_rooms_v2_with_two_extra_fields() -> None:
+    """Test newer room subset format with two extra trailing fields.
+
+    Captured from a DEEBOT T90 PRO OMNI (twunby) on firmware 1.97.0, which
+    reports 12 fields per room and doesn't support getMapSubSet.
+    """
+    mid = "658564180"
+    msid = "2147157086"
+    set_type = MapSetType.ROOMS
+    subsets_comp = (
+        "KLUv/WDzALUGAGJLIBtgR6MOqNpY//lX94si29XwrWSDO9wczCEIAh6GsUkA"
+        "VSgcD1EE7iwVPpcgiBu4r4saJw8yXPd0b0pCcEDc1TInEd3dshwFQyMMLWHm"
+        "Uagty/EOg0bckWHqoFOQFnDPixqmD/dEg+ee1lL3lAzh3dwXJkSY9zx3lzhC"
+        "8p4j7ueiCCAAi0vAyHIADVUXsrN9J9liSRgGS1gM2gKQFRWOIkgYgCJB1dog"
+        "h8tRILgaA1ZjQDGwmRlVgtzCSDiYAQMcuC4kzB8aE+FOUAvUbL8LA4IrRAE="
+    )
+    subsets = [1, 2, 3, 5, 6, 7, 8]
+    rooms_names = [
+        "Corridoio",
+        "Bagno",
+        "Cameretta",
+        "Camera da letto",
+        "Cucina",
+        "Soggiorno",
+        "Ingresso",
+    ]
+    json, firmware_event = get_request_json(
+        get_success_body(
+            {
+                "type": set_type,
+                "mid": mid,
+                "msid": msid,
+                "batid": "felnaf",
+                "subsets": subsets_comp,
+                "infoSize": 499,
+            }
+        )
+    )
+    rooms = [
+        Room(room_name, subset, "")
+        for subset, room_name in zip(subsets, rooms_names, strict=False)
+    ]
+    events = [firmware_event, RoomsEvent(mid, rooms)]
+
+    await assert_command(
+        GetMapSetV2(mid, set_type),
+        json,
+        events,
+    )
+
+
 async def test_getMapTrace() -> None:
     start = 0
     total = 160


### PR DESCRIPTION
## Summary

The map capability was removed from `twunby` in https://github.com/DeebotUniverse/client.py/pull/1648 because `getMajorMap` and `getMapSubSet` answer `20003 "rcp not support"`. Probing a DEEBOT T90 PRO OMNI on firmware `1.97.0` shows the device does support maps — just not through those commands.

| Command | Result |
| --- | --- |
| `getCachedMapInfo` | `code 0` |
| `getMapInfo_V2` | `code 0`, `outlineVer=1` |
| `getMapSet_V2` | `code 0` |
| `getMapTrace` | `code 0` |
| `getPos` | `code 0` |
| `getMajorMap`, `getMajorMap_V2` | `20003` |
| `getMinorMap_V2` | `20003` |
| `getMapSubSet`, `getMapSubSet_V2` | `20003` |
| `getMapInfo_V3` | `20003` |

`getMinorMap` answers `20005 "get minor map fail"` rather than `20003`: the command exists, it just has no major map to derive piece indexes from.

## Root cause

The `getMapSubSet` calls that triggered the removal were only issued because this device reports **12 fields** per room subset — one more than `_handle_rooms_subsets` knew about — so it fell through to the legacy branch that requests every subset individually:

```
['1', 'Corridoio',       '12', '2-3-5-7', '0', '-3825', '6775',  '1-0-2', ' ', '1',   '0', '0']
['2', 'Bagno',           '0',  '1',       '0', '-1625', '8075',  '1-0-2', ' ', '1',   '0', '0']
['3', 'Cameretta',       '0',  '1',       '0', '-1325', '6125',  '1-0-2', ' ', '2-0', '0', '0']
['5', 'Camera da letto', '3',  '1',       '0', '-2325', '10725', '1-0-2', ' ', '2-0', '0', '0']
['6', 'Cucina',          '5',  '7-8',     '0', '-1275', '325',   '1-0-2', ' ', '1',   '1', '0']
['7', 'Soggiorno',       '1',  '1-6-8',   '0', '-725',  '2775',  '1-0-2', ' ', '1',   '0', '0']
['8', 'Ingresso',        '0',  '6-7',     '0', '-4225', '125',   '1-0-2', ' ', '1',   '0', '0']
```

The layout matches the documented 11-field format with one further trailing field, which is `0` for every room on this device. I could not determine its meaning and left it commented as unknown.

With 12 fields accepted, the room coordinates come from the `MapInfo_V2` message exactly as they do for the 10/11 field formats, and no `getMapSubSet` is needed.

## Changes

* `_handle_rooms_subsets` accepts 12-field room subsets.
* `CapabilityMap.major` and `CapabilityMap.minor` become optional: on this device the map outline arrives compressed in `MapInfo_V2` instead of piece by piece.
* `Map` skips the major/minor subscriptions and the `MajorMapEvent` refresh when those capabilities are absent.
* `twunby` declares the map capability again, without `major`/`minor`. `k2iwaq` inherits it through the symlink.

## Verification

* New test built from the device's real `getMapSet_V2` payload.
* Feeding the device's real `MapInfo_V2` outline to `MapData` produces a complete SVG (3682 chars, 29 paths, 7 rooms) with no major/minor map involved.
* `mypy` clean on the touched files.

Caveat: this is a single T90 PRO OMNI on firmware `1.97.0`. I have no way to tell whether other units or firmware revisions report the same 12-field subsets.

Fixes https://github.com/DeebotUniverse/client.py/issues/1620
Related: https://github.com/home-assistant/core/issues/173158