### PR TITLE
Add GOAT rain settings support

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -39,6 +39,8 @@ from deebot_client.events import (
     NetworkInfoEvent,
     OtaEvent,
     PositionsEvent,
+    ProtectStateEvent,
+    RainDelayEvent,
     ReportStatsEvent,
     RoomsEvent,
     SafeProtectEvent,
@@ -220,6 +222,7 @@ class CapabilitySettings:
         | None
     ) = None
     moveup_warning: CapabilitySetEnable[MoveUpWarningEvent] | None = None
+    rain_delay: CapabilitySet[RainDelayEvent, [bool, int]] | None = None
     cross_map_border_warning: CapabilitySetEnable[CrossMapBorderWarningEvent] | None = (
         None
     )
@@ -278,6 +281,7 @@ class Capabilities(ABC):
     map: CapabilityMap | None = None
     network: CapabilityEvent[NetworkInfoEvent]
     play_sound: CapabilityExecute[[]]
+    protect_state: CapabilityEvent[ProtectStateEvent] | None = None
     settings: CapabilitySettings
     state: CapabilityEvent[StateEvent]
     station: CapabilityStation | None = None

--- a/deebot_client/commands/json/__init__.py
+++ b/deebot_client/commands/json/__init__.py
@@ -43,6 +43,7 @@ from .network import GetNetInfo, GetNetInfoLegacy
 from .ota import GetOta, SetOta
 from .play_sound import PlaySound
 from .pos import GetPos
+from .rain_delay import SetRainDelay
 from .relocation import SetRelocationState
 from .safe_protect import GetSafeProtect, SetSafeProtect
 from .stats import GetStats, GetTotalStats
@@ -126,6 +127,7 @@ __all__ = [
     "SetMoveUpWarning",
     "SetMultimapState",
     "SetOta",
+    "SetRainDelay",
     "SetRelocationState",
     "SetSafeProtect",
     "SetSweepMode",
@@ -227,6 +229,8 @@ _COMMANDS: list[type[JsonCommand]] = [
     GetPos,
 
     SetRelocationState,
+
+    SetRainDelay,
 
     GetSafeProtect,
     SetSafeProtect,

--- a/deebot_client/commands/json/rain_delay.py
+++ b/deebot_client/commands/json/rain_delay.py
@@ -1,0 +1,34 @@
+"""Rain delay commands."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Final
+
+from deebot_client.command import InitParam
+
+from .common import ExecuteCommand, JsonCommandMqttP2P
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+RAIN_DELAY_VALUES: Final = frozenset(range(0, 301, 30))
+
+
+class SetRainDelay(ExecuteCommand, JsonCommandMqttP2P):
+    """Set the rain sensor state and post-rain delay in minutes."""
+
+    NAME = "setRainDelay"
+    _mqtt_params = MappingProxyType(
+        {"enable": InitParam(bool, "enabled"), "delay": InitParam(int)}
+    )
+
+    def __init__(self, enabled: bool, delay: int) -> None:
+        if delay not in RAIN_DELAY_VALUES:
+            message = f"Unsupported rain delay: {delay}"
+            raise ValueError(message)
+        super().__init__({"enable": 1 if enabled else 0, "delay": delay})
+
+    def _handle_mqtt_p2p(self, event_bus: EventBus, response: dict[str, Any]) -> None:
+        """Handle the acknowledgement; onRainDelay reports the resulting state."""
+        self.handle(event_bus, response)

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -28,6 +28,8 @@ from .map import (
     PositionsEvent,
 )
 from .network import NetworkInfoEvent
+from .protect_state import ProtectStateEvent
+from .rain_delay import RainDelayEvent
 from .station import StationEvent
 from .work_mode import WorkMode, WorkModeEvent
 
@@ -58,6 +60,8 @@ __all__ = [
     "NetworkInfoEvent",
     "Position",
     "PositionsEvent",
+    "ProtectStateEvent",
+    "RainDelayEvent",
     "StationEvent",
     "SweepModeEvent",
     "WorkMode",

--- a/deebot_client/events/protect_state.py
+++ b/deebot_client/events/protect_state.py
@@ -1,0 +1,20 @@
+"""Protection state events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import Event
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProtectStateEvent(Event):
+    """Raw boolean protection states reported by the device."""
+
+    is_anim_protect: bool
+    is_rain_protect: bool
+    is_rain_delay: bool
+    is_e_stop: bool
+    is_locked: bool
+    is_pin_code: bool
+    is_prepare_data_success: bool

--- a/deebot_client/events/rain_delay.py
+++ b/deebot_client/events/rain_delay.py
@@ -1,0 +1,15 @@
+"""Rain delay events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import Event
+
+
+@dataclass(frozen=True)
+class RainDelayEvent(Event):
+    """Rain sensor configuration, with delay expressed in minutes."""
+
+    enabled: bool
+    delay: int

--- a/deebot_client/hardware/2i0fns.py
+++ b/deebot_client/hardware/2i0fns.py
@@ -28,6 +28,7 @@ from deebot_client.commands.json import (
     SetCrossMapBorderWarning,
     SetCutDirection,
     SetMoveUpWarning,
+    SetRainDelay,
     SetSafeProtect,
 )
 from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
@@ -58,6 +59,8 @@ from deebot_client.events import (
     LifeSpanEvent,
     MoveUpWarningEvent,
     NetworkInfoEvent,
+    ProtectStateEvent,
+    RainDelayEvent,
     ReportStatsEvent,
     SafeProtectEvent,
     StateEvent,
@@ -109,6 +112,7 @@ def get_device_info() -> StaticDeviceInfo:
             ),
             network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
             play_sound=CapabilityExecute(PlaySound),
+            protect_state=CapabilityEvent(ProtectStateEvent, []),
             settings=CapabilitySettings(
                 advanced_mode=CapabilitySetEnable(
                     AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
@@ -125,6 +129,7 @@ def get_device_info() -> StaticDeviceInfo:
                 moveup_warning=CapabilitySetEnable(
                     MoveUpWarningEvent, [GetMoveUpWarning()], SetMoveUpWarning
                 ),
+                rain_delay=CapabilitySet(RainDelayEvent, [], SetRainDelay),
                 cross_map_border_warning=CapabilitySetEnable(
                     CrossMapBorderWarningEvent,
                     [GetCrossMapBorderWarning()],

--- a/deebot_client/messages/json/__init__.py
+++ b/deebot_client/messages/json/__init__.py
@@ -11,6 +11,8 @@ from .auto_empty import OnAutoEmpty
 from .battery import OnBattery
 from .gps_position import OnGpsPos
 from .map import OnCachedMapInfo, OnMajorMap, OnMapInfoV2, OnMapSetV2
+from .protect_state import OnProtectState
+from .rain_delay import OnRainDelay
 from .station_state import OnStationState
 from .stats import OnStats, ReportStats
 from .work_state import OnWorkState
@@ -24,6 +26,8 @@ __all__ = [
     "OnMajorMap",
     "OnMapInfoV2",
     "OnMapSetV2",
+    "OnProtectState",
+    "OnRainDelay",
     "OnStats",
     "OnWorkState",
     "ReportStats",
@@ -42,6 +46,10 @@ _MESSAGES: list[type[Message]] = [
     OnMajorMap,
     OnMapInfoV2,
     OnMapSetV2,
+
+    OnProtectState,
+
+    OnRainDelay,
 
     OnStationState,
 

--- a/deebot_client/messages/json/protect_state.py
+++ b/deebot_client/messages/json/protect_state.py
@@ -1,0 +1,39 @@
+"""Protection state messages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.events.protect_state import ProtectStateEvent
+from deebot_client.message import HandlingResult, MessageBodyDataDict
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+
+class OnProtectState(MessageBodyDataDict):
+    """Protection state update."""
+
+    NAME = "onProtectState"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        """Notify subscribers without interpreting the boolean states.
+
+        During actual rain, isRainProtect=1 and isRainDelay=0 were observed.
+        No semantics are inferred for unobserved transitions or isRainDelay=1.
+        """
+        event_bus.notify(
+            ProtectStateEvent(
+                is_anim_protect=bool(data["isAnimProtect"]),
+                is_rain_protect=bool(data["isRainProtect"]),
+                is_rain_delay=bool(data["isRainDelay"]),
+                is_e_stop=bool(data["isEStop"]),
+                is_locked=bool(data["isLocked"]),
+                is_pin_code=bool(data["isPinCode"]),
+                is_prepare_data_success=bool(data["isPrepareDataSuccess"]),
+            )
+        )
+        return HandlingResult.success()

--- a/deebot_client/messages/json/rain_delay.py
+++ b/deebot_client/messages/json/rain_delay.py
@@ -1,0 +1,27 @@
+"""Rain delay messages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.events.rain_delay import RainDelayEvent
+from deebot_client.message import HandlingResult, MessageBodyDataDict
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+
+class OnRainDelay(MessageBodyDataDict):
+    """Rain sensor configuration update."""
+
+    NAME = "onRainDelay"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        """Notify subscribers with the reported rain sensor configuration."""
+        event_bus.notify(
+            RainDelayEvent(enabled=bool(data["enable"]), delay=int(data["delay"]))
+        )
+        return HandlingResult.success()

--- a/tests/commands/json/test_rain_delay.py
+++ b/tests/commands/json/test_rain_delay.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import orjson
+import pytest
+
+from deebot_client.commands.json import SetRainDelay
+from deebot_client.event_bus import EventBus
+from tests.commands.json import assert_execute_command
+
+
+@pytest.mark.parametrize(
+    ("enabled", "delay"),
+    [
+        (False, 180),
+        (True, 0),
+        (True, 30),
+        (True, 180),
+        (True, 300),
+    ],
+)
+async def test_set_rain_delay(enabled: bool, delay: int) -> None:
+    command = SetRainDelay(enabled, delay)
+    args = {"enable": 1 if enabled else 0, "delay": delay}
+
+    await assert_execute_command(command, args)
+    assert command._get_payload()["body"] == {"data": args}
+    assert command.create_from_mqtt(orjson.dumps({"body": {"data": args}})) == command
+
+    event_bus = Mock(spec_set=EventBus)
+    command.handle_mqtt_p2p(event_bus, orjson.dumps({"body": {"code": 0, "msg": "ok"}}))
+    event_bus.notify.assert_not_called()
+
+
+@pytest.mark.parametrize("delay", [-1, 1, 15, 301])
+def test_set_rain_delay_rejects_unsupported_delay(delay: int) -> None:
+    with pytest.raises(ValueError, match=f"Unsupported rain delay: {delay}"):
+        SetRainDelay(True, delay)

--- a/tests/hardware/test_protect_state.py
+++ b/tests/hardware/test_protect_state.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from deebot_client.events import ProtectStateEvent
+from deebot_client.hardware import get_static_device_info
+from deebot_client.messages import get_message
+from deebot_client.messages.json import OnProtectState
+
+
+async def test_protect_state_capability() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    capability = device_info.capabilities.protect_state
+    assert capability is not None
+    assert capability.event is ProtectStateEvent
+    assert capability.get == []
+    assert device_info.capabilities.get_refresh_commands(ProtectStateEvent) == []
+
+
+async def test_protect_state_registration() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    assert get_message(OnProtectState.NAME, device_info) is OnProtectState

--- a/tests/hardware/test_rain_delay.py
+++ b/tests/hardware/test_rain_delay.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from deebot_client.commands.json import COMMANDS, SetRainDelay
+from deebot_client.events import RainDelayEvent
+from deebot_client.hardware import get_static_device_info
+from deebot_client.messages import get_message
+from deebot_client.messages.json import OnRainDelay
+
+
+async def test_rain_delay_capability() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    capability = device_info.capabilities.settings.rain_delay
+    assert capability is not None
+    assert capability.event is RainDelayEvent
+    assert capability.get == []
+    assert capability.set is SetRainDelay
+    assert device_info.capabilities.get_refresh_commands(RainDelayEvent) == []
+
+
+async def test_rain_delay_registration() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    assert COMMANDS[SetRainDelay.NAME] is SetRainDelay
+    assert get_message(OnRainDelay.NAME, device_info) is OnRainDelay

--- a/tests/messages/json/test_protect_state.py
+++ b/tests/messages/json/test_protect_state.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from deebot_client.events import FirmwareEvent, ProtectStateEvent
+from deebot_client.messages.json import OnProtectState
+from tests.messages.json import assert_message
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (
+            {
+                "isAnimProtect": 0,
+                "isRainProtect": 1,
+                "isRainDelay": 0,
+                "isEStop": 0,
+                "isLocked": 0,
+                "isPinCode": 0,
+                "isPrepareDataSuccess": 1,
+            },
+            ProtectStateEvent(
+                is_anim_protect=False,
+                is_rain_protect=True,
+                is_rain_delay=False,
+                is_e_stop=False,
+                is_locked=False,
+                is_pin_code=False,
+                is_prepare_data_success=True,
+            ),
+        ),
+        (
+            {
+                "isAnimProtect": 0,
+                "isRainProtect": 0,
+                "isRainDelay": 0,
+                "isEStop": 0,
+                "isLocked": 0,
+                "isPinCode": 0,
+                "isPrepareDataSuccess": 0,
+            },
+            ProtectStateEvent(
+                is_anim_protect=False,
+                is_rain_protect=False,
+                is_rain_delay=False,
+                is_e_stop=False,
+                is_locked=False,
+                is_pin_code=False,
+                is_prepare_data_success=False,
+            ),
+        ),
+        (
+            {
+                "isAnimProtect": 1,
+                "isRainProtect": 0,
+                "isRainDelay": 1,
+                "isEStop": 0,
+                "isLocked": 1,
+                "isPinCode": 0,
+                "isPrepareDataSuccess": 1,
+            },
+            ProtectStateEvent(
+                is_anim_protect=True,
+                is_rain_protect=False,
+                is_rain_delay=True,
+                is_e_stop=False,
+                is_locked=True,
+                is_pin_code=False,
+                is_prepare_data_success=True,
+            ),
+        ),
+    ],
+    ids=["observed-rain", "all-zero", "bool-conversion"],
+)
+def test_on_protect_state(data: dict[str, Any], expected: ProtectStateEvent) -> None:
+    payload = {
+        "header": {"fwVer": "1.13.10"},
+        "body": {"data": data, "code": 0, "msg": "ok"},
+    }
+
+    assert_message(OnProtectState, payload, (FirmwareEvent("1.13.10"), expected))

--- a/tests/messages/json/test_rain_delay.py
+++ b/tests/messages/json/test_rain_delay.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from deebot_client.events import FirmwareEvent, RainDelayEvent
+from deebot_client.messages.json import OnRainDelay
+from tests.messages.json import assert_message
+
+
+@pytest.mark.parametrize(
+    ("enable", "delay", "enabled"),
+    [(0, 180, False), (1, 0, True), (1, 30, True), (1, 300, True)],
+)
+def test_on_rain_delay(enable: int, delay: int, enabled: bool) -> None:
+    data = {
+        "header": {"fwVer": "1.13.10"},
+        "body": {"data": {"enable": enable, "delay": delay}},
+    }
+
+    assert_message(
+        OnRainDelay,
+        data,
+        (FirmwareEvent("1.13.10"), RainDelayEvent(enabled=enabled, delay=delay)),
+    )


### PR DESCRIPTION
## Summary

- add `SetRainDelay` support for GOAT mower class `2i0fns`
- add `RainDelayEvent` parsing from `onRainDelay`
- add read-only `ProtectStateEvent` parsing from `onProtectState`
- expose both through device capabilities without undocumented refresh commands

## Protocol

`SetRainDelay` sends the observed `enable` and `delay` fields. Supported delay values are 0 through 300 in 30-minute steps.

`onRainDelay` updates the configuration event. `onProtectState` exposes the reported boolean protection flags without additional semantic interpretation.

No `getRainDelay` or `getProtectState` command is introduced; both capabilities use an empty get-command list.

## Testing

- 20 focused rain/protect-state tests passed
- 729 tests passed in the broad Windows-compatible suite (11 deselected)
- Ruff passed
- mypy passed
- `git diff --check` passed

## Notes

- event code 2052 and rain-specific pause-reason mappings are intentionally not included because their semantics are not yet sufficiently documented.
