### PR TITLE
Add mower progress to StatsEvent

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -199,6 +199,7 @@ class CapabilityStats:
     clean: CapabilityEvent[StatsEvent]
     report: CapabilityEvent[ReportStatsEvent]
     total: CapabilityEvent[TotalStatsEvent]
+    mowing_job_progress: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/deebot_client/commands/json/stats.py
+++ b/deebot_client/commands/json/stats.py
@@ -30,6 +30,7 @@ class GetStats(JsonCommandWithMessageHandling, MessageBodyDataDict):
             area=data.get("area"),
             time=data.get("time"),
             type=data.get("type"),
+            mowed_area=data.get("mowedArea"),
         )
         event_bus.notify(stats_event)
         return HandlingResult.success()

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum, unique
 from typing import TYPE_CHECKING, Any
 
@@ -189,6 +189,7 @@ class StatsEvent(Event):
     area: int | None
     time: int | None
     type: str | None
+    mowed_area: int | None = field(default=None, kw_only=True)
 
 
 @dataclass(frozen=True)

--- a/deebot_client/hardware/2i0fns.py
+++ b/deebot_client/hardware/2i0fns.py
@@ -143,6 +143,7 @@ def get_device_info() -> StaticDeviceInfo:
                 clean=CapabilityEvent(StatsEvent, [GetStats()]),
                 report=CapabilityEvent(ReportStatsEvent, []),
                 total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+                mowing_job_progress=True,
             ),
         ),
     )

--- a/deebot_client/messages/json/stats.py
+++ b/deebot_client/messages/json/stats.py
@@ -56,6 +56,11 @@ class OnStats(MessageBodyDataDict):
         :return: A message response
         """
         event_bus.notify(
-            StatsEvent(area=data["area"], time=data["time"], type=data.get("type"))
+            StatsEvent(
+                area=data["area"],
+                time=data["time"],
+                type=data.get("type"),
+                mowed_area=data.get("mowedArea"),
+            )
         )
         return HandlingResult.success()

--- a/tests/commands/json/test_stats.py
+++ b/tests/commands/json/test_stats.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from deebot_client.commands.json import GetStats
+from deebot_client.events import StatsEvent
+from tests.helpers import get_request_json, get_success_body
+
+from . import assert_command
+
+
+async def test_GetStats() -> None:
+    json, firmware_event = get_request_json(
+        get_success_body({"area": 2889500, "time": 11269, "mowedArea": 1005475})
+    )
+    await assert_command(
+        GetStats(),
+        json,
+        (
+            firmware_event,
+            StatsEvent(area=2889500, time=11269, type=None, mowed_area=1005475),
+        ),
+    )

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -116,6 +116,18 @@ async def test_get_static_device_info(
 
 @pytest.mark.parametrize(
     ("class_", "expected"),
+    [("2i0fns", True), ("5xu9h3", False)],
+)
+async def test_mowing_job_progress_capability(class_: str, *, expected: bool) -> None:
+    """Test mowing job progress capability."""
+    info = await hardware.get_static_device_info(class_)
+    assert info is not None
+    assert info.capabilities.stats.mowing_job_progress is expected
+    assert info.capabilities.get_refresh_commands(StatsEvent) == [GetStats()]
+
+
+@pytest.mark.parametrize(
+    ("class_", "expected"),
     [
         (
             "5xu9h3",

--- a/tests/messages/json/test_stats.py
+++ b/tests/messages/json/test_stats.py
@@ -116,6 +116,7 @@ def test_ReportStats(data: dict[str, Any], expected: ReportStatsEvent) -> None:
                 area=2889500,
                 time=11269,
                 type=None,
+                mowed_area=1005475,
             ),
         ),
     ],


### PR DESCRIPTION
## Summary

Add support for mowing job progress statistics reported by GOAT mowers, with the behavior enabled explicitly for the GOAT O1200 LiDAR (`2i0fns`).

For the O1200, observed stats semantics are:

- `area`: planned total mowing area
- `mowedArea`: area mowed so far
- `time`: estimated total mowing duration

This change preserves compatibility for existing devices while exposing the additional data needed by consumers to calculate mowing progress.

## Changes

- Add optional keyword-only `StatsEvent.mowed_area`
- Parse `mowedArea` from `onStats`
- Parse `mowedArea` from `GetStats`
- Add `CapabilityStats.mowing_job_progress`, defaulting to `False`
- Enable `mowing_job_progress` only for hardware class `2i0fns`
- Keep existing mower models such as `5xu9h3` on their current stats semantics
- Add focused command/message and hardware capability tests

Consumers can derive progress for devices with `mowing_job_progress=True` as:

`mowed_area / area * 100`

## Verification

Observed on a GOAT O1200 LiDAR during a mowing job:

- `area=492475` -> 49.2475 m² planned area
- `mowedArea=28699` -> 2.8699 m² mowed
- progress ≈ 5.83%, shown as 6% in the Ecovacs app
- `time=2304` -> 38m24s estimated total mowing duration

Relevant stats and hardware tests pass locally.