### PR TITLE
Fix DEEBOT T30C capabilities (ulzked)

### DIFF
--- a/deebot_client/hardware/ulzked.py
+++ b/deebot_client/hardware/ulzked.py
@@ -1,1 +1,291 @@
-qdajz8.py
+"""DEEBOT T30C Capabilities (ulzked)."""
+
+from __future__ import annotations
+
+from deebot_client.capabilities import (
+    Capabilities,
+    CapabilityClean,
+    CapabilityCleanAction,
+    CapabilityCustomCommand,
+    CapabilityEvent,
+    CapabilityExecute,
+    CapabilityExecuteTypes,
+    CapabilityLifeSpan,
+    CapabilityMap,
+    CapabilityNumber,
+    CapabilitySet,
+    CapabilitySetEnable,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStation,
+    CapabilityStats,
+    CapabilityWater,
+    DeviceType,
+)
+from deebot_client.commands import StationAction
+from deebot_client.commands.json import station_action
+from deebot_client.commands.json.advanced_mode import GetAdvancedMode, SetAdvancedMode
+from deebot_client.commands.json.auto_empty import GetAutoEmpty, SetAutoEmpty
+from deebot_client.commands.json.battery import GetBattery
+from deebot_client.commands.json.carpet import (
+    GetCarpetAutoFanBoost,
+    SetCarpetAutoFanBoost,
+)
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.child_lock import GetChildLock, SetChildLock
+from deebot_client.commands.json.clean import CleanAreaV2, CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.clean_count import GetCleanCount, SetCleanCount
+from deebot_client.commands.json.clean_logs import GetCleanLogs
+from deebot_client.commands.json.continuous_cleaning import (
+    GetContinuousCleaning,
+    SetContinuousCleaning,
+)
+from deebot_client.commands.json.custom import CustomCommand
+from deebot_client.commands.json.efficiency import GetEfficiencyMode, SetEfficiencyMode
+from deebot_client.commands.json.error import GetError
+from deebot_client.commands.json.fan_speed import GetFanSpeed, SetFanSpeed
+from deebot_client.commands.json.life_span import GetLifeSpan, ResetLifeSpan
+from deebot_client.commands.json.map import (
+    GetCachedMapInfo,
+    GetMajorMap,
+    GetMapInfoV2,
+    GetMapSetV2,
+    GetMapTrace,
+    GetMinorMap,
+    SetMajorMap,
+)
+from deebot_client.commands.json.mop_auto_wash_frequency import (
+    GetMopAutoWashFrequency,
+    SetMopAutoWashFrequency,
+)
+from deebot_client.commands.json.multimap_state import (
+    GetMultimapState,
+    SetMultimapState,
+)
+from deebot_client.commands.json.network import GetNetInfo
+from deebot_client.commands.json.ota import GetOta, SetOta
+from deebot_client.commands.json.play_sound import PlaySound
+from deebot_client.commands.json.pos import GetPos
+from deebot_client.commands.json.relocation import SetRelocationState
+from deebot_client.commands.json.stats import GetStats, GetTotalStats
+from deebot_client.commands.json.sweep_mode import GetSweepMode, SetSweepMode
+from deebot_client.commands.json.true_detect import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.volume import GetVolume, SetVolume
+from deebot_client.commands.json.water_info import GetWaterInfo, SetWaterInfo
+from deebot_client.commands.json.work_mode import GetWorkMode, SetWorkMode
+from deebot_client.commands.json.work_state import GetWorkState
+from deebot_client.const import DataType
+from deebot_client.events import (
+    AdvancedModeEvent,
+    AvailabilityEvent,
+    BatteryEvent,
+    CachedMapInfoEvent,
+    CarpetAutoFanBoostEvent,
+    ChildLockEvent,
+    CleanCountEvent,
+    CleanLogEvent,
+    ContinuousCleaningEvent,
+    CustomCommandEvent,
+    EfficiencyModeEvent,
+    ErrorEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    LifeSpan,
+    LifeSpanEvent,
+    MajorMapEvent,
+    MapChangedEvent,
+    MapTraceEvent,
+    MultimapStateEvent,
+    NetworkInfoEvent,
+    OtaEvent,
+    PositionsEvent,
+    ReportStatsEvent,
+    RoomsEvent,
+    StateEvent,
+    StationEvent,
+    StatsEvent,
+    SweepModeEvent,
+    TotalStatsEvent,
+    TrueDetectEvent,
+    VolumeEvent,
+    WorkMode,
+    WorkModeEvent,
+    auto_empty,
+    water_info,
+)
+from deebot_client.events.auto_empty import AutoEmptyEvent
+from deebot_client.events.efficiency_mode import EfficiencyMode
+from deebot_client.events.mop_auto_wash_frequency import MopAutoWashFrequencyEvent
+from deebot_client.models import StaticDeviceInfo
+
+
+def get_device_info() -> StaticDeviceInfo:
+    """Get device info for this model."""
+    life_span_types = (
+        LifeSpan.BRUSH,
+        LifeSpan.CLEANING_SOLUTION,
+        LifeSpan.DUST_BAG,
+        LifeSpan.HAND_FILTER,
+        LifeSpan.FILTER,
+        LifeSpan.ROUND_MOP,
+        LifeSpan.SEWAGE_BOX,
+        LifeSpan.SIDE_BRUSH,
+        LifeSpan.STRAINER,
+        LifeSpan.UNIT_CARE,
+        LifeSpan.WATER_SINK,
+    )
+
+    return StaticDeviceInfo(
+        DataType.JSON,
+        Capabilities(
+            device_type=DeviceType.VACUUM,
+            availability=CapabilityEvent(
+                AvailabilityEvent, [GetBattery(is_available_check=True)]
+            ),
+            battery=CapabilityEvent(BatteryEvent, [GetBattery()]),
+            charge=CapabilityExecute(Charge),
+            clean=CapabilityClean(
+                action=CapabilityCleanAction(command=CleanV2, area=CleanAreaV2),
+                continuous=CapabilitySetEnable(
+                    ContinuousCleaningEvent,
+                    [GetContinuousCleaning()],
+                    SetContinuousCleaning,
+                ),
+                count=CapabilitySet(CleanCountEvent, [GetCleanCount()], SetCleanCount),
+                log=CapabilityEvent(CleanLogEvent, [GetCleanLogs()]),
+                work_mode=CapabilitySetTypes(
+                    event=WorkModeEvent,
+                    get=[GetWorkMode()],
+                    set=SetWorkMode,
+                    types=(
+                        WorkMode.MOP,
+                        WorkMode.MOP_AFTER_VACUUM,
+                        WorkMode.VACUUM,
+                        WorkMode.VACUUM_AND_MOP,
+                    ),
+                ),
+            ),
+            custom=CapabilityCustomCommand(
+                event=CustomCommandEvent, get=[], set=CustomCommand
+            ),
+            error=CapabilityEvent(ErrorEvent, [GetError()]),
+            fan_speed=CapabilitySetTypes(
+                event=FanSpeedEvent,
+                get=[GetFanSpeed()],
+                set=SetFanSpeed,
+                types=(
+                    FanSpeedLevel.QUIET,
+                    FanSpeedLevel.NORMAL,
+                    FanSpeedLevel.MAX,
+                    FanSpeedLevel.MAX_PLUS,
+                ),
+            ),
+            life_span=CapabilityLifeSpan(
+                types=life_span_types,
+                event=LifeSpanEvent,
+                get=[GetLifeSpan(list(life_span_types))],
+                reset=ResetLifeSpan,
+            ),
+            map=CapabilityMap(
+                cached_info=CapabilityEvent(CachedMapInfoEvent, [GetCachedMapInfo()]),
+                changed=CapabilityEvent(MapChangedEvent, []),
+                info=CapabilityExecute(GetMapInfoV2),
+                major=CapabilitySet(MajorMapEvent, [GetMajorMap()], SetMajorMap),
+                minor=CapabilityExecute(GetMinorMap),
+                multi_state=CapabilitySetEnable(
+                    MultimapStateEvent, [GetMultimapState()], SetMultimapState
+                ),
+                position=CapabilityEvent(PositionsEvent, [GetPos()]),
+                relocation=CapabilityExecute(SetRelocationState),
+                rooms=CapabilityEvent(RoomsEvent, [GetCachedMapInfo()]),
+                set=CapabilityExecute(GetMapSetV2),
+                trace=CapabilityEvent(MapTraceEvent, [GetMapTrace()]),
+            ),
+            network=CapabilityEvent(NetworkInfoEvent, [GetNetInfo()]),
+            play_sound=CapabilityExecute(PlaySound),
+            settings=CapabilitySettings(
+                advanced_mode=CapabilitySetEnable(
+                    AdvancedModeEvent, [GetAdvancedMode()], SetAdvancedMode
+                ),
+                carpet_auto_fan_boost=CapabilitySetEnable(
+                    CarpetAutoFanBoostEvent,
+                    [GetCarpetAutoFanBoost()],
+                    SetCarpetAutoFanBoost,
+                ),
+                child_lock=CapabilitySetEnable(
+                    ChildLockEvent, [GetChildLock()], SetChildLock
+                ),
+                efficiency_mode=CapabilitySetTypes(
+                    event=EfficiencyModeEvent,
+                    get=[GetEfficiencyMode()],
+                    set=SetEfficiencyMode,
+                    types=(
+                        EfficiencyMode.ENERGY_EFFICIENT_MODE,
+                        EfficiencyMode.STANDARD_MODE,
+                    ),
+                ),
+                ota=CapabilitySetEnable(OtaEvent, [GetOta()], SetOta),
+                sweep_mode=CapabilitySetEnable(
+                    SweepModeEvent, [GetSweepMode()], SetSweepMode
+                ),
+                mop_auto_wash_frequency=CapabilityNumber(
+                    event=MopAutoWashFrequencyEvent,
+                    get=[GetMopAutoWashFrequency()],
+                    set=SetMopAutoWashFrequency,
+                    min=10,
+                    max=25,
+                ),
+                true_detect=CapabilitySetEnable(
+                    TrueDetectEvent, [GetTrueDetect()], SetTrueDetect
+                ),
+                volume=CapabilityNumber(
+                    event=VolumeEvent,
+                    get=[GetVolume()],
+                    set=lambda volume: SetVolume(volume=volume),
+                    min=0,
+                    max=10,
+                ),
+            ),
+            state=CapabilityEvent(
+                StateEvent, [GetChargeState(), GetCleanInfoV2(), GetWorkState()]
+            ),
+            station=CapabilityStation(
+                action=CapabilityExecuteTypes(
+                    station_action.StationAction,
+                    types=(
+                        StationAction.EMPTY_DUSTBIN,
+                        StationAction.WASH_MOP,
+                        StationAction.DRY_MOP,
+                    ),
+                ),
+                auto_empty=CapabilitySetTypes(
+                    event=AutoEmptyEvent,
+                    get=[GetAutoEmpty()],
+                    set=SetAutoEmpty,
+                    types=(
+                        auto_empty.Frequency.AUTO,
+                        auto_empty.Frequency.SMART,
+                    ),
+                ),
+                state=CapabilityEvent(StationEvent, [GetWorkState()]),
+            ),
+            stats=CapabilityStats(
+                clean=CapabilityEvent(StatsEvent, [GetStats()]),
+                report=CapabilityEvent(ReportStatsEvent, []),
+                total=CapabilityEvent(TotalStatsEvent, [GetTotalStats()]),
+            ),
+            water=CapabilityWater(
+                amount=CapabilityNumber(
+                    event=water_info.WaterCustomAmountEvent,
+                    get=[GetWaterInfo()],
+                    set=lambda custom_amount: SetWaterInfo(custom_amount=custom_amount),
+                    min=0,
+                    max=50,
+                ),
+                mop_attached=CapabilityEvent(
+                    water_info.MopAttachedEvent, [GetWaterInfo()]
+                ),
+            ),
+        ),
+    )

--- a/tests/hardware/test_ulzked.py
+++ b/tests/hardware/test_ulzked.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.clean import CleanAreaV2, CleanV2, GetCleanInfoV2
+from deebot_client.commands.json.map import GetMapInfoV2, GetMapSetV2
+from deebot_client.commands.json.work_state import GetWorkState
+from deebot_client.events import LifeSpan
+from deebot_client.hardware.ulzked import get_device_info
+
+
+def test_ulzked_uses_v2_capabilities() -> None:
+    capabilities = get_device_info().capabilities
+
+    assert capabilities.clean.action.command is CleanV2
+    assert capabilities.clean.action.area is CleanAreaV2
+    assert capabilities.state.get == [
+        GetChargeState(),
+        GetCleanInfoV2(),
+        GetWorkState(),
+    ]
+
+    assert capabilities.map is not None
+    assert capabilities.map.info is not None
+    assert capabilities.map.info.execute is GetMapInfoV2
+    assert capabilities.map.set.execute is GetMapSetV2
+
+    assert capabilities.station is not None
+    assert capabilities.station.state.get == [GetWorkState()]
+    assert capabilities.life_span.types == (
+        LifeSpan.BRUSH,
+        LifeSpan.CLEANING_SOLUTION,
+        LifeSpan.DUST_BAG,
+        LifeSpan.HAND_FILTER,
+        LifeSpan.FILTER,
+        LifeSpan.ROUND_MOP,
+        LifeSpan.SEWAGE_BOX,
+        LifeSpan.SIDE_BRUSH,
+        LifeSpan.STRAINER,
+        LifeSpan.UNIT_CARE,
+        LifeSpan.WATER_SINK,
+    )


### PR DESCRIPTION
## Summary

- replace the legacy T20 profile alias for T30C hardware class `ulzked` with a dedicated V2 profile
- use the supported V2 clean and map commands and `getWorkState` for vacuum/station state
- expose the lifespan components reported by this hardware class
- add a regression test for the corrected command selection

## Live device validation

Validated against a DEEBOT T30C reporting hardware class `ulzked`. The device accepted `clean_V2`, `getCleanInfo_V2`, `getWorkState`, `getMapInfo_V2`, and `getMapSet_V2`; `getMapSet_V2` returned six rooms using the supported V2 map-set records. The legacy clean/map calls used by the current T20 alias returned Ecovacs error `20003` (`rcp not support`).

This is related to #1394, which reports the same T30C V2 protocol requirement for a different hardware class (`r0321c`).

## Testing

- `pytest tests/hardware/test_ulzked.py`: 1 passed
- `pytest -m "not docker"`: 740 passed, 11 Docker-dependent tests deselected
- `ruff check .`: passed
- `ruff format --check deebot_client/hardware/ulzked.py tests/hardware/test_ulzked.py`: passed
- `mypy deebot_client/hardware/ulzked.py tests/hardware/test_ulzked.py`: passed
- `git diff --check`: passed