### PR TITLE
Add support for yeedi vac station (mnx7f4)

### DIFF
--- a/deebot_client/commands/json/auto_empty.py
+++ b/deebot_client/commands/json/auto_empty.py
@@ -23,7 +23,10 @@ class SetAutoEmpty(ExecuteCommand):
     NAME = "setAutoEmpty"
 
     def __init__(
-        self, enable: bool | None = None, frequency: Frequency | str | None = None
+        self,
+        enable: bool | None = None,
+        frequency: Frequency | str | None = None,
+        act: str | None = None,
     ) -> None:
         if frequency is not None and not isinstance(frequency, Frequency):
             frequency = get_enum(Frequency, frequency)
@@ -33,4 +36,6 @@ class SetAutoEmpty(ExecuteCommand):
             params["enable"] = int(enable)
         if frequency:
             params["frequency"] = frequency.value
+        if act:
+            params["act"] = act
         super().__init__(params)

--- a/deebot_client/hardware/mnx7f4.py
+++ b/deebot_client/hardware/mnx7f4.py
@@ -1,0 +1,151 @@
+"""Yeedi Vac Station Capabilities."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityExecuteTypes,
+    CapabilityLifeSpan,
+    CapabilitySet,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStation,
+    CapabilityStats,
+    CapabilityWater,
+    DeviceType,
+)
+from deebot_client.commands import StationAction
+from deebot_client.commands.json.auto_empty import GetAutoEmpty, SetAutoEmpty
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.clean import Clean, CleanArea, GetCleanInfo
+from deebot_client.commands.json.clean_logs import GetCleanLogs
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AvailabilityEvent,
+    BatteryEvent,
+    CleanLogEvent,
+    CustomCommandEvent,
+    ErrorEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    LifeSpan,
+    LifeSpanEvent,
+    NetworkInfoEvent,
+    ReportStatsEvent,
+    StateEvent,
+    StationEvent,
+    StatsEvent,
+    TotalStatsEvent,
+    VolumeEvent,
+    auto_empty,
+    water_info,
+)
+from deebot_client.events.auto_empty import AutoEmptyEvent
+from deebot_client.models import StaticDeviceInfo
+
+
+def get_device_info() -> StaticDeviceInfo:
+    """Get device info for this model."""
+    return StaticDeviceInfo(
+        DataType.JSON,
+        Capabilities(
+            device_type=DeviceType.VACUUM,
+            availability=CapabilityEvent(
+                AvailabilityEvent, [GetBattery(is_available_check=True)]
+            ),
+            battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+            charge=CapabilityExecute(Charge),
+            clean=CapabilityClean(
+                action=CapabilityCleanAction(command=Clean, area=CleanArea),
+                log=CapabilityEvent(CleanLogEvent, [GetCleanLogs()]),
+            ),
+            custom=CapabilityCustomCommand(
+                event=CustomCommandEvent, get=[], set=CustomCommand
+            ),
+            error=CapabilityEvent(ErrorEvent, [GetError()]),
+            fan_speed=CapabilitySetTypes(
+                event=FanSpeedEvent,
+                get=[GetFanSpeed()],
+                set=SetFanSpeed,
+                types=(
+                    FanSpeedLevel.NORMAL,
+                    FanSpeedLevel.MAX,
+                    FanSpeedLevel.MAX_PLUS,
+                ),
+            ),
+            life_span=CapabilityLifeSpan(
+                types=(
+                    LifeSpan.BRUSH,
+                    LifeSpan.FILTER,
+                    LifeSpan.SIDE_BRUSH,
+                ),
+                event=LifeSpanEvent,
+                get=[
+                    GetLifeSpan(
+                        [
+                            LifeSpan.BRUSH,
+                            LifeSpan.FILTER,
+                            LifeSpan.SIDE_BRUSH,
+                        ]
+                    )
+                ],
+                reset=ResetLifeSpan,
+            ),
+            network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+            play_sound=CapabilityExecute(PlaySound),
+            settings=CapabilitySettings(
+                volume=CapabilitySet(VolumeEvent, [GetVolume()], SetVolume),
+            ),
+            state=CapabilityEvent(StateEvent, [GetChargeState(), GetCleanInfo()]),
+            station=CapabilityStation(
+                action=CapabilityExecuteTypes(
+                    lambda _: SetAutoEmpty(act="start"),
+                    types=(StationAction.EMPTY_DUSTBIN,),
+                ),
+                auto_empty=CapabilitySetTypes(
+                    event=AutoEmptyEvent,
+                    get=[GetAutoEmpty()],
+                    set=SetAutoEmpty,
+                    types=(auto_empty.Frequency.AUTO,),
+                ),
+                state=CapabilityEvent(StationEvent, []),
+            ),
+            stats=CapabilityStats(
+                clean=CapabilityEvent(StatsEvent, [GetStats()]),
+                report=CapabilityEvent(ReportStatsEvent, []),
+                total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+            ),
+            water=CapabilityWater(
+                amount=CapabilitySetTypes(
+                    event=water_info.WaterAmountEvent,
+                    get=[GetWaterInfo()],
+                    set=SetWaterInfo,
+                    types=(
+                        water_info.WaterAmount.LOW,
+                        water_info.WaterAmount.MEDIUM,
+                        water_info.WaterAmount.HIGH,
+                        water_info.WaterAmount.ULTRAHIGH,
+                    ),
+                ),
+                mop_attached=CapabilityEvent(
+                    water_info.MopAttachedEvent, [GetWaterInfo()]
+                ),
+            ),
+        ),
+    )

--- a/tests/commands/json/test_auto_empty.py
+++ b/tests/commands/json/test_auto_empty.py
@@ -119,3 +119,9 @@ async def test_SetAutoEmpty(
     """Test SetAutoEmpty."""
     command = SetAutoEmpty(enabled, frequency)
     await assert_execute_command(command, args)
+
+
+async def test_SetAutoEmpty_act() -> None:
+    """Test SetAutoEmpty with act."""
+    command = SetAutoEmpty(act="start")
+    await assert_execute_command(command, {"act": "start"})


### PR DESCRIPTION
# Add support for yeedi vac station (mnx7f4)

## Summary

Adds a hardware capability definition for the **yeedi vac station** (class `mnx7f4`, sold as K26 / K781+), following the Yeedi Floor 3 Station (#1472). The robot authenticates against the Ecovacs cloud (account migrated from yeedi to Ecovacs) and already shows up in device discovery — it just had no capability module, so `get_devices` dropped it with `Device class "mnx7f4" not recognized`.

Related: #461 · independent of, but complementary to, the native yeedi-account login in #1611.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changes

- **New file `deebot_client/hardware/mnx7f4.py`** — capability definition, modelled after `b2jqs4.py` (DEEBOT N8+, the closest Ecovacs sibling of this device generation), then trimmed and adjusted against the real device (see Testing).
- **`deebot_client/commands/json/station_action.py`** — new `StationActionLegacy` command: this device generation does not answer `stationAction`; the manual dustbin empty is triggered via `setAutoEmpty` with `act: start` instead. Accepts only `EMPTY_DUSTBIN`, raises on anything else. Deliberately not added to the `_COMMANDS` registry (its `NAME` would clash with `SetAutoEmpty`).
- **`tests/commands/json/test_station_action.py`** — tests for the payload and the unsupported-action guard.

**Capabilities included:**

| Capability | Details |
|---|---|
| `availability` | `GetBattery` availability check |
| `battery` | `GetBattery` |
| `charge` | `Charge` |
| `clean.action` | `Clean`, `CleanArea` |
| `clean.log` | `GetCleanLogs` |
| `error` | `GetError` |
| `fan_speed` | NORMAL, MAX, MAX_PLUS (QUIET rejected by the device, see below) |
| `life_span` | BRUSH, FILTER, SIDE_BRUSH |
| `network` | `GetNetInfo` |
| `play_sound` | `PlaySound` |
| `settings.volume` | `GetVolume` / `SetVolume` |
| `state` | `GetChargeState`, `GetCleanInfo` |
| `station.action` | EMPTY_DUSTBIN via `StationActionLegacy` |
| `station.auto_empty` | on/off with readback; only `AUTO` declared (device reports no frequency) |
| `station.state` | declared, **not polled** (device never answers `getStationState`) |
| `stats` | `GetStats`, `GetTotalStats` |
| `water.amount` | LOW, MEDIUM, HIGH, ULTRAHIGH |
| `water.mop_attached` | `GetWaterInfo` |
| `custom` | `CustomCommand` pass-through |

No map capability is declared: map image retrieval is not available for this class (ecovacs-deebot.js lists it as `map_image_supported: false`).

## Device Details

```
Device:    yeedi vac station (K26 / K781+)
Class:     mnx7f4
Protocol:  JSON over MQTT (950type, non-V2)
Firmware:  1.2.9 (hwVer 0.1.1)
Station:   auto-empty only (no mop wash/dry)
Cloud:     Ecovacs (portal-ww.ecouser.net), account migrated from yeedi
Region:    DE
```

## Testing

Validated against a physical unit with this branch, through a standalone deebot-client script (login, MQTT, event subscriptions on all declared capabilities, actuator round-trips).

### Confirmed working

- [x] Login, discovery, MQTT connection (Ecovacs cloud, migrated account)
- [x] All declared getters answer with plausible values: battery, charge state, clean info, error, network, speed, life span, volume, water info, stats, total stats, clean logs, auto empty
- [x] Clean start → CLEANING, stop → IDLE, charge → RETURNING → DOCKED
- [x] `setSpeed` round-trips for NORMAL / MAX / MAX_PLUS (echoed back by the device)
- [x] `setWaterAmount` round-trips for LOW / MEDIUM / HIGH / ULTRAHIGH
- [x] `setVolume` round-trip; `playSound` audible
- [x] `setAutoEmpty` enable=0/1 with `getAutoEmpty` readback
- [x] `setAutoEmpty act=start` (`StationActionLegacy`): device answers `code 0` and the station audibly empties the dustbin
- [x] Error propagation: picking the robot up mid-run surfaced `code 102 HostHang: Robot is off the floor` and recovered cleanly to NoError / DOCKED

### Not yet verified

- [ ] End-to-end through the Home Assistant Ecovacs integration (entities/UI) — validation above was done directly against deebot-client
- [ ] Area / room cleaning (`CleanArea`) — the unit has no stored map yet
- [ ] Long-term stability (>24h)

## Known Limitations

- **QUIET fan speed:** rejected by the device with `code 20012: set speed 1000, device support 0or1 now only` — left out of the declared types. MAX_PLUS (2) is accepted and echoed back despite what that message suggests.
- **`getStationState`:** never answered; station state is declared but not polled to avoid request warnings.
- **Auto-empty frequency:** the device reports `frequency: None` (on/off only), so only `AUTO` is declared.

## Checklist

- [x] My code follows the style guidelines of this project (ruff check + format, mypy clean)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (`StationActionLegacy`)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Related Work

- #1472 — Yeedi Floor 3 Station (kd0una), the precedent for yeedi hardware in this repo
- #1611 — native yeedi-account login (auth domain); once merged, this device works without the account migration
- Follow-up candidate: room/area cleaning verification once the unit has a stored map
