### PR TITLE
feat(mower): add GOAT area names support

### DIFF
--- a/.codex-write-test.txt
+++ b/.codex-write-test.txt
@@ -1,0 +1,1 @@
+Codex write test

--- a/.codex-write-test.txt
+++ b/.codex-write-test.txt
@@ -1,1 +1,0 @@
-Codex write test

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -149,6 +149,7 @@ class CapabilityClean:
     """Capabilities for clean."""
 
     action: CapabilityCleanAction
+    areas: CapabilityEvent[RoomsEvent] | None = None
     continuous: CapabilitySetEnable[ContinuousCleaningEvent] | None = None
     count: CapabilitySet[CleanCountEvent, [int]] | None = None
     log: CapabilityEvent[CleanLogEvent] | None = None

--- a/deebot_client/commands/json/__init__.py
+++ b/deebot_client/commands/json/__init__.py
@@ -26,6 +26,7 @@ from .error import GetError
 from .fan_speed import GetFanSpeed, SetFanSpeed
 from .life_span import GetLifeSpan, ResetLifeSpan
 from .map import (
+    GetAreaSet,
     GetCachedMapInfo,
     GetMajorMap,
     GetMapInfoV2,
@@ -65,6 +66,7 @@ __all__ = [
     "CleanV2",
     "ClearMap",
     "GetAdvancedMode",
+    "GetAreaSet",
     "GetBattery",
     "GetBorderSpin",
     "GetBorderSwitch",
@@ -197,6 +199,7 @@ _COMMANDS: list[type[JsonCommand]] = [
     GetLifeSpan,
     ResetLifeSpan,
 
+    GetAreaSet,
     GetCachedMapInfo,
     GetMajorMap,
     GetMapInfoV2,

--- a/deebot_client/commands/json/map/__init__.py
+++ b/deebot_client/commands/json/map/__init__.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from deebot_client.event_bus import EventBus
 
 __all__ = [
+    "GetAreaSet",
     "GetCachedMapInfo",
     "GetMajorMap",
     "GetMapSet",
@@ -40,6 +41,32 @@ __all__ = [
 ]
 
 _LOGGER = get_logger(__name__)
+
+
+class GetAreaSet(JsonCommandWithMessageHandling, MessageBodyDataDict):
+    """Get mower area set command."""
+
+    NAME = "getAreaSet"
+
+    def __init__(self) -> None:
+        super().__init__({"mid": "1", "aid": "0", "type": "ar"})
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        """Handle mower areas and notify room event subscribers."""
+        if data.get("type") != "ar" or not data.get("subsets"):
+            return HandlingResult.analyse()
+
+        subsets = orjson.loads(decompress_base64_data(data["subsets"]).decode())
+        event_bus.notify(
+            RoomsEvent(
+                subsets[0][0],
+                [Room(subset[2], int(subset[1]), "") for subset in subsets],
+            )
+        )
+        return HandlingResult.success()
 
 
 class GetMapSet(JsonCommandWithMessageHandling, MessageBodyDataDict):

--- a/deebot_client/hardware/2i0fns.py
+++ b/deebot_client/hardware/2i0fns.py
@@ -38,7 +38,7 @@ from deebot_client.commands.json.clean import CleanV2, GetCleanInfoV2
 from deebot_client.commands.json.custom import CustomCommand
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
-from deebot_client.commands.json.map import GetMapSetV2
+from deebot_client.commands.json.map import GetAreaSet
 from deebot_client.commands.json.network import GetNetInfo
 from deebot_client.commands.json.play_sound import PlaySound
 from deebot_client.commands.json.stats import GetStats, GetTotalStats
@@ -57,7 +57,6 @@ from deebot_client.events import (
     ErrorEvent,
     LifeSpan,
     LifeSpanEvent,
-    MapSetType,
     MoveUpWarningEvent,
     NetworkInfoEvent,
     ReportStatsEvent,
@@ -85,7 +84,7 @@ def get_device_info() -> StaticDeviceInfo:
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
                 action=CapabilityCleanAction(command=CleanV2),
-                areas=CapabilityEvent(RoomsEvent, [GetMapSetV2("", MapSetType.ROOMS)]),
+                areas=CapabilityEvent(RoomsEvent, [GetAreaSet()]),
             ),
             custom=CapabilityCustomCommand(
                 event=CustomCommandEvent, get=[], set=CustomCommand

--- a/deebot_client/hardware/2i0fns.py
+++ b/deebot_client/hardware/2i0fns.py
@@ -38,6 +38,7 @@ from deebot_client.commands.json.clean import CleanV2, GetCleanInfoV2
 from deebot_client.commands.json.custom import CustomCommand
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import GetMapSetV2
 from deebot_client.commands.json.network import GetNetInfo
 from deebot_client.commands.json.play_sound import PlaySound
 from deebot_client.commands.json.stats import GetStats, GetTotalStats
@@ -56,9 +57,11 @@ from deebot_client.events import (
     ErrorEvent,
     LifeSpan,
     LifeSpanEvent,
+    MapSetType,
     MoveUpWarningEvent,
     NetworkInfoEvent,
     ReportStatsEvent,
+    RoomsEvent,
     SafeProtectEvent,
     StateEvent,
     StatsEvent,
@@ -82,6 +85,7 @@ def get_device_info() -> StaticDeviceInfo:
             charge=CapabilityExecute(Charge),
             clean=CapabilityClean(
                 action=CapabilityCleanAction(command=CleanV2),
+                areas=CapabilityEvent(RoomsEvent, [GetMapSetV2("", MapSetType.ROOMS)]),
             ),
             custom=CapabilityCustomCommand(
                 event=CustomCommandEvent, get=[], set=CustomCommand

--- a/tests/commands/json/map/test_init.py
+++ b/tests/commands/json/map/test_init.py
@@ -10,7 +10,7 @@ from deebot_client.commands.json import (
     GetMapSubSet,
     GetMapTrace,
 )
-from deebot_client.commands.json.map import GetMapInfoV2, GetMapSetV2
+from deebot_client.commands.json.map import GetAreaSet, GetMapInfoV2, GetMapSetV2
 from deebot_client.events import (
     Event,
     FirmwareEvent,
@@ -25,6 +25,30 @@ from deebot_client.message import HandlingResult, HandlingState
 from deebot_client.models import Room
 from tests.commands.json import assert_command
 from tests.helpers import get_request_json, get_success_body
+
+
+async def test_getAreaSet() -> None:
+    subsets = "XQAABACRAAAAAC2WwEIAXhHX9FS5sGj0QZjR5C9LwgskaRv7NNnlwYLfW5cqizd8DELGgHRrytM6XLeHVxHTtCZRrB5hCVldTC+NInBErb3e8FmImM2Df07MYA=="
+    json, firmware_event = get_request_json(
+        get_success_body({"type": "ar", "subsets": subsets})
+    )
+    command = GetAreaSet()
+    assert command._args == {"mid": "1", "aid": "0", "type": "ar"}
+    await assert_command(
+        command,
+        json,
+        [
+            firmware_event,
+            RoomsEvent(
+                "1",
+                [
+                    Room("Østkanten", 4, ""),
+                    Room("Sentrum", 1, ""),
+                    Room("Vestkanten", 2, ""),
+                ],
+            ),
+        ],
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -30,9 +30,9 @@ from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.fan_speed import GetFanSpeed
 from deebot_client.commands.json.life_span import GetLifeSpan
 from deebot_client.commands.json.map import (
+    GetAreaSet,
     GetCachedMapInfo,
     GetMajorMap,
-    GetMapSetV2,
     GetMapTrace,
 )
 from deebot_client.commands.json.moveup_warning import GetMoveUpWarning
@@ -65,7 +65,6 @@ from deebot_client.events import (
     ErrorEvent,
     LifeSpan,
     LifeSpanEvent,
-    MapSetType,
     MoveUpWarningEvent,
     MultimapStateEvent,
     OtaEvent,
@@ -274,7 +273,7 @@ async def test_goat_o1200_area_names_capability() -> None:
     areas = capabilities.clean.areas
     assert areas is not None
     assert areas.event is RoomsEvent
-    expected_command = GetMapSetV2("", MapSetType.ROOMS)
+    expected_command = GetAreaSet()
     assert areas.get == [expected_command]
     assert capabilities.get_refresh_commands(RoomsEvent) == [expected_command]
     assert capabilities.map is None

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -29,7 +29,12 @@ from deebot_client.commands.json.efficiency import GetEfficiencyMode
 from deebot_client.commands.json.error import GetError
 from deebot_client.commands.json.fan_speed import GetFanSpeed
 from deebot_client.commands.json.life_span import GetLifeSpan
-from deebot_client.commands.json.map import GetCachedMapInfo, GetMajorMap, GetMapTrace
+from deebot_client.commands.json.map import (
+    GetCachedMapInfo,
+    GetMajorMap,
+    GetMapSetV2,
+    GetMapTrace,
+)
 from deebot_client.commands.json.moveup_warning import GetMoveUpWarning
 from deebot_client.commands.json.multimap_state import GetMultimapState
 from deebot_client.commands.json.network import GetNetInfo
@@ -60,6 +65,7 @@ from deebot_client.events import (
     ErrorEvent,
     LifeSpan,
     LifeSpanEvent,
+    MapSetType,
     MoveUpWarningEvent,
     MultimapStateEvent,
     OtaEvent,
@@ -258,6 +264,20 @@ async def test_capabilities_event_extraction(
         assert capabilities.get_refresh_commands(event) == expected_commands, (
             f"Refresh commands doesn't match for {event}"
         )
+
+
+async def test_goat_o1200_area_names_capability() -> None:
+    """Test GOAT O1200 area names capability."""
+    info = await hardware.get_static_device_info("2i0fns")
+    assert info is not None
+    capabilities = info.capabilities
+    areas = capabilities.clean.areas
+    assert areas is not None
+    assert areas.event is RoomsEvent
+    expected_command = GetMapSetV2("", MapSetType.ROOMS)
+    assert areas.get == [expected_command]
+    assert capabilities.get_refresh_commands(RoomsEvent) == [expected_command]
+    assert capabilities.map is None
 
 
 async def test_all_models_loaded() -> None:


### PR DESCRIPTION
## Summary

Add area/zone name support for GOAT mowers, initially enabled for the GOAT O1200 LiDAR Pro (`2i0fns`).

This is a focused replacement for #1626. That earlier PR mixed zone names with mower area settings; this PR only adds the area-name capability and wires it into the existing event/capability architecture.

## Implementation

- Add optional `CapabilityClean.areas` using the existing `RoomsEvent` model.
- Add `GetAreaSet`, matching the command used by the Ecovacs Android app for GOAT mower areas:
  - request: `{"mid":"1","aid":"0","type":"ar"}`
  - decodes the compressed `subsets` payload using the existing `decompress_base64_data` helper
  - emits a `RoomsEvent` with existing `Room` objects
- Enable `GetAreaSet()` as the area refresh command for hardware class `2i0fns`.
- Keep `capabilities.map` unset for the mower; area names do not imply full map support.

## Real-device validation

Captured from a GOAT O1200 LiDAR Pro (`2i0fns`) running firmware `1.13.10`.

The real `getAreaSet` response decoded to these areas:

- Area 4: `Østkanten`
- Area 1: `Sentrum`
- Area 2: `Vestkanten`

An end-to-end live test was also performed without the Ecovacs app open:

1. subscribe to `RoomsEvent`
2. first subscription triggers the capability refresh
3. client sends `getAreaSet`
4. mower returns the compressed area payload
5. parser emits `RoomsEvent(map_id="1", rooms=[...])` with all three expected names and IDs

## Tests

- map command tests: `23 passed`
- targeted O1200 hardware capability test: `1 passed`
- Ruff lint: passed
- Ruff format check: passed

The command regression test uses the captured O1200 payload and verifies the decoded names and IDs, including the `Ø` in `Østkanten`.

Supersedes #1626 for the zone-name part only; mower area parameters/settings remain separate work.