### PR TITLE
Refactor command lookup per device

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
+from deebot_client.command import Command
 from deebot_client.events import (
     AdvancedModeEvent,
     AvailabilityEvent,
@@ -56,14 +57,13 @@ from deebot_client.events import (
     mop_auto_wash_frequency,
     water_info,
 )
-from deebot_client.command import Command
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from _typeshed import DataclassInstance
 
-    from deebot_client.command import Command, CommandWithMessageHandling
+    from deebot_client.command import CommandWithMessageHandling
     from deebot_client.commands import StationAction
     from deebot_client.events.efficiency_mode import EfficiencyMode, EfficiencyModeEvent
     from deebot_client.models import CleanAction, CleanMode
@@ -83,6 +83,7 @@ def _get_events(
             events.update(_get_events(field_value))
 
     return MappingProxyType(events)
+
 
 def _get_commands(
     capabilities: DataclassInstance | type[DataclassInstance],
@@ -106,10 +107,11 @@ def _get_commands(
                 commands[value.NAME] = type(value)
             elif isinstance(value, type) and issubclass(value, Command):
                 commands[value.NAME] = value
-            elif is_dataclass(value):
+            elif is_dataclass(value) and not isinstance(value, type):
                 commands.update(_get_commands(value))
 
     return MappingProxyType(commands)
+
 
 @dataclass(frozen=True)
 class CapabilityEvent[E: Event]:
@@ -260,7 +262,7 @@ class CapabilitySettings:
 
 @dataclass(frozen=True, kw_only=True)
 class CapabilityStation:
-    """Capabilities for the station."""
+    """Capabilities for station."""
 
     action: CapabilityExecuteTypes[StationAction]
     auto_empty: CapabilitySetTypes[

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -104,9 +104,9 @@ def _get_commands(
 
         for value in values:
             if isinstance(value, Command):
-                commands[value.NAME] = type(value)
+                commands.setdefault(value.NAME, type(value))
             elif isinstance(value, type) and issubclass(value, Command):
-                commands[value.NAME] = value
+                commands.setdefault(value.NAME, value)
             elif is_dataclass(value) and not isinstance(value, type):
                 commands.update(_get_commands(value))
 

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -96,7 +96,9 @@ def _get_commands(
             continue
 
         field_value = getattr(capabilities, field_.name)
-        values = field_value if isinstance(field_value, (list, tuple)) else (field_value,)
+        values = (
+            field_value if isinstance(field_value, (list, tuple)) else (field_value,)
+        )
 
         for value in values:
             if isinstance(value, Command):

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -96,11 +96,7 @@ def _get_commands(
             continue
 
         field_value = getattr(capabilities, field_.name)
-        values = (
-            field_value
-            if isinstance(field_value, (list, tuple))
-            else (field_value,)
-        )
+        values = field_value if isinstance(field_value, (list, tuple)) else (field_value,)
 
         for value in values:
             if isinstance(value, Command):

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -56,6 +56,7 @@ from deebot_client.events import (
     mop_auto_wash_frequency,
     water_info,
 )
+from deebot_client.command import Command
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -83,6 +84,32 @@ def _get_events(
 
     return MappingProxyType(events)
 
+def _get_commands(
+    capabilities: DataclassInstance | type[DataclassInstance],
+) -> MappingProxyType[str, type[Command]]:
+    """Get commands configured for the capabilities."""
+    commands: dict[str, type[Command]] = {}
+
+    for field_ in fields(capabilities):
+        if not field_.init:
+            continue
+
+        field_value = getattr(capabilities, field_.name)
+        values = (
+            field_value
+            if isinstance(field_value, (list, tuple))
+            else (field_value,)
+        )
+
+        for value in values:
+            if isinstance(value, Command):
+                commands[value.NAME] = type(value)
+            elif isinstance(value, type) and issubclass(value, Command):
+                commands[value.NAME] = value
+            elif is_dataclass(value):
+                commands.update(_get_commands(value))
+
+    return MappingProxyType(commands)
 
 @dataclass(frozen=True)
 class CapabilityEvent[E: Event]:
@@ -285,14 +312,20 @@ class Capabilities(ABC):
     water: CapabilityWater | None = None
 
     _events: MappingProxyType[type[Event], list[Command]] = field(init=False)
+    _commands: MappingProxyType[str, type[Command]] = field(init=False)
 
     def __post_init__(self) -> None:
         """Post init."""
         object.__setattr__(self, "_events", _get_events(self))
+        object.__setattr__(self, "_commands", _get_commands(self))
 
     def get_refresh_commands(self, event: type[Event]) -> list[Command]:
         """Return refresh command for given event."""
         return self._events.get(event, [])
+
+    def get_command(self, name: str) -> type[Command] | None:
+        """Return command configured for this device."""
+        return self._commands.get(name)
 
 
 class DeviceType(StrEnum):

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -108,7 +108,8 @@ def _get_commands(
             elif isinstance(value, type) and issubclass(value, Command):
                 commands.setdefault(value.NAME, value)
             elif is_dataclass(value) and not isinstance(value, type):
-                commands.update(_get_commands(value))
+                for name, command in _get_commands(value).items():
+                    commands.setdefault(name, command)
 
     return MappingProxyType(commands)
 

--- a/deebot_client/messages/__init__.py
+++ b/deebot_client/messages/__init__.py
@@ -47,7 +47,9 @@ def get_message(
 
     if static.data_type == DataType.JSON and (
         found_message := get_legacy_message(
-            message_name, converted_name, has_map=static.capabilities.map is not None
+            message_name,
+            converted_name,
+            capabilities=static.capabilities,
         )
     ):
         return found_message

--- a/deebot_client/messages/json/__init__.py
+++ b/deebot_client/messages/json/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from deebot_client.logging_filter import get_logger
 from deebot_client.message import Message
@@ -14,6 +15,9 @@ from .map import OnCachedMapInfo, OnMajorMap, OnMapInfoV2, OnMapSetV2
 from .station_state import OnStationState
 from .stats import OnStats, ReportStats
 from .work_state import OnWorkState
+
+if TYPE_CHECKING:
+    from deebot_client.capabilities import Capabilities
 
 _LOGGER = get_logger(__name__)
 
@@ -95,7 +99,7 @@ def get_legacy_message(
     message_name: str,
     converted_name: str,
     *,
-    has_map: bool = True,
+    capabilities: Capabilities,
 ) -> type[Message] | None:
     """Try to find the message for the given name using legacy way."""
     # Handle message starting with "on","off","report" the same as "get" commands
@@ -109,18 +113,21 @@ def get_legacy_message(
         _LOGGER.debug('Unknown message "%s"', message_name)
         return None
 
-    if not has_map and converted_name in _MAP_LEGACY_COMMANDS:
+    if capabilities.map is None and converted_name in _MAP_LEGACY_COMMANDS:
         _LOGGER.debug(
             'Skipping legacy map fallback for "%s" on device without map capability',
             message_name,
         )
         return None
 
-    from deebot_client.commands.json import (  # noqa: PLC0415
-        COMMANDS,
-    )
+    found_command = capabilities.get_command(converted_name)
 
-    if found_command := COMMANDS.get(converted_name, None):
+    if found_command is None:
+        from deebot_client.commands.json import COMMANDS  # noqa: PLC0415
+
+        found_command = COMMANDS.get(converted_name)
+
+    if found_command:
         if issubclass(found_command, Message):
             _LOGGER.debug("Falling back to legacy way for %s", message_name)
             return found_command

--- a/deebot_client/mqtt_client.py
+++ b/deebot_client/mqtt_client.py
@@ -292,8 +292,8 @@ class MqttClient:
     ) -> type[CommandMqttP2P] | None:
         """Return the P2P command configured for the device."""
         if sub_info := self._subscriptions.get(device_id):
-            command_type = (
-                sub_info.device_info.static.capabilities.get_command(command_name)
+            command_type = sub_info.device_info.static.capabilities.get_command(
+                command_name
             )
             if command_type is not None:
                 if issubclass(command_type, CommandMqttP2P):

--- a/deebot_client/mqtt_client.py
+++ b/deebot_client/mqtt_client.py
@@ -16,6 +16,7 @@ from cachetools import TTLCache
 from deebot_client.const import UNDEFINED, DataType, UndefinedType
 from deebot_client.exceptions import AuthenticationError, MqttError
 
+from .command import CommandMqttP2P
 from .commands import COMMANDS_WITH_MQTT_P2P_HANDLING
 from .logging_filter import get_logger
 from .util.continents import get_continent_url_postfix
@@ -24,7 +25,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, MutableMapping
 
     from .authentication import Authenticator
-    from .command import CommandMqttP2P
     from .event_bus import EventBus
     from .models import Credentials, DeviceInfo
 
@@ -284,6 +284,24 @@ class MqttClient:
         except Exception:
             _LOGGER.exception("An exception occurred during handling atr message")
 
+    def _get_p2p_command_type(
+        self,
+        command_name: str,
+        data_type: DataType,
+        device_id: str,
+    ) -> type[CommandMqttP2P] | None:
+        """Return the P2P command configured for the device."""
+        if sub_info := self._subscriptions.get(device_id):
+            command_type = (
+                sub_info.device_info.static.capabilities.get_command(command_name)
+            )
+            if command_type is not None:
+                if issubclass(command_type, CommandMqttP2P):
+                    return command_type
+                return None
+
+        return COMMANDS_WITH_MQTT_P2P_HANDLING.get(data_type, {}).get(command_name)
+
     def _handle_p2p(self, topic_split: list[str], payload: bytes) -> None:
         try:
             if (data_type := DataType.get(topic_split[11])) is None:
@@ -291,17 +309,23 @@ class MqttClient:
                 return
 
             command_name = topic_split[2]
-            command_type = COMMANDS_WITH_MQTT_P2P_HANDLING.get(data_type, {}).get(
-                command_name, None
+            is_request = topic_split[9] == "q"
+            request_id = topic_split[10]
+
+            # For a request the subscribed device is the receiver.
+            # For a response the subscribed device is the sender.
+            device_id = topic_split[6] if is_request else topic_split[3]
+
+            command_type = self._get_p2p_command_type(
+                command_name,
+                data_type,
+                device_id,
             )
             if command_type is None:
                 _LOGGER.debug(
                     "Command %s does not support p2p handling (yet)", command_name
                 )
                 return
-
-            is_request = topic_split[9] == "q"
-            request_id = topic_split[10]
 
             if is_request:
                 self._received_p2p_commands[request_id] = command_type.create_from_mqtt(

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -114,6 +114,7 @@ async def test_get_static_device_info(
         assert static_device_info_cached == expected
         mock_import.assert_not_called()
 
+
 def test_capabilities_command_lookup_is_device_specific() -> None:
     """Test commands with the same name can be resolved per device."""
 
@@ -136,6 +137,7 @@ def test_capabilities_command_lookup_is_device_specific() -> None:
     assert info.capabilities.get_command("clean") is Clean
     assert alternative_capabilities.get_command("clean") is AlternativeClean
     assert info.capabilities.get_command("doesNotExist") is None
+
 
 @pytest.mark.parametrize(
     ("class_", "expected"),

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -17,7 +18,7 @@ from deebot_client.commands.json.border_switch import GetBorderSwitch
 from deebot_client.commands.json.carpet import GetCarpetAutoFanBoost
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock
-from deebot_client.commands.json.clean import GetCleanInfo, GetCleanInfoV2
+from deebot_client.commands.json.clean import Clean, GetCleanInfo, GetCleanInfoV2
 from deebot_client.commands.json.clean_count import GetCleanCount
 from deebot_client.commands.json.clean_logs import GetCleanLogs
 from deebot_client.commands.json.clean_preference import GetCleanPreference
@@ -113,6 +114,28 @@ async def test_get_static_device_info(
         assert static_device_info_cached == expected
         mock_import.assert_not_called()
 
+def test_capabilities_command_lookup_is_device_specific() -> None:
+    """Test commands with the same name can be resolved per device."""
+
+    class AlternativeClean(Clean):
+        """Alternative clean command using the same command name."""
+
+    info = get_yna5xi_info()
+
+    alternative_capabilities = replace(
+        info.capabilities,
+        clean=replace(
+            info.capabilities.clean,
+            action=replace(
+                info.capabilities.clean.action,
+                command=AlternativeClean,
+            ),
+        ),
+    )
+
+    assert info.capabilities.get_command("clean") is Clean
+    assert alternative_capabilities.get_command("clean") is AlternativeClean
+    assert info.capabilities.get_command("doesNotExist") is None
 
 @pytest.mark.parametrize(
     ("class_", "expected"),

--- a/tests/messages/test_get_messages.py
+++ b/tests/messages/test_get_messages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -35,3 +36,26 @@ def test_get_messages(
 ) -> None:
     """Test get messages."""
     assert get_message(name, static_device_info) == expected
+
+
+def test_get_message_uses_device_command(
+    static_device_info: StaticDeviceInfo,
+) -> None:
+    """Test legacy message lookup uses the device-specific command."""
+
+    class AlternativeGetError(GetError):
+        """Alternative get error command using the same command name."""
+
+    alternative_static = replace(
+        static_device_info,
+        capabilities=replace(
+            static_device_info.capabilities,
+            error=replace(
+                static_device_info.capabilities.error,
+                get=[AlternativeGetError()],
+            ),
+        ),
+    )
+
+    assert get_message("onError", static_device_info) is GetError
+    assert get_message("onError", alternative_static) is AlternativeGetError

--- a/tests/messages/test_get_messages.py
+++ b/tests/messages/test_get_messages.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from deebot_client.commands.json.custom import CustomCommand
 from deebot_client.commands.json.error import GetError
 from deebot_client.messages import get_message
 from deebot_client.messages.json.battery import OnBattery
@@ -59,3 +60,42 @@ def test_get_message_uses_device_command(
 
     assert get_message("onError", static_device_info) is GetError
     assert get_message("onError", alternative_static) is AlternativeGetError
+
+
+def test_get_message_falls_back_to_command_registry(
+    static_device_info: StaticDeviceInfo,
+) -> None:
+    """Use the global command registry when the device has no command."""
+    without_error_command = replace(
+        static_device_info,
+        capabilities=replace(
+            static_device_info.capabilities,
+            error=replace(static_device_info.capabilities.error, get=[]),
+        ),
+    )
+
+    assert get_message("onError", without_error_command) is GetError
+
+
+def test_get_message_rejects_non_message_legacy_command(
+    static_device_info: StaticDeviceInfo,
+) -> None:
+    """Do not return a command that cannot handle messages."""
+
+    class NonMessageCommand(CustomCommand):
+        """Command with the legacy command name but no message handling."""
+
+        NAME = "getError"
+
+    non_message_command = replace(
+        static_device_info,
+        capabilities=replace(
+            static_device_info.capabilities,
+            error=replace(
+                static_device_info.capabilities.error,
+                get=[NonMessageCommand("getError")],
+            ),
+        ),
+    )
+
+    assert get_message("onError", non_message_command) is None

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -14,7 +14,7 @@ import pytest
 
 from deebot_client.commands.json.battery import GetBattery
 from deebot_client.commands.json.volume import SetVolume
-from deebot_client.const import UNDEFINED, DataType, UndefinedType
+from deebot_client.const import UNDEFINED, UndefinedType
 from deebot_client.exceptions import AuthenticationError, MqttError
 from deebot_client.mqtt_client import MqttClient, MqttConfiguration, create_mqtt_config
 
@@ -123,9 +123,11 @@ async def test_p2p_success(
     command_type = Mock(spec=SetVolume)
     create_from_mqtt = command_type.create_from_mqtt
     create_from_mqtt.return_value = command_object
-    with patch.dict(
-        "deebot_client.mqtt_client.COMMANDS_WITH_MQTT_P2P_HANDLING",
-        {DataType.JSON: {command_name: command_type}},
+
+    with patch.object(
+        mqtt_client,
+        "_get_p2p_command_type",
+        return_value=command_type,
     ):
         request_id = "req"
         payload = await _publish_p2p(
@@ -224,9 +226,11 @@ async def test_p2p_to_late(
     command_type = Mock(spec=SetVolume)
     create_from_mqtt = command_type.create_from_mqtt
     create_from_mqtt.return_value = command_object
-    with patch.dict(
-        "deebot_client.mqtt_client.COMMANDS_WITH_MQTT_P2P_HANDLING",
-        {DataType.JSON: {command_name: command_type}},
+
+    with patch.object(
+        mqtt_client,
+        "_get_p2p_command_type",
+        return_value=command_type,
     ):
         request_id = "req"
         payload = await _publish_p2p(

--- a/tests/test_mqtt_device_command_lookup.py
+++ b/tests/test_mqtt_device_command_lookup.py
@@ -130,3 +130,32 @@ def test_p2p_command_lookup_is_device_specific(
         )
         is SetVolume
     )
+
+    no_volume_capabilities = replace(
+        device_info.static.capabilities,
+        settings=replace(
+            device_info.static.capabilities.settings,
+            volume=None,
+        ),
+    )
+    no_volume_device_info = replace(
+        device_info,
+        static=replace(
+            device_info.static,
+            capabilities=no_volume_capabilities,
+        ),
+    )
+    client._subscriptions[device_info.api["did"]] = SubscriberInfo(
+        device_info=no_volume_device_info,
+        events=event_bus,
+        callback=lambda _name, _payload: None,
+    )
+
+    assert (
+        client._get_p2p_command_type(
+            SetVolume.NAME,
+            DataType.JSON,
+            device_info.api["did"],
+        )
+        is SetVolume
+    )

--- a/tests/test_mqtt_device_command_lookup.py
+++ b/tests/test_mqtt_device_command_lookup.py
@@ -28,9 +28,6 @@ def test_p2p_command_lookup_is_device_specific(
 
         NAME = SetVolume.NAME
 
-        def __init__(self, volume: int) -> None:
-            super().__init__()
-
     client = MqttClient(
         MqttConfiguration(
             hostname="localhost",

--- a/tests/test_mqtt_device_command_lookup.py
+++ b/tests/test_mqtt_device_command_lookup.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.const import DataType
+from deebot_client.mqtt_client import MqttClient, MqttConfiguration, SubscriberInfo
+
+if TYPE_CHECKING:
+    from deebot_client.authentication import Authenticator
+    from deebot_client.event_bus import EventBus
+    from deebot_client.models import DeviceInfo
+
+
+def test_p2p_command_lookup_is_device_specific(
+    authenticator: Authenticator,
+    device_info: DeviceInfo,
+    event_bus: EventBus,
+) -> None:
+    """Test P2P command lookup uses the device-specific command."""
+
+    class AlternativeSetVolume(SetVolume):
+        """Alternative set volume command using the same command name."""
+
+    class NonP2PSetVolume(GetVolume):
+        """Non-P2P command using the same command name."""
+
+        NAME = SetVolume.NAME
+
+        def __init__(self, volume: int) -> None:
+            super().__init__()
+
+    client = MqttClient(
+        MqttConfiguration(
+            hostname="localhost",
+            port=1883,
+            ssl_context=None,
+            device_id="test",
+        ),
+        authenticator,
+    )
+
+    volume = device_info.static.capabilities.settings.volume
+    assert volume is not None
+
+    client._subscriptions[device_info.api["did"]] = SubscriberInfo(
+        device_info=device_info,
+        events=event_bus,
+        callback=lambda _name, _payload: None,
+    )
+
+    assert (
+        client._get_p2p_command_type(
+            SetVolume.NAME,
+            DataType.JSON,
+            device_info.api["did"],
+        )
+        is SetVolume
+    )
+
+    alternative_capabilities = replace(
+        device_info.static.capabilities,
+        settings=replace(
+            device_info.static.capabilities.settings,
+            volume=replace(
+                volume,
+                set=AlternativeSetVolume,
+            ),
+        ),
+    )
+    alternative_device_info = replace(
+        device_info,
+        static=replace(
+            device_info.static,
+            capabilities=alternative_capabilities,
+        ),
+    )
+
+    client._subscriptions[device_info.api["did"]] = SubscriberInfo(
+        device_info=alternative_device_info,
+        events=event_bus,
+        callback=lambda _name, _payload: None,
+    )
+
+    assert (
+        client._get_p2p_command_type(
+            SetVolume.NAME,
+            DataType.JSON,
+            device_info.api["did"],
+        )
+        is AlternativeSetVolume
+    )
+
+    non_p2p_capabilities = replace(
+        device_info.static.capabilities,
+        settings=replace(
+            device_info.static.capabilities.settings,
+            volume=replace(
+                volume,
+                set=NonP2PSetVolume,
+            ),
+        ),
+    )
+    non_p2p_device_info = replace(
+        device_info,
+        static=replace(
+            device_info.static,
+            capabilities=non_p2p_capabilities,
+        ),
+    )
+
+    client._subscriptions[device_info.api["did"]] = SubscriberInfo(
+        device_info=non_p2p_device_info,
+        events=event_bus,
+        callback=lambda _name, _payload: None,
+    )
+
+    assert (
+        client._get_p2p_command_type(
+            SetVolume.NAME,
+            DataType.JSON,
+            device_info.api["did"],
+        )
+        is None
+    )
+
+    assert (
+        client._get_p2p_command_type(
+            SetVolume.NAME,
+            DataType.JSON,
+            "unknown-device",
+        )
+        is SetVolume
+    )

--- a/tests/test_mqtt_p2p_device_routing.py
+++ b/tests/test_mqtt_p2p_device_routing.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from deebot_client.const import DataType
+from deebot_client.mqtt_client import MqttClient, MqttConfiguration
+
+if TYPE_CHECKING:
+    from deebot_client.authentication import Authenticator
+
+
+def _create_client(authenticator: Authenticator) -> MqttClient:
+    """Create MQTT client for P2P routing tests."""
+    return MqttClient(
+        MqttConfiguration(
+            hostname="localhost",
+            port=1883,
+            ssl_context=None,
+            device_id="test",
+        ),
+        authenticator,
+    )
+
+
+def test_p2p_request_uses_receiver_device(
+    authenticator: Authenticator,
+) -> None:
+    """Test P2P requests use the receiver device for command lookup."""
+    client = _create_client(authenticator)
+
+    topic_split = [
+        "iot",
+        "p2p",
+        "setVolume",
+        "sender-did",
+        "sender-class",
+        "sender-resource",
+        "receiver-did",
+        "receiver-class",
+        "receiver-resource",
+        "q",
+        "request-id",
+        "j",
+    ]
+
+    with patch.object(
+        client,
+        "_get_p2p_command_type",
+        return_value=None,
+    ) as command_lookup:
+        client._handle_p2p(topic_split, b"{}")
+
+    command_lookup.assert_called_once_with(
+        "setVolume",
+        DataType.JSON,
+        "receiver-did",
+    )
+
+
+def test_p2p_response_uses_sender_device(
+    authenticator: Authenticator,
+) -> None:
+    """Test P2P responses use the sender device for command lookup."""
+    client = _create_client(authenticator)
+
+    topic_split = [
+        "iot",
+        "p2p",
+        "setVolume",
+        "sender-did",
+        "sender-class",
+        "sender-resource",
+        "receiver-did",
+        "receiver-class",
+        "receiver-resource",
+        "p",
+        "request-id",
+        "j",
+    ]
+
+    with patch.object(
+        client,
+        "_get_p2p_command_type",
+        return_value=None,
+    ) as command_lookup:
+        client._handle_p2p(topic_split, b"{}")
+
+    command_lookup.assert_called_once_with(
+        "setVolume",
+        DataType.JSON,
+        "sender-did",
+    )


### PR DESCRIPTION
## Summary

Refactor command lookup so command classes can be resolved from the capabilities configured for a specific device, instead of relying only on the global command-name dictionaries.

This is a prerequisite for supporting different command implementations that use the same command name on different device families.

## Motivation

This addresses the architectural blocker discussed in #1624.

The current global command lookup requires command names to be unique. That prevents, for example, registering two device-specific command classes that both use the same MQTT/API command name.

This PR adds a device-specific lookup while retaining the existing global registries as fallbacks for backwards compatibility.

## Changes

### Device capabilities

- Extract command classes configured in the capability tree.
- Store a per-device command lookup in `Capabilities`.
- Add `Capabilities.get_command(name)`.
- Preserve the first/primary configured command when multiple capabilities use the same command name.
- Keep commands hidden behind lambdas or otherwise not directly discoverable working through the existing global fallback.

### Legacy message lookup

- Pass the device's capabilities into JSON legacy message lookup.
- Resolve the corresponding command from the device first.
- Fall back to the existing global `COMMANDS` lookup when no device-specific command is available.

### MQTT P2P lookup

- Resolve P2P command classes from the subscribed device's capabilities first.
- Use the receiver device for P2P requests (`q`).
- Use the sender device for P2P responses (`p`).
- Fall back to the existing global P2P command registry when the device does not configure the command.
- Do not fall back to another global implementation when the device explicitly configures the same command name with a non-P2P command.

## Tests

Added coverage for:

- command lookup being specific to device capabilities
- different command classes sharing the same command name
- device-specific legacy message lookup
- device-specific MQTT P2P command lookup
- global MQTT P2P fallback
- preventing an incorrect global P2P fallback for an explicitly configured device command
- correct P2P device routing:
  - request → receiver device
  - response → sender device

## Follow-up

Once this prerequisite is accepted, device families can safely select different command implementations with the same command name, including the mower `clean` command work discussed in #1624.