### PR TITLE
Add FreeCleanV2 to enable room cleaning in HA for newer Bots

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -141,7 +141,7 @@ class CapabilityCleanAction:
     """Capabilities for clean action."""
 
     command: Callable[[CleanAction], Command]
-    area: Callable[[CleanMode, list[int | float], int], Command] | None = None
+    area: Callable[[CleanMode, list[int | float | str], int], Command] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -122,16 +122,16 @@ class FreeCleanV2(CleanV2):
     ) -> None:
         match mode:
             case CleanMode.SPOT_AREA:
-                ctype = CleanMode.FREE_CLEAN
+                cleanType = CleanMode.FREE_CLEAN
                 value = ";".join(("1," + str(i)) for i in area)
             case CleanMode.CUSTOM_AREA:
-                ctype = CleanMode.FREE_CLEAN
+                cleanType = CleanMode.FREE_CLEAN
                 value = "3,null," + ",".join(str(i) for i in area)
             case CleanMode.FREE_CLEAN:
-                ctype = mode
-                value = ";".join(str(i) for i in area)
+                cleanType = mode
+                value = ";".join(i)
         self._additional_content = {
-            "type": ctype.value,
+            "type": cleanType.value,
             "value": value,
         }
         super().__init__(CleanAction.START)

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -129,7 +129,7 @@ class FreeCleanV2(CleanV2):
                 value = "3,null," + ",".join(str(i) for i in area)
             case CleanMode.FREE_CLEAN:
                 clean_type = mode
-                value = ";".join(area)
+                value = ";".join(str(i) for i in area)
         self._additional_content = {
             "type": clean_type.value,
             "value": value,

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -112,7 +112,7 @@ class CleanAreaV2(CleanV2):
             args["content"].update(self._additional_content)
         return args
 
-class CleanAreaV2FreeClean(CleanV2):
+class FreeCleanV2(CleanV2):
     """Clean area command for bots that require cleanmode freeclean"""
 
     def __init__(

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -112,6 +112,33 @@ class CleanAreaV2(CleanV2):
             args["content"].update(self._additional_content)
         return args
 
+class CleanAreaV2FreeClean(CleanV2):
+    """Clean area command for bots that require cleanmode freeclean"""
+
+    def __init__(
+        self, mode: CleanMode, area: list[int | float | string], _: int = 1
+    ) -> None:
+        match mode:
+            case CleanMode.SPOT_AREA:
+                type = CleanMode.FREE_CLEAN
+                value = ";".join(("1," + str(i)) for i in area)
+            case CleanMode.CUSTOM_AREA:
+                type = CleanMode.FREE_CLEAN
+                value = "3,null," + ",".join(str(i) for i in area)
+            case CeanMode.FREE_CLEAN:
+                type = mode
+                value = ";".join(i) for i in area)
+        self._additional_content = {
+            "type": type.value,
+            "value": value,
+        }
+        super().__init__(CleanAction.START)
+
+    def _get_args(self, action: CleanAction) -> dict[str, Any]:
+        args = super()._get_args(action)
+        if action == CleanAction.START:
+            args["content"].update(self._additional_content)
+        return args
 
 class GetCleanInfo(JsonCommandWithMessageHandling, MessageBodyDataDict):
     """Get clean info command."""

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from deebot_client.authentication import Authenticator
     from deebot_client.event_bus import EventBus
 
-
 _LOGGER = get_logger(__name__)
 
 

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -118,7 +118,7 @@ class FreeCleanV2(CleanV2):
     """Clean area command for bots that require cleanmode freeclean"""
 
     def __init__(
-        self, mode: CleanMode, area: list[int | float | str], cleanings: int = 1
+        self, mode: CleanMode, area: list[int | float | str], _: int = 1
     ) -> None:
         match mode:
             case CleanMode.SPOT_AREA:

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -122,16 +122,16 @@ class FreeCleanV2(CleanV2):
     ) -> None:
         match mode:
             case CleanMode.SPOT_AREA:
-                cleanType = CleanMode.FREE_CLEAN
+                clean_type = CleanMode.FREE_CLEAN
                 value = ";".join(("1," + str(i)) for i in area)
             case CleanMode.CUSTOM_AREA:
-                cleanType = CleanMode.FREE_CLEAN
+                clean_type = CleanMode.FREE_CLEAN
                 value = "3,null," + ",".join(str(i) for i in area)
             case CleanMode.FREE_CLEAN:
-                cleanType = mode
-                value = ";".join(i)
+                clean_type = mode
+                value = ";".join(area)
         self._additional_content = {
-            "type": cleanType.value,
+            "type": clean_type.value,
             "value": value,
         }
         super().__init__(CleanAction.START)

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -115,7 +115,7 @@ class CleanAreaV2(CleanV2):
 
 
 class FreeCleanV2(CleanV2):
-    """Clean area command for bots that require cleanmode freeclean"""
+    """Clean area command for bots that require type freeClean."""
 
     def __init__(
         self, mode: CleanMode, area: list[int | float | str], _: int = 1

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from deebot_client.authentication import Authenticator
     from deebot_client.event_bus import EventBus
 
+
 _LOGGER = get_logger(__name__)
 
 
@@ -112,24 +113,25 @@ class CleanAreaV2(CleanV2):
             args["content"].update(self._additional_content)
         return args
 
+
 class FreeCleanV2(CleanV2):
     """Clean area command for bots that require cleanmode freeclean"""
 
     def __init__(
-        self, mode: CleanMode, area: list[int | float | string], _: int = 1
+        self, mode: CleanMode, area: list[int | float | str], cleanings: int = 1
     ) -> None:
         match mode:
             case CleanMode.SPOT_AREA:
-                type = CleanMode.FREE_CLEAN
+                ctype = CleanMode.FREE_CLEAN
                 value = ";".join(("1," + str(i)) for i in area)
             case CleanMode.CUSTOM_AREA:
-                type = CleanMode.FREE_CLEAN
+                ctype = CleanMode.FREE_CLEAN
                 value = "3,null," + ",".join(str(i) for i in area)
-            case CeanMode.FREE_CLEAN:
-                type = mode
-                value = ";".join(i) for i in area)
+            case CleanMode.FREE_CLEAN:
+                ctype = mode
+                value = ";".join(str(i) for i in area)
         self._additional_content = {
-            "type": type.value,
+            "type": ctype.value,
             "value": value,
         }
         super().__init__(CleanAction.START)
@@ -139,6 +141,7 @@ class FreeCleanV2(CleanV2):
         if action == CleanAction.START:
             args["content"].update(self._additional_content)
         return args
+
 
 class GetCleanInfo(JsonCommandWithMessageHandling, MessageBodyDataDict):
     """Get clean info command."""

--- a/deebot_client/commands/json/clean.py
+++ b/deebot_client/commands/json/clean.py
@@ -60,7 +60,7 @@ class CleanArea(Clean):
     """Clean area command."""
 
     def __init__(
-        self, mode: CleanMode, area: list[int | float], cleanings: int = 1
+        self, mode: CleanMode, area: list[int | float | str], cleanings: int = 1
     ) -> None:
         self._additional_args = {
             "type": mode.value,
@@ -96,7 +96,7 @@ class CleanAreaV2(CleanV2):
     """Clean area command."""
 
     def __init__(
-        self, mode: CleanMode, area: list[int | float], cleanings: int = 1
+        self, mode: CleanMode, area: list[int | float | str], cleanings: int = 1
     ) -> None:
         value = ",".join(str(i) for i in area)
         if mode == CleanMode.FREE_CLEAN:

--- a/deebot_client/commands/xml/clean.py
+++ b/deebot_client/commands/xml/clean.py
@@ -49,7 +49,7 @@ class CleanArea(Clean):
     def __init__(
         self,
         mode: CleanMode,
-        area_or_coordinates: list[int | float],
+        area_or_coordinates: list[int | float | str],
         cleanings: int = 1,
     ) -> None:
         key = "mid" if mode == CleanMode.SPOT_AREA else "p"

--- a/deebot_client/hardware/viq3mw.py
+++ b/deebot_client/hardware/viq3mw.py
@@ -34,7 +34,7 @@ from deebot_client.commands.json.carpet import (
 from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
-from deebot_client.commands.json.clean import CleanAreaV2, CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.clean import FreeCleanV2, CleanV2, GetCleanInfoV2
 from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
 from deebot_client.commands.json.clean_logs import GetCleanLogs
 from deebot_client.commands.json.continuous_cleaning import (
@@ -132,7 +132,7 @@ def get_device_info() -> StaticDeviceInfo:
             battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
-                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaV2),
+                action=CapabilityCleanAction(command=CleanV2, area=FreeCleanV2),
                 continuous=CapabilitySetEnable(
                     ContinuousCleaningEvent,
                     [GetContinuousCleaning()],

--- a/deebot_client/hardware/viq3mw.py
+++ b/deebot_client/hardware/viq3mw.py
@@ -34,7 +34,7 @@ from deebot_client.commands.json.carpet import (
 from deebot_client.commands.json.charge import Charge
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
-from deebot_client.commands.json.clean import FreeCleanV2, CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.clean import CleanV2, FreeCleanV2, GetCleanInfoV2
 from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
 from deebot_client.commands.json.clean_logs import GetCleanLogs
 from deebot_client.commands.json.continuous_cleaning import (

--- a/tests/commands/json/test_clean.py
+++ b/tests/commands/json/test_clean.py
@@ -159,6 +159,13 @@ async def test_Clean_act(
             },
         ),
         (
+            FreeCleanV2(CleanMode.SPOT_AREA, [5]),
+            {
+                "act": "start",
+                "content": {"type": "freeClean", "value": "1,5"},
+            },
+        ),
+        (
             FreeCleanV2(
                 CleanMode.CUSTOM_AREA,
                 [1580.0, -4087.0, 3833.0, -7525.0],
@@ -171,6 +178,19 @@ async def test_Clean_act(
                 },
             },
         ),
+        (
+            FreeCleanV2(
+                CleanMode.FREE_CLEAN,
+                [ "1,5", "3,null,1580.0,-4087.0,3833.0,-7525.0", "1,8"],
+            ),
+            {
+                "act": "start",
+                "content": {
+                    "type": "freeClean",
+                    "value": "1,5;3,null,1580.0,-4087.0,3833.0,-7525.0;1,8",
+                },
+            },
+        ),
     ],
     ids=[
         "Rooms",
@@ -179,8 +199,10 @@ async def test_Clean_act(
         "Coordinates V2",
         "FreeClean",
         "FreeClean single room 2x",
-        "FreeClean SPOT",
-        "FreeClean CUSTOM",
+        "FreeCleanV2 SPOT_AREA single room",
+        "FreeCleanV2 SPOT_AREA multiple rooms",
+        "FreeCleanV2 CUSTOM_AREA",
+        "FreeCleanV2 FREE_CLEAN",
     ],
 )
 async def test_CleanArea(

--- a/tests/commands/json/test_clean.py
+++ b/tests/commands/json/test_clean.py
@@ -11,6 +11,7 @@ from deebot_client.commands.json.clean import (
     CleanArea,
     CleanAreaV2,
     CleanV2,
+    FreeCleanV2,
     GetCleanInfoV2,
 )
 from deebot_client.event_bus import EventBus
@@ -150,6 +151,26 @@ async def test_Clean_act(
                 "content": {"type": "freeClean", "value": "2,0"},
             },
         ),
+        (
+            FreeCleanV2(CleanMode.SPOT_AREA, [5, 8]),
+            {
+                "act": "start",
+                "content": {"type": "freeClean", "value": "1,5;1,8"},
+            },
+        ),
+        (
+            FreeCleanV2(
+                CleanMode.CUSTOM_AREA,
+                [1580.0, -4087.0, 3833.0, -7525.0],
+            ),
+            {
+                "act": "start",
+                "content": {
+                    "type": "freeClean",
+                    "value": "3,null,1580.0,-4087.0,3833.0,-7525.0",
+                },
+            },
+        ),
     ],
     ids=[
         "Rooms",
@@ -158,9 +179,11 @@ async def test_Clean_act(
         "Coordinates V2",
         "FreeClean",
         "FreeClean single room 2x",
+        "FreeClean SPOT",
+        "FreeClean CUSTOM",
     ],
 )
 async def test_CleanArea(
-    command: CleanArea | CleanAreaV2, args: dict[str, str]
+    command: CleanArea | CleanAreaV2 | FreeCleanV2, args: dict[str, str]
 ) -> None:
     await assert_execute_command(command, args)

--- a/tests/commands/json/test_clean.py
+++ b/tests/commands/json/test_clean.py
@@ -181,7 +181,7 @@ async def test_Clean_act(
         (
             FreeCleanV2(
                 CleanMode.FREE_CLEAN,
-                [ "1,5", "3,null,1580.0,-4087.0,3833.0,-7525.0", "1,8"],
+                ["1,5", "3,null,1580.0,-4087.0,3833.0,-7525.0", "1,8"],
             ),
             {
                 "act": "start",


### PR DESCRIPTION
Hi, 

after some try and error I found how the freeClean action on newer bots works:

- One rooms selected: 
`payload=b'{"body":{"data":{"act":"start","content":{"type":"freeClean","value":"1,3"}}},`
- Two room selected:
`payload=b'{"body":{"data":{"act":"start","content":{"type":"freeClean","value":"1,2;1,3"}}},`
- One area selected:
`payload=b'{"body":{"data":{"act":"start","content":{"type":"freeClean","value":"3,null,2414,-226,633,-2038"}}}`
- Two areas and one room selected:
`payload=b'{"body":{"data":{"act":"start","content":{"type":"freeClean","value":"3,null,2434,-414,536,-2129;3,null,-983,-2017,-3097,-3050;1,5"}}}`

I tried to incorporate these findings as well as possible.

BR, Markus