### PR TITLE
Add support for DEEBOT T80S (nazy54)

### DIFF
--- a/deebot_client/hardware/nazy54.py
+++ b/deebot_client/hardware/nazy54.py
@@ -1,0 +1,1 @@
+rzwv5p.py


### PR DESCRIPTION
Add support for DEEBOT T80S  (nazy54).

Capabilities are reused from rzwv5p (T80S Omni) via symlink.