### PR TITLE
Accept outline version 2 in MapInfoV2 messages

### DIFF
--- a/deebot_client/messages/json/map/__init__.py
+++ b/deebot_client/messages/json/map/__init__.py
@@ -84,7 +84,7 @@ class OnMapInfoV2(MessageBodyDataDict):
         if (outline_version := data.get("outlineVer")) == "0":
             # Skip it as it will be sent for non-active maps
             return HandlingResult.success()
-        if outline_version != "1":
+        if outline_version not in ("1", "2"):
             # Unsupported version
             return HandlingResult.analyse()
 

--- a/tests/commands/json/map/test_init.py
+++ b/tests/commands/json/map/test_init.py
@@ -596,7 +596,8 @@ async def test_getMapTrace() -> None:
     )
 
 
-async def test_getMapInfoV2() -> None:
+@pytest.mark.parametrize("outline_version", ["1", "2"])
+async def test_getMapInfoV2(outline_version: str) -> None:
     mid = "98100521"
     info = "KLUv/QRYmQAAW1siMSJdLFsiMiJdLFsiNiJdXbBRuA4="
     json, firmware_event = get_request_json(
@@ -609,7 +610,7 @@ async def test_getMapInfoV2() -> None:
                 "mid": mid,
                 "msgid": "",
                 "outlineComplete": 0,
-                "outlineVer": "1",
+                "outlineVer": outline_version,
                 "serial": "1",
                 "type": "0",
                 "using": 0,
@@ -635,7 +636,7 @@ async def test_getMapInfoV2_unsupported_version() -> None:
                 "mid": mid,
                 "msgid": "",
                 "outlineComplete": 0,
-                "outlineVer": "2",
+                "outlineVer": "3",
                 "serial": "1",
                 "type": "0",
                 "using": 0,

--- a/tests/messages/json/map/test_init.py
+++ b/tests/messages/json/map/test_init.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
+from base64 import b64encode
+from compression.zstd import compress
 from typing import TYPE_CHECKING
 
+from defusedxml.ElementTree import fromstring
+import orjson
 import pytest
 
-from deebot_client.commands.json.map import GetMapSetV2
+from deebot_client.commands.json.map import GetMapInfoV2, GetMapSetV2
 from deebot_client.events import FirmwareEvent
 from deebot_client.events.map import MajorMapEvent, MapInfoEvent, MapSetType
 from deebot_client.message import HandlingState
 from deebot_client.messages.json import OnMapSetV2
 from deebot_client.messages.json.map import OnMajorMap, OnMapInfoV2
+from deebot_client.rs.map import MapData, RotationAngle
+from tests.helpers import get_request_json, get_success_body
 from tests.messages.json import assert_message
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock
+
     from deebot_client.events.base import Event
 
 
@@ -153,7 +161,8 @@ def test_onMajorMap() -> None:
     [
         ("0", HandlingState.SUCCESS, False),
         ("1", HandlingState.SUCCESS, True),
-        ("2", HandlingState.ANALYSE_LOGGED, False),
+        ("2", HandlingState.SUCCESS, True),
+        ("3", HandlingState.ANALYSE_LOGGED, False),
     ],
 )
 @pytest.mark.benchmark
@@ -201,4 +210,41 @@ def test_onMapInfo_V2(
         data,
         expected_events,
         expected_state=expected_state,
+    )
+
+
+@pytest.mark.parametrize("message", [OnMapInfoV2, GetMapInfoV2])
+def test_map_info_v2_renders_outline_version_2(
+    message: type[OnMapInfoV2], event_bus_mock: Mock
+) -> None:
+    """Render synthetic V2 outline, room and block-line layers without map tiles."""
+    layers = [
+        ["1", "1;0,0,1;200,0,1;200,100,1;0,100,1"],
+        ["2", "1;0,0;200,0;200,100;0,100"],
+        ["6", "1;0,0;200,0;200,100;0,100"],
+    ]
+    info = b64encode(compress(orjson.dumps(layers))).decode()
+    payload, _ = get_request_json(
+        get_success_body({"mid": "1", "outlineVer": "2", "info": info})
+    )
+
+    result = message.handle(event_bus_mock, payload["resp"])
+
+    assert result.state is HandlingState.SUCCESS
+    map_events = [
+        call.args[0]
+        for call in event_bus_mock.notify.call_args_list
+        if isinstance(call.args[0], MapInfoEvent)
+    ]
+    assert map_events == [MapInfoEvent("1", info)]
+    map_data = MapData()
+    map_data.map_info.set(map_events[0].info)
+    svg = map_data.generate_svg([], [], RotationAngle.DEG_0)
+
+    assert svg is not None
+    root = fromstring(svg)
+    # The renderer uses 50 mm per SVG unit and inverts the Y axis.
+    assert root.attrib["viewBox"] == "0 -2 4 2"
+    assert (
+        len(root.findall("svg:g/svg:path", {"svg": "http://www.w3.org/2000/svg"})) == 4
     )


### PR DESCRIPTION
## Problem

Some newer robots return `outlineVer: "2"` in `getMapInfo_V2` responses. The shared `OnMapInfoV2` handler currently rejects this before publishing `MapInfoEvent`, so the map stays empty and Home Assistant's image endpoint returns HTTP 500.

Refs #1762. Also reproduced on an X8 PRO OMNI (`n0vyif`, firmware `1.133.0`).

## Change

Accept outline versions `"1"` and `"2"` in the shared handler. Version `"0"` still skips inactive maps, and unknown versions are still rejected. This covers both requested responses and pushed map messages.

The observed V2 payload uses outline, room and block-line layers already supported by the existing Rust renderer. No renderer, hardware profile, dependency or Home Assistant changes are included.

## Validation

- Expanded version-handling tests for both message and command paths.
- Added a synthetic compressed map test that passes through each handler into the real SVG renderer, checking geometry and bounds without legacy map tiles. The fixture contains no real floor-plan data.
- Confirmed the four new V2 cases fail on unmodified `dev` at `5453eba`, then pass with the one-line change.
- Focused map suite: **62 passed, four existing SVG snapshots passed**. One existing pytest generator-parametrization deprecation warning remains.
- Ruff check/format and changed-file mypy (`--follow-imports=silent`) pass.
- Local native tests used the released 18.5.1 extension; the Rust source is unchanged between that tag and the tested upstream base. No fresh native build or full test suite was run locally.

On Home Assistant 2026.8.3 / deebot-client 18.5.1, the equivalent gate change was deployed via a temporary compatibility wrapper. The X8 map endpoint changed from HTTP 500 to HTTP 200, with room geometry, cleaning trace and position visible. A T9+ map continued to render. The captured X8 payload also rendered locally through the direct library patch.

Raw device logs, identifiers and the household's map are deliberately not attached. The reported T50/X11 devices in #1762 were not available for physical testing.
