### PR TITLE
Add GOAT mower settings support

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -39,6 +39,8 @@ from deebot_client.events import (
     NetworkInfoEvent,
     OtaEvent,
     PositionsEvent,
+    ProtectStateEvent,
+    RainDelayEvent,
     ReportStatsEvent,
     RoomsEvent,
     SafeProtectEvent,
@@ -220,6 +222,7 @@ class CapabilitySettings:
         | None
     ) = None
     moveup_warning: CapabilitySetEnable[MoveUpWarningEvent] | None = None
+    rain_delay: CapabilitySet[RainDelayEvent, [bool, int]] | None = None
     cross_map_border_warning: CapabilitySetEnable[CrossMapBorderWarningEvent] | None = (
         None
     )
@@ -278,6 +281,7 @@ class Capabilities(ABC):
     map: CapabilityMap | None = None
     network: CapabilityEvent[NetworkInfoEvent]
     play_sound: CapabilityExecute[[]]
+    protect_state: CapabilityEvent[ProtectStateEvent] | None = None
     settings: CapabilitySettings
     state: CapabilityEvent[StateEvent]
     station: CapabilityStation | None = None

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 from deebot_client.events import (
     AdvancedModeEvent,
+    AiRecognitionEvent,
+    AnimalProtectionEvent,
     AvailabilityEvent,
     BatteryEvent,
     BorderSpinEvent,
@@ -26,8 +28,10 @@ from deebot_client.events import (
     CutDirectionEvent,
     ErrorEvent,
     Event,
+    FallVolumeEvent,
     FanSpeedEvent,
     FanSpeedLevel,
+    HumanoidAiEvent,
     LifeSpan,
     LifeSpanEvent,
     MajorMapEvent,
@@ -36,6 +40,7 @@ from deebot_client.events import (
     MapTraceEvent,
     MoveUpWarningEvent,
     MultimapStateEvent,
+    NarrowAdaptEvent,
     NetworkInfoEvent,
     OtaEvent,
     PositionsEvent,
@@ -208,6 +213,10 @@ class CapabilitySettings:
     """Capabilities for settings."""
 
     advanced_mode: CapabilitySetEnable[AdvancedModeEvent] | None = None
+    ai_recognition: CapabilitySetEnable[AiRecognitionEvent] | None = None
+    animal_protection: CapabilitySet[AnimalProtectionEvent, [bool, str, str]] | None = (
+        None
+    )
     carpet_auto_fan_boost: CapabilitySetEnable[CarpetAutoFanBoostEvent] | None = None
     efficiency_mode: (
         CapabilitySetTypes[EfficiencyModeEvent, [EfficiencyMode | str], EfficiencyMode]
@@ -222,6 +231,8 @@ class CapabilitySettings:
         | None
     ) = None
     moveup_warning: CapabilitySetEnable[MoveUpWarningEvent] | None = None
+    humanoid_ai: CapabilitySetEnable[HumanoidAiEvent] | None = None
+    narrow_adapt: CapabilitySetEnable[NarrowAdaptEvent] | None = None
     rain_delay: CapabilitySet[RainDelayEvent, [bool, int]] | None = None
     cross_map_border_warning: CapabilitySetEnable[CrossMapBorderWarningEvent] | None = (
         None
@@ -232,6 +243,7 @@ class CapabilitySettings:
     true_detect: CapabilitySetEnable[TrueDetectEvent] | None = None
     voice_assistant: CapabilitySetEnable[VoiceAssistantStateEvent] | None = None
     volume: CapabilitySet[VolumeEvent, [int]] | None = None
+    fall_volume: CapabilitySet[FallVolumeEvent, [int]] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/deebot_client/commands/json/__init__.py
+++ b/deebot_client/commands/json/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from . import auto_empty, station_action, station_state
 from .advanced_mode import GetAdvancedMode, SetAdvancedMode
+from .animal_protection import GetAnimalProtection, SetAnimalProtection
 from .battery import GetBattery
 from .border_spin import GetBorderSpin, SetBorderSpin
 from .border_switch import GetBorderSwitch, SetBorderSwitch
@@ -24,6 +25,7 @@ from .cut_direction import GetCutDirection, SetCutDirection
 from .efficiency import GetEfficiencyMode, SetEfficiencyMode
 from .error import GetError
 from .fan_speed import GetFanSpeed, SetFanSpeed
+from .humanoid_ai import GetHumanoidAi, SetHumanoidAi
 from .life_span import GetLifeSpan, ResetLifeSpan
 from .map import (
     GetCachedMapInfo,
@@ -39,18 +41,20 @@ from .map import (
 from .mop_auto_wash_frequency import GetMopAutoWashFrequency, SetMopAutoWashFrequency
 from .moveup_warning import GetMoveUpWarning, SetMoveUpWarning
 from .multimap_state import GetMultimapState, SetMultimapState
+from .narrow_adapt import GetNarrowAdapt, SetNarrowAdapt
 from .network import GetNetInfo, GetNetInfoLegacy
 from .ota import GetOta, SetOta
 from .play_sound import PlaySound
 from .pos import GetPos
 from .rain_delay import SetRainDelay
+from .recognization import GetRecognization, SetRecognization
 from .relocation import SetRelocationState
 from .safe_protect import GetSafeProtect, SetSafeProtect
 from .stats import GetStats, GetTotalStats
 from .sweep_mode import GetSweepMode, SetSweepMode
 from .true_detect import GetTrueDetect, SetTrueDetect
 from .voice_assistant_state import GetVoiceAssistantState, SetVoiceAssistantState
-from .volume import GetVolume, SetVolume
+from .volume import GetVolume, SetFallVolume, SetVolume
 from .water_info import GetWaterInfo, SetWaterInfo
 from .work_mode import GetWorkMode, SetWorkMode
 
@@ -66,6 +70,7 @@ __all__ = [
     "CleanV2",
     "ClearMap",
     "GetAdvancedMode",
+    "GetAnimalProtection",
     "GetBattery",
     "GetBorderSpin",
     "GetBorderSwitch",
@@ -84,6 +89,7 @@ __all__ = [
     "GetEfficiencyMode",
     "GetError",
     "GetFanSpeed",
+    "GetHumanoidAi",
     "GetLifeSpan",
     "GetMajorMap",
     "GetMapInfoV2",
@@ -95,10 +101,12 @@ __all__ = [
     "GetMopAutoWashFrequency",
     "GetMoveUpWarning",
     "GetMultimapState",
+    "GetNarrowAdapt",
     "GetNetInfo",
     "GetNetInfoLegacy",
     "GetOta",
     "GetPos",
+    "GetRecognization",
     "GetSafeProtect",
     "GetStats",
     "GetSweepMode",
@@ -111,6 +119,7 @@ __all__ = [
     "PlaySound",
     "ResetLifeSpan",
     "SetAdvancedMode",
+    "SetAnimalProtection",
     "SetBorderSpin",
     "SetBorderSwitch",
     "SetCarpetAutoFanBoost",
@@ -121,13 +130,17 @@ __all__ = [
     "SetCrossMapBorderWarning",
     "SetCutDirection",
     "SetEfficiencyMode",
+    "SetFallVolume",
     "SetFanSpeed",
+    "SetHumanoidAi",
     "SetMajorMap",
     "SetMopAutoWashFrequency",
     "SetMoveUpWarning",
     "SetMultimapState",
+    "SetNarrowAdapt",
     "SetOta",
     "SetRainDelay",
+    "SetRecognization",
     "SetRelocationState",
     "SetSafeProtect",
     "SetSweepMode",
@@ -143,6 +156,9 @@ __all__ = [
 _COMMANDS: list[type[JsonCommand]] = [
     GetAdvancedMode,
     SetAdvancedMode,
+
+    GetAnimalProtection,
+    SetAnimalProtection,
 
     auto_empty.GetAutoEmpty,
     auto_empty.SetAutoEmpty,
@@ -199,6 +215,9 @@ _COMMANDS: list[type[JsonCommand]] = [
     GetLifeSpan,
     ResetLifeSpan,
 
+    GetHumanoidAi,
+    SetHumanoidAi,
+
     GetCachedMapInfo,
     GetMajorMap,
     GetMapInfoV2,
@@ -214,6 +233,9 @@ _COMMANDS: list[type[JsonCommand]] = [
 
     GetMoveUpWarning,
     SetMoveUpWarning,
+
+    GetNarrowAdapt,
+    SetNarrowAdapt,
 
     GetMultimapState,
     SetMultimapState,
@@ -231,6 +253,9 @@ _COMMANDS: list[type[JsonCommand]] = [
     SetRelocationState,
 
     SetRainDelay,
+
+    GetRecognization,
+    SetRecognization,
 
     GetSafeProtect,
     SetSafeProtect,

--- a/deebot_client/commands/json/__init__.py
+++ b/deebot_client/commands/json/__init__.py
@@ -43,6 +43,7 @@ from .network import GetNetInfo, GetNetInfoLegacy
 from .ota import GetOta, SetOta
 from .play_sound import PlaySound
 from .pos import GetPos
+from .rain_delay import SetRainDelay
 from .relocation import SetRelocationState
 from .safe_protect import GetSafeProtect, SetSafeProtect
 from .stats import GetStats, GetTotalStats
@@ -126,6 +127,7 @@ __all__ = [
     "SetMoveUpWarning",
     "SetMultimapState",
     "SetOta",
+    "SetRainDelay",
     "SetRelocationState",
     "SetSafeProtect",
     "SetSweepMode",
@@ -227,6 +229,8 @@ _COMMANDS: list[type[JsonCommand]] = [
     GetPos,
 
     SetRelocationState,
+
+    SetRainDelay,
 
     GetSafeProtect,
     SetSafeProtect,

--- a/deebot_client/commands/json/animal_protection.py
+++ b/deebot_client/commands/json/animal_protection.py
@@ -1,0 +1,63 @@
+"""Animal protection commands."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.command import InitParam
+from deebot_client.events import AnimalProtectionEvent
+from deebot_client.message import HandlingResult
+
+from .common import JsonGetCommand, JsonSetCommand
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+
+def normalize_time(value: str) -> str:
+    """Normalize device times to zero-padded HH:MM."""
+    hour, minute = value.split(":", maxsplit=1)
+    return f"{hour.zfill(2)}:{minute.zfill(2)}"
+
+
+class GetAnimalProtection(JsonGetCommand):
+    """Get animal protection configuration."""
+
+    NAME = "getAnimProtect"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        event_bus.notify(
+            AnimalProtectionEvent(
+                enabled=bool(data["enable"]),
+                start=normalize_time(data["start"]),
+                end=normalize_time(data["end"]),
+            )
+        )
+        return HandlingResult.success()
+
+
+class SetAnimalProtection(JsonSetCommand):
+    """Set the complete animal protection configuration."""
+
+    NAME = "setAnimProtect"
+    get_command = GetAnimalProtection
+    _mqtt_params = MappingProxyType(
+        {
+            "enable": InitParam(bool, "enabled"),
+            "start": InitParam(str),
+            "end": InitParam(str),
+        }
+    )
+
+    def __init__(self, enabled: bool, start: str, end: str) -> None:
+        super().__init__(
+            {
+                "enable": 1 if enabled else 0,
+                "start": normalize_time(start),
+                "end": normalize_time(end),
+            }
+        )

--- a/deebot_client/commands/json/humanoid_ai.py
+++ b/deebot_client/commands/json/humanoid_ai.py
@@ -1,0 +1,21 @@
+"""Smart mowing with avoidance commands."""
+
+from __future__ import annotations
+
+from deebot_client.events import HumanoidAiEvent
+
+from .common import GetEnableCommand, SetEnableCommand
+
+
+class GetHumanoidAi(GetEnableCommand):
+    """Get smart mowing with avoidance state."""
+
+    NAME = "getHumanoidAI"
+    EVENT_TYPE = HumanoidAiEvent
+
+
+class SetHumanoidAi(SetEnableCommand):
+    """Set smart mowing with avoidance state."""
+
+    NAME = "setHumanoidAI"
+    get_command = GetHumanoidAi

--- a/deebot_client/commands/json/narrow_adapt.py
+++ b/deebot_client/commands/json/narrow_adapt.py
@@ -1,0 +1,23 @@
+"""Narrow passage adaptation commands."""
+
+from __future__ import annotations
+
+from deebot_client.events import NarrowAdaptEvent
+
+from .common import GetEnableCommand, SetEnableCommand
+
+
+class GetNarrowAdapt(GetEnableCommand):
+    """Get narrow passage adaptation state."""
+
+    NAME = "getNarrowAdapt"
+    EVENT_TYPE = NarrowAdaptEvent
+    _field_name = "state"
+
+
+class SetNarrowAdapt(SetEnableCommand):
+    """Set narrow passage adaptation state."""
+
+    NAME = "setNarrowAdapt"
+    get_command = GetNarrowAdapt
+    _field_name = "state"

--- a/deebot_client/commands/json/rain_delay.py
+++ b/deebot_client/commands/json/rain_delay.py
@@ -1,0 +1,34 @@
+"""Rain delay commands."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Final
+
+from deebot_client.command import InitParam
+
+from .common import ExecuteCommand, JsonCommandMqttP2P
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+RAIN_DELAY_VALUES: Final = frozenset(range(0, 301, 30))
+
+
+class SetRainDelay(ExecuteCommand, JsonCommandMqttP2P):
+    """Set the rain sensor state and post-rain delay in minutes."""
+
+    NAME = "setRainDelay"
+    _mqtt_params = MappingProxyType(
+        {"enable": InitParam(bool, "enabled"), "delay": InitParam(int)}
+    )
+
+    def __init__(self, enabled: bool, delay: int) -> None:
+        if delay not in RAIN_DELAY_VALUES:
+            message = f"Unsupported rain delay: {delay}"
+            raise ValueError(message)
+        super().__init__({"enable": 1 if enabled else 0, "delay": delay})
+
+    def _handle_mqtt_p2p(self, event_bus: EventBus, response: dict[str, Any]) -> None:
+        """Handle the acknowledgement; onRainDelay reports the resulting state."""
+        self.handle(event_bus, response)

--- a/deebot_client/commands/json/recognization.py
+++ b/deebot_client/commands/json/recognization.py
@@ -1,0 +1,23 @@
+"""AI recognition commands."""
+
+from __future__ import annotations
+
+from deebot_client.events import AiRecognitionEvent
+
+from .common import GetEnableCommand, SetEnableCommand
+
+
+class GetRecognization(GetEnableCommand):
+    """Get AI recognition state."""
+
+    NAME = "getRecognization"
+    EVENT_TYPE = AiRecognitionEvent
+    _field_name = "state"
+
+
+class SetRecognization(SetEnableCommand):
+    """Set AI recognition state."""
+
+    NAME = "setRecognization"
+    get_command = GetRecognization
+    _field_name = "state"

--- a/deebot_client/commands/json/volume.py
+++ b/deebot_client/commands/json/volume.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from deebot_client.command import InitParam
-from deebot_client.events import VolumeEvent
+from deebot_client.events import FallVolumeEvent, VolumeEvent
 from deebot_client.message import HandlingResult
 
 from .common import JsonGetCommand, JsonSetCommand
@@ -28,7 +28,17 @@ class GetVolume(JsonGetCommand):
 
         :return: A message response
         """
+        if data.get("type") == "fall":
+            event_bus.notify(
+                FallVolumeEvent(volume=data["volume"], maximum=data.get("total"))
+            )
+            return HandlingResult.success()
+
         event_bus.notify(VolumeEvent(volume=data["volume"], maximum=data.get("total")))
+        if "fallVolume" in data:
+            event_bus.notify(
+                FallVolumeEvent(volume=data["fallVolume"], maximum=data.get("total"))
+            )
         return HandlingResult.success()
 
 
@@ -40,9 +50,34 @@ class SetVolume(JsonSetCommand):
     _mqtt_params = MappingProxyType(
         {
             "volume": InitParam(int),
-            "total": None,  # Remove it as we don't can set it (App includes it)
+            "type": InitParam(str, "channel", optional=True),
+            "total": InitParam(int, optional=True),
         }
     )
 
-    def __init__(self, volume: int) -> None:
-        super().__init__({"volume": volume})
+    def __init__(
+        self, volume: int, channel: str | None = None, total: int | None = None
+    ) -> None:
+        args: dict[str, Any] = {"volume": volume}
+        if channel is not None:
+            args["type"] = channel
+        if total is not None:
+            args["total"] = total
+        super().__init__(args)
+
+
+class SetFallVolume(JsonSetCommand):
+    """Set lifted-alarm volume."""
+
+    NAME = "setVolume"
+    get_command = GetVolume
+    _mqtt_params = MappingProxyType(
+        {
+            "volume": InitParam(int),
+            "type": None,
+            "total": InitParam(int, optional=True),
+        }
+    )
+
+    def __init__(self, volume: int, total: int = 10) -> None:
+        super().__init__({"type": "fall", "total": total, "volume": volume})

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -28,6 +28,8 @@ from .map import (
     PositionsEvent,
 )
 from .network import NetworkInfoEvent
+from .protect_state import ProtectStateEvent
+from .rain_delay import RainDelayEvent
 from .station import StationEvent
 from .work_mode import WorkMode, WorkModeEvent
 
@@ -58,6 +60,8 @@ __all__ = [
     "NetworkInfoEvent",
     "Position",
     "PositionsEvent",
+    "ProtectStateEvent",
+    "RainDelayEvent",
     "StationEvent",
     "SweepModeEvent",
     "WorkMode",

--- a/deebot_client/events/__init__.py
+++ b/deebot_client/events/__init__.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from deebot_client.util.enum import StrEnumWithXml
 
 from . import auto_empty, mop_auto_wash_frequency, station, water_info
+from .animal_protection import AnimalProtectionEvent
 from .auto_empty import AutoEmptyEvent
 from .base import Event
 from .efficiency_mode import EfficiencyMode, EfficiencyModeEvent
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
     from deebot_client.models import Room, State
 
 __all__ = [
+    "AnimalProtectionEvent",
     "AutoEmptyEvent",
     "BatteryEvent",
     "CachedMapInfoEvent",
@@ -247,6 +249,14 @@ class VolumeEvent(Event):
 
 
 @dataclass(frozen=True)
+class FallVolumeEvent(Event):
+    """Lifted-alarm volume event."""
+
+    volume: int
+    maximum: int | None
+
+
+@dataclass(frozen=True)
 class EnableEvent(Event):
     """Enabled event."""
 
@@ -316,6 +326,21 @@ class CrossMapBorderWarningEvent(EnableEvent):
 @dataclass(frozen=True)
 class MoveUpWarningEvent(EnableEvent):
     """Move up warning event."""
+
+
+@dataclass(frozen=True)
+class AiRecognitionEvent(EnableEvent):
+    """AI recognition event."""
+
+
+@dataclass(frozen=True)
+class HumanoidAiEvent(EnableEvent):
+    """Smart mowing with avoidance event."""
+
+
+@dataclass(frozen=True)
+class NarrowAdaptEvent(EnableEvent):
+    """Narrow passage adaptation event."""
 
 
 @dataclass(frozen=True)

--- a/deebot_client/events/animal_protection.py
+++ b/deebot_client/events/animal_protection.py
@@ -1,0 +1,16 @@
+"""Animal protection events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import Event
+
+
+@dataclass(frozen=True)
+class AnimalProtectionEvent(Event):
+    """Animal protection schedule."""
+
+    enabled: bool
+    start: str
+    end: str

--- a/deebot_client/events/protect_state.py
+++ b/deebot_client/events/protect_state.py
@@ -1,0 +1,20 @@
+"""Protection state events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import Event
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProtectStateEvent(Event):
+    """Raw boolean protection states reported by the device."""
+
+    is_anim_protect: bool
+    is_rain_protect: bool
+    is_rain_delay: bool
+    is_e_stop: bool
+    is_locked: bool
+    is_pin_code: bool
+    is_prepare_data_success: bool

--- a/deebot_client/events/rain_delay.py
+++ b/deebot_client/events/rain_delay.py
@@ -1,0 +1,15 @@
+"""Rain delay events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import Event
+
+
+@dataclass(frozen=True)
+class RainDelayEvent(Event):
+    """Rain sensor configuration, with delay expressed in minutes."""
+
+    enabled: bool
+    delay: int

--- a/deebot_client/hardware/2i0fns.py
+++ b/deebot_client/hardware/2i0fns.py
@@ -17,18 +17,26 @@ from deebot_client.capabilities import (
     DeviceType,
 )
 from deebot_client.commands.json import (
+    GetAnimalProtection,
     GetBorderSwitch,
     GetChildLock,
     GetCrossMapBorderWarning,
     GetCutDirection,
+    GetHumanoidAi,
     GetMoveUpWarning,
+    GetNarrowAdapt,
+    GetRecognization,
     GetSafeProtect,
+    SetAnimalProtection,
     SetBorderSwitch,
     SetChildLock,
     SetCrossMapBorderWarning,
     SetCutDirection,
+    SetHumanoidAi,
     SetMoveUpWarning,
+    SetNarrowAdapt,
     SetRainDelay,
+    SetRecognization,
     SetSafeProtect,
 )
 from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
@@ -43,10 +51,12 @@ from deebot_client.commands.json.network import GetNetInfo
 from deebot_client.commands.json.play_sound import PlaySound
 from deebot_client.commands.json.stats import GetStats, GetTotalStats
 from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
-from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.volume import GetVolume, SetFallVolume, SetVolume
 from deebot_client.const import DataType
 from deebot_client.events import (
     AdvancedModeEvent,
+    AiRecognitionEvent,
+    AnimalProtectionEvent,
     AvailabilityEvent,
     BatteryEvent,
     BorderSwitchEvent,
@@ -55,9 +65,12 @@ from deebot_client.events import (
     CustomCommandEvent,
     CutDirectionEvent,
     ErrorEvent,
+    FallVolumeEvent,
+    HumanoidAiEvent,
     LifeSpan,
     LifeSpanEvent,
     MoveUpWarningEvent,
+    NarrowAdaptEvent,
     NetworkInfoEvent,
     ProtectStateEvent,
     RainDelayEvent,
@@ -114,6 +127,14 @@ def get_device_info() -> StaticDeviceInfo:
             play_sound=CapabilityExecute(PlaySound),
             protect_state=CapabilityEvent(ProtectStateEvent, []),
             settings=CapabilitySettings(
+                ai_recognition=CapabilitySetEnable(
+                    AiRecognitionEvent, [GetRecognization()], SetRecognization
+                ),
+                animal_protection=CapabilitySet(
+                    AnimalProtectionEvent,
+                    [GetAnimalProtection()],
+                    SetAnimalProtection,
+                ),
                 advanced_mode=CapabilitySetEnable(
                     AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
                 ),
@@ -129,6 +150,12 @@ def get_device_info() -> StaticDeviceInfo:
                 moveup_warning=CapabilitySetEnable(
                     MoveUpWarningEvent, [GetMoveUpWarning()], SetMoveUpWarning
                 ),
+                humanoid_ai=CapabilitySetEnable(
+                    HumanoidAiEvent, [GetHumanoidAi()], SetHumanoidAi
+                ),
+                narrow_adapt=CapabilitySetEnable(
+                    NarrowAdaptEvent, [GetNarrowAdapt()], SetNarrowAdapt
+                ),
                 rain_delay=CapabilitySet(RainDelayEvent, [], SetRainDelay),
                 cross_map_border_warning=CapabilitySetEnable(
                     CrossMapBorderWarningEvent,
@@ -141,7 +168,14 @@ def get_device_info() -> StaticDeviceInfo:
                 true_detect=CapabilitySetEnable(
                     TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
                 ),
-                volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+                volume=CapabilitySet(
+                    VolumeEvent,
+                    [GetVolume()],
+                    lambda volume: SetVolume(volume, channel="sys", total=10),
+                ),
+                fall_volume=CapabilitySet(
+                    FallVolumeEvent, [GetVolume()], SetFallVolume
+                ),
             ),
             state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfoV2()]),
             stats=CapabilityStats(

--- a/deebot_client/hardware/2i0fns.py
+++ b/deebot_client/hardware/2i0fns.py
@@ -28,6 +28,7 @@ from deebot_client.commands.json import (
     SetCrossMapBorderWarning,
     SetCutDirection,
     SetMoveUpWarning,
+    SetRainDelay,
     SetSafeProtect,
 )
 from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
@@ -58,6 +59,8 @@ from deebot_client.events import (
     LifeSpanEvent,
     MoveUpWarningEvent,
     NetworkInfoEvent,
+    ProtectStateEvent,
+    RainDelayEvent,
     ReportStatsEvent,
     SafeProtectEvent,
     StateEvent,
@@ -109,6 +112,7 @@ def get_device_info() -> StaticDeviceInfo:
             ),
             network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
             play_sound=CapabilityExecute(PlaySound),
+            protect_state=CapabilityEvent(ProtectStateEvent, []),
             settings=CapabilitySettings(
                 advanced_mode=CapabilitySetEnable(
                     AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
@@ -125,6 +129,7 @@ def get_device_info() -> StaticDeviceInfo:
                 moveup_warning=CapabilitySetEnable(
                     MoveUpWarningEvent, [GetMoveUpWarning()], SetMoveUpWarning
                 ),
+                rain_delay=CapabilitySet(RainDelayEvent, [], SetRainDelay),
                 cross_map_border_warning=CapabilitySetEnable(
                     CrossMapBorderWarningEvent,
                     [GetCrossMapBorderWarning()],

--- a/deebot_client/messages/json/__init__.py
+++ b/deebot_client/messages/json/__init__.py
@@ -11,6 +11,8 @@ from .auto_empty import OnAutoEmpty
 from .battery import OnBattery
 from .gps_position import OnGpsPos
 from .map import OnCachedMapInfo, OnMajorMap, OnMapInfoV2, OnMapSetV2
+from .protect_state import OnProtectState
+from .rain_delay import OnRainDelay
 from .station_state import OnStationState
 from .stats import OnStats, ReportStats
 from .work_state import OnWorkState
@@ -24,6 +26,8 @@ __all__ = [
     "OnMajorMap",
     "OnMapInfoV2",
     "OnMapSetV2",
+    "OnProtectState",
+    "OnRainDelay",
     "OnStats",
     "OnWorkState",
     "ReportStats",
@@ -42,6 +46,10 @@ _MESSAGES: list[type[Message]] = [
     OnMajorMap,
     OnMapInfoV2,
     OnMapSetV2,
+
+    OnProtectState,
+
+    OnRainDelay,
 
     OnStationState,
 

--- a/deebot_client/messages/json/__init__.py
+++ b/deebot_client/messages/json/__init__.py
@@ -11,6 +11,14 @@ from .auto_empty import OnAutoEmpty
 from .battery import OnBattery
 from .gps_position import OnGpsPos
 from .map import OnCachedMapInfo, OnMajorMap, OnMapInfoV2, OnMapSetV2
+from .mower_settings import (
+    OnAnimalProtection,
+    OnHumanoidAi,
+    OnMoveUpWarning,
+    OnNarrowAdapt,
+    OnRecognization,
+    OnVolume,
+)
 from .protect_state import OnProtectState
 from .rain_delay import OnRainDelay
 from .station_state import OnStationState
@@ -20,15 +28,21 @@ from .work_state import OnWorkState
 _LOGGER = get_logger(__name__)
 
 __all__ = [
+    "OnAnimalProtection",
     "OnBattery",
     "OnCachedMapInfo",
     "OnGpsPos",
+    "OnHumanoidAi",
     "OnMajorMap",
     "OnMapInfoV2",
     "OnMapSetV2",
+    "OnMoveUpWarning",
+    "OnNarrowAdapt",
     "OnProtectState",
     "OnRainDelay",
+    "OnRecognization",
     "OnStats",
+    "OnVolume",
     "OnWorkState",
     "ReportStats",
 ]
@@ -46,6 +60,13 @@ _MESSAGES: list[type[Message]] = [
     OnMajorMap,
     OnMapInfoV2,
     OnMapSetV2,
+
+    OnAnimalProtection,
+    OnHumanoidAi,
+    OnMoveUpWarning,
+    OnNarrowAdapt,
+    OnRecognization,
+    OnVolume,
 
     OnProtectState,
 

--- a/deebot_client/messages/json/mower_settings.py
+++ b/deebot_client/messages/json/mower_settings.py
@@ -1,0 +1,46 @@
+"""Mower setting push messages."""
+
+from __future__ import annotations
+
+from deebot_client.commands.json.animal_protection import GetAnimalProtection
+from deebot_client.commands.json.humanoid_ai import GetHumanoidAi
+from deebot_client.commands.json.moveup_warning import GetMoveUpWarning
+from deebot_client.commands.json.narrow_adapt import GetNarrowAdapt
+from deebot_client.commands.json.recognization import GetRecognization
+from deebot_client.commands.json.volume import GetVolume
+
+
+class OnRecognization(GetRecognization):
+    """AI recognition update."""
+
+    NAME = "onRecognization"
+
+
+class OnHumanoidAi(GetHumanoidAi):
+    """Smart mowing with avoidance update."""
+
+    NAME = "onHumanoidAI"
+
+
+class OnNarrowAdapt(GetNarrowAdapt):
+    """Narrow passage adaptation update."""
+
+    NAME = "onNarrowAdapt"
+
+
+class OnMoveUpWarning(GetMoveUpWarning):
+    """Mower lifted alarm update."""
+
+    NAME = "onMoveupWarning"
+
+
+class OnAnimalProtection(GetAnimalProtection):
+    """Animal protection configuration update."""
+
+    NAME = "onAnimProtect"
+
+
+class OnVolume(GetVolume):
+    """Mower volume configuration update."""
+
+    NAME = "onVolume"

--- a/deebot_client/messages/json/protect_state.py
+++ b/deebot_client/messages/json/protect_state.py
@@ -1,0 +1,39 @@
+"""Protection state messages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.events.protect_state import ProtectStateEvent
+from deebot_client.message import HandlingResult, MessageBodyDataDict
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+
+class OnProtectState(MessageBodyDataDict):
+    """Protection state update."""
+
+    NAME = "onProtectState"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        """Notify subscribers without interpreting the boolean states.
+
+        During actual rain, isRainProtect=1 and isRainDelay=0 were observed.
+        No semantics are inferred for unobserved transitions or isRainDelay=1.
+        """
+        event_bus.notify(
+            ProtectStateEvent(
+                is_anim_protect=bool(data["isAnimProtect"]),
+                is_rain_protect=bool(data["isRainProtect"]),
+                is_rain_delay=bool(data["isRainDelay"]),
+                is_e_stop=bool(data["isEStop"]),
+                is_locked=bool(data["isLocked"]),
+                is_pin_code=bool(data["isPinCode"]),
+                is_prepare_data_success=bool(data["isPrepareDataSuccess"]),
+            )
+        )
+        return HandlingResult.success()

--- a/deebot_client/messages/json/rain_delay.py
+++ b/deebot_client/messages/json/rain_delay.py
@@ -1,0 +1,27 @@
+"""Rain delay messages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.events.rain_delay import RainDelayEvent
+from deebot_client.message import HandlingResult, MessageBodyDataDict
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+
+class OnRainDelay(MessageBodyDataDict):
+    """Rain sensor configuration update."""
+
+    NAME = "onRainDelay"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        """Notify subscribers with the reported rain sensor configuration."""
+        event_bus.notify(
+            RainDelayEvent(enabled=bool(data["enable"]), delay=int(data["delay"]))
+        )
+        return HandlingResult.success()

--- a/tests/commands/json/test_mower_settings.py
+++ b/tests/commands/json/test_mower_settings.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from deebot_client.commands.json import (
+    GetAnimalProtection,
+    GetHumanoidAi,
+    GetNarrowAdapt,
+    GetRecognization,
+    SetAnimalProtection,
+    SetHumanoidAi,
+    SetNarrowAdapt,
+    SetRecognization,
+)
+from deebot_client.events import (
+    AiRecognitionEvent,
+    AnimalProtectionEvent,
+    HumanoidAiEvent,
+    NarrowAdaptEvent,
+)
+from tests.helpers import get_request_json, get_success_body
+
+from . import assert_command, assert_set_command, assert_set_enable_command
+
+
+@pytest.mark.parametrize(
+    ("get_command", "set_command", "event_type", "field_name"),
+    [
+        (GetRecognization, SetRecognization, AiRecognitionEvent, "state"),
+        (GetHumanoidAi, SetHumanoidAi, HumanoidAiEvent, "enable"),
+        (GetNarrowAdapt, SetNarrowAdapt, NarrowAdaptEvent, "state"),
+    ],
+)
+@pytest.mark.parametrize("enabled", [False, True])
+async def test_enable_settings(
+    get_command: type,
+    set_command: type,
+    event_type: type,
+    field_name: str,
+    *,
+    enabled: bool,
+) -> None:
+    json, firmware_event = get_request_json(
+        get_success_body({field_name: int(enabled)})
+    )
+    await assert_command(get_command(), json, (firmware_event, event_type(enabled)))
+    await assert_set_enable_command(
+        set_command(enabled), event_type, enabled=enabled, field_name=field_name
+    )
+
+
+async def test_animal_protection() -> None:
+    json, firmware_event = get_request_json(
+        get_success_body({"enable": 1, "start": "23:45", "end": "6:30"})
+    )
+    event = AnimalProtectionEvent(True, "23:45", "06:30")
+    await assert_command(GetAnimalProtection(), json, (firmware_event, event))
+    await assert_set_command(
+        SetAnimalProtection(True, "23:45", "6:30"),
+        {"enable": 1, "start": "23:45", "end": "06:30"},
+        event,
+    )

--- a/tests/commands/json/test_rain_delay.py
+++ b/tests/commands/json/test_rain_delay.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import orjson
+import pytest
+
+from deebot_client.commands.json import SetRainDelay
+from deebot_client.event_bus import EventBus
+from tests.commands.json import assert_execute_command
+
+
+@pytest.mark.parametrize(
+    ("enabled", "delay"),
+    [
+        (False, 180),
+        (True, 0),
+        (True, 30),
+        (True, 180),
+        (True, 300),
+    ],
+)
+async def test_set_rain_delay(enabled: bool, delay: int) -> None:
+    command = SetRainDelay(enabled, delay)
+    args = {"enable": 1 if enabled else 0, "delay": delay}
+
+    await assert_execute_command(command, args)
+    assert command._get_payload()["body"] == {"data": args}
+    assert command.create_from_mqtt(orjson.dumps({"body": {"data": args}})) == command
+
+    event_bus = Mock(spec_set=EventBus)
+    command.handle_mqtt_p2p(event_bus, orjson.dumps({"body": {"code": 0, "msg": "ok"}}))
+    event_bus.notify.assert_not_called()
+
+
+@pytest.mark.parametrize("delay", [-1, 1, 15, 301])
+def test_set_rain_delay_rejects_unsupported_delay(delay: int) -> None:
+    with pytest.raises(ValueError, match=f"Unsupported rain delay: {delay}"):
+        SetRainDelay(True, delay)

--- a/tests/commands/json/test_volume.py
+++ b/tests/commands/json/test_volume.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from deebot_client.commands.json import GetVolume, SetVolume
-from deebot_client.events import VolumeEvent
+from deebot_client.commands.json import GetVolume, SetFallVolume, SetVolume
+from deebot_client.events import FallVolumeEvent, VolumeEvent
 from tests.helpers import get_request_json, get_success_body
 
 from . import assert_command, assert_set_command
@@ -16,7 +16,33 @@ async def test_GetVolume() -> None:
     await assert_command(GetVolume(), json, (firmware_event, VolumeEvent(2, 10)))
 
 
+async def test_GetMowerVolume() -> None:
+    json, firmware_event = get_request_json(
+        get_success_body(
+            {"total": 10, "volume": 5, "fallVolume": 2, "searchVolume": 10}
+        )
+    )
+    await assert_command(
+        GetVolume(),
+        json,
+        (firmware_event, VolumeEvent(5, 10), FallVolumeEvent(2, 10)),
+    )
+
+
 @pytest.mark.parametrize("level", [0, 2, 10])
 async def test_SetVolume(level: int) -> None:
     args = {"volume": level}
     await assert_set_command(SetVolume(level), args, VolumeEvent(level, None))
+
+
+async def test_SetMowerSystemVolume() -> None:
+    args = {"type": "sys", "total": 10, "volume": 6}
+    await assert_set_command(
+        SetVolume(6, channel="sys", total=10), args, VolumeEvent(6, 10)
+    )
+
+
+@pytest.mark.parametrize("level", [2, 6, 10])
+async def test_SetFallVolume(level: int) -> None:
+    args = {"type": "fall", "total": 10, "volume": level}
+    await assert_set_command(SetFallVolume(level), args, FallVolumeEvent(level, 10))

--- a/tests/hardware/test_mower_settings.py
+++ b/tests/hardware/test_mower_settings.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from deebot_client.commands.json import COMMANDS
+from deebot_client.commands.json.animal_protection import (
+    GetAnimalProtection,
+    SetAnimalProtection,
+)
+from deebot_client.commands.json.humanoid_ai import GetHumanoidAi, SetHumanoidAi
+from deebot_client.commands.json.narrow_adapt import GetNarrowAdapt, SetNarrowAdapt
+from deebot_client.commands.json.recognization import (
+    GetRecognization,
+    SetRecognization,
+)
+from deebot_client.commands.json.volume import GetVolume, SetFallVolume, SetVolume
+from deebot_client.events import (
+    AiRecognitionEvent,
+    AnimalProtectionEvent,
+    FallVolumeEvent,
+    HumanoidAiEvent,
+    NarrowAdaptEvent,
+    VolumeEvent,
+)
+from deebot_client.hardware import get_static_device_info
+from deebot_client.messages import get_message
+from deebot_client.messages.json import (
+    OnAnimalProtection,
+    OnHumanoidAi,
+    OnMoveUpWarning,
+    OnNarrowAdapt,
+    OnRecognization,
+    OnVolume,
+)
+
+
+async def test_mower_settings_capabilities() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+    settings = device_info.capabilities.settings
+
+    expected = [
+        (
+            settings.ai_recognition,
+            AiRecognitionEvent,
+            GetRecognization,
+            SetRecognization,
+        ),
+        (settings.humanoid_ai, HumanoidAiEvent, GetHumanoidAi, SetHumanoidAi),
+        (settings.narrow_adapt, NarrowAdaptEvent, GetNarrowAdapt, SetNarrowAdapt),
+        (
+            settings.animal_protection,
+            AnimalProtectionEvent,
+            GetAnimalProtection,
+            SetAnimalProtection,
+        ),
+        (settings.fall_volume, FallVolumeEvent, GetVolume, SetFallVolume),
+    ]
+    for capability, event, get_command, set_command in expected:
+        assert capability is not None
+        assert capability.event is event
+        assert capability.get == [get_command()]
+        assert capability.set is set_command
+
+    assert settings.volume is not None
+    assert settings.volume.event is VolumeEvent
+    assert settings.volume.get == [GetVolume()]
+    assert settings.volume.set(6) == SetVolume(6, channel="sys", total=10)
+
+
+async def test_mower_settings_registration() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    for command in (
+        GetRecognization,
+        SetRecognization,
+        GetHumanoidAi,
+        SetHumanoidAi,
+        GetNarrowAdapt,
+        SetNarrowAdapt,
+        GetAnimalProtection,
+        SetAnimalProtection,
+    ):
+        assert COMMANDS[command.NAME] is command
+
+    for message in (
+        OnRecognization,
+        OnHumanoidAi,
+        OnNarrowAdapt,
+        OnMoveUpWarning,
+        OnAnimalProtection,
+        OnVolume,
+    ):
+        assert get_message(message.NAME, device_info) is message
+
+
+async def test_mower_settings_are_model_specific() -> None:
+    device_info = await get_static_device_info("yna5xi")
+    assert device_info is not None
+    settings = device_info.capabilities.settings
+
+    assert settings.ai_recognition is None
+    assert settings.animal_protection is None
+    assert settings.humanoid_ai is None
+    assert settings.narrow_adapt is None
+    assert settings.fall_volume is None

--- a/tests/hardware/test_protect_state.py
+++ b/tests/hardware/test_protect_state.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from deebot_client.events import ProtectStateEvent
+from deebot_client.hardware import get_static_device_info
+from deebot_client.messages import get_message
+from deebot_client.messages.json import OnProtectState
+
+
+async def test_protect_state_capability() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    capability = device_info.capabilities.protect_state
+    assert capability is not None
+    assert capability.event is ProtectStateEvent
+    assert capability.get == []
+    assert device_info.capabilities.get_refresh_commands(ProtectStateEvent) == []
+
+
+async def test_protect_state_registration() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    assert get_message(OnProtectState.NAME, device_info) is OnProtectState

--- a/tests/hardware/test_rain_delay.py
+++ b/tests/hardware/test_rain_delay.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from deebot_client.commands.json import COMMANDS, SetRainDelay
+from deebot_client.events import RainDelayEvent
+from deebot_client.hardware import get_static_device_info
+from deebot_client.messages import get_message
+from deebot_client.messages.json import OnRainDelay
+
+
+async def test_rain_delay_capability() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    capability = device_info.capabilities.settings.rain_delay
+    assert capability is not None
+    assert capability.event is RainDelayEvent
+    assert capability.get == []
+    assert capability.set is SetRainDelay
+    assert device_info.capabilities.get_refresh_commands(RainDelayEvent) == []
+
+
+async def test_rain_delay_registration() -> None:
+    device_info = await get_static_device_info("2i0fns")
+    assert device_info is not None
+
+    assert COMMANDS[SetRainDelay.NAME] is SetRainDelay
+    assert get_message(OnRainDelay.NAME, device_info) is OnRainDelay

--- a/tests/messages/json/test_mower_settings.py
+++ b/tests/messages/json/test_mower_settings.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deebot_client.events import (
+    AiRecognitionEvent,
+    AnimalProtectionEvent,
+    FallVolumeEvent,
+    FirmwareEvent,
+    HumanoidAiEvent,
+    MoveUpWarningEvent,
+    NarrowAdaptEvent,
+    VolumeEvent,
+)
+from deebot_client.messages.json import (
+    OnAnimalProtection,
+    OnHumanoidAi,
+    OnMoveUpWarning,
+    OnNarrowAdapt,
+    OnRecognization,
+    OnVolume,
+)
+from tests.messages.json import assert_message
+
+if TYPE_CHECKING:
+    from deebot_client.events.base import Event
+
+
+@pytest.mark.parametrize(
+    ("message", "payload", "event"),
+    [
+        (OnRecognization, {"state": 1}, AiRecognitionEvent(True)),
+        (OnHumanoidAi, {"enable": 0}, HumanoidAiEvent(False)),
+        (OnNarrowAdapt, {"state": 1}, NarrowAdaptEvent(True)),
+        (OnMoveUpWarning, {"enable": 1}, MoveUpWarningEvent(True)),
+        (
+            OnAnimalProtection,
+            {"enable": 1, "start": "22:00", "end": "6:30"},
+            AnimalProtectionEvent(True, "22:00", "06:30"),
+        ),
+    ],
+)
+def test_mower_setting_push(
+    message: type, payload: dict[str, int | str], event: Event
+) -> None:
+    data = {"header": {"fwVer": "1.13.10"}, "body": {"data": payload}}
+    assert_message(message, data, (FirmwareEvent("1.13.10"), event))
+
+
+def test_volume_push() -> None:
+    data = {
+        "header": {"fwVer": "1.13.10"},
+        "body": {
+            "data": {
+                "total": 10,
+                "volume": 5,
+                "fallVolume": 2,
+                "searchVolume": 10,
+            }
+        },
+    }
+    assert_message(
+        OnVolume,
+        data,
+        (FirmwareEvent("1.13.10"), VolumeEvent(5, 10), FallVolumeEvent(2, 10)),
+    )

--- a/tests/messages/json/test_protect_state.py
+++ b/tests/messages/json/test_protect_state.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from deebot_client.events import FirmwareEvent, ProtectStateEvent
+from deebot_client.messages.json import OnProtectState
+from tests.messages.json import assert_message
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (
+            {
+                "isAnimProtect": 0,
+                "isRainProtect": 1,
+                "isRainDelay": 0,
+                "isEStop": 0,
+                "isLocked": 0,
+                "isPinCode": 0,
+                "isPrepareDataSuccess": 1,
+            },
+            ProtectStateEvent(
+                is_anim_protect=False,
+                is_rain_protect=True,
+                is_rain_delay=False,
+                is_e_stop=False,
+                is_locked=False,
+                is_pin_code=False,
+                is_prepare_data_success=True,
+            ),
+        ),
+        (
+            {
+                "isAnimProtect": 0,
+                "isRainProtect": 0,
+                "isRainDelay": 0,
+                "isEStop": 0,
+                "isLocked": 0,
+                "isPinCode": 0,
+                "isPrepareDataSuccess": 0,
+            },
+            ProtectStateEvent(
+                is_anim_protect=False,
+                is_rain_protect=False,
+                is_rain_delay=False,
+                is_e_stop=False,
+                is_locked=False,
+                is_pin_code=False,
+                is_prepare_data_success=False,
+            ),
+        ),
+        (
+            {
+                "isAnimProtect": 1,
+                "isRainProtect": 0,
+                "isRainDelay": 1,
+                "isEStop": 0,
+                "isLocked": 1,
+                "isPinCode": 0,
+                "isPrepareDataSuccess": 1,
+            },
+            ProtectStateEvent(
+                is_anim_protect=True,
+                is_rain_protect=False,
+                is_rain_delay=True,
+                is_e_stop=False,
+                is_locked=True,
+                is_pin_code=False,
+                is_prepare_data_success=True,
+            ),
+        ),
+    ],
+    ids=["observed-rain", "all-zero", "bool-conversion"],
+)
+def test_on_protect_state(data: dict[str, Any], expected: ProtectStateEvent) -> None:
+    payload = {
+        "header": {"fwVer": "1.13.10"},
+        "body": {"data": data, "code": 0, "msg": "ok"},
+    }
+
+    assert_message(OnProtectState, payload, (FirmwareEvent("1.13.10"), expected))

--- a/tests/messages/json/test_rain_delay.py
+++ b/tests/messages/json/test_rain_delay.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from deebot_client.events import FirmwareEvent, RainDelayEvent
+from deebot_client.messages.json import OnRainDelay
+from tests.messages.json import assert_message
+
+
+@pytest.mark.parametrize(
+    ("enable", "delay", "enabled"),
+    [(0, 180, False), (1, 0, True), (1, 30, True), (1, 300, True)],
+)
+def test_on_rain_delay(enable: int, delay: int, enabled: bool) -> None:
+    data = {
+        "header": {"fwVer": "1.13.10"},
+        "body": {"data": {"enable": enable, "delay": delay}},
+    }
+
+    assert_message(
+        OnRainDelay,
+        data,
+        (FirmwareEvent("1.13.10"), RainDelayEvent(enabled=enabled, delay=delay)),
+    )


### PR DESCRIPTION
## Summary

Add settings support for the ECOVACS GOAT O1200 LiDAR (`2i0fns`) based on observed app/MQTT behavior.

This includes the earlier rain settings work plus the remaining global mower settings:

- rain sensor enable/state and post-rain delay
- AI recognition
- smart mowing with avoidance (`HumanoidAI`)
- narrow passage adaptation
- mower lifted alarm push handling
- animal protection with enabled/start/end configuration
- mower system volume
- mower lifted-alarm volume

## Protocol handling

- Adds explicit JSON commands and push-message handling for the observed GOAT settings.
- Keeps `VolumeEvent` and `SetVolume(volume)` backward compatible for existing devices.
- Adds a separate `FallVolumeEvent` / fall-volume setter for the mower lifted alarm.
- Normalizes animal-protection times to `HH:MM` while sending the complete configuration on set.
- Registers the new capabilities only for `2i0fns`.

## Validation

- Targeted Ruff: passed
- Targeted mypy: passed
- Targeted pytest: `31 passed`
- Extended command/message/hardware test run: `359 passed`, `3 failed`
- `git diff --check`: passed

The three extended-suite failures are caused by the existing Windows checkout representation of hardware symlinks as text files, rather than by the changed files.

## Remaining protocol assumptions

- GOAT volume setters use the observed `total: 10`.
- `searchVolume` is read from the complete device payload but is not exposed as a separate capability because no setter protocol has been observed.
- Animal Protection updates use the complete `enable` / `start` / `end` configuration; toggle writes were observed directly and time updates were confirmed through push state updates.

Draft for review and CI validation.