### PR TITLE
Add support for DEEBOT T80 OMNI (xwk78e)

### DIFF
--- a/deebot_client/commands/json/xwk78e.py
+++ b/deebot_client/commands/json/xwk78e.py
@@ -1,0 +1,347 @@
+"""China T80-specific commands."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.command import InitParam
+from deebot_client.commands.json.auto_empty import SetAutoEmpty
+from deebot_client.commands.json.charge import Charge
+from deebot_client.commands.json.clean import CleanV2
+from deebot_client.commands.json.clean_preference import (
+    GetCleanPreference,
+    SetCleanPreference,
+)
+from deebot_client.commands.json.common import (
+    ExecuteCommand,
+    JsonCommandWithMessageHandling,
+    JsonGetCommand,
+    JsonSetCommand,
+)
+from deebot_client.commands.json.station_action import StationAction
+from deebot_client.events import (
+    CleanCountEvent,
+    FanSpeedEvent,
+    StateEvent,
+    TrueDetectEvent,
+    WorkModeEvent,
+)
+from deebot_client.events.auto_empty import Frequency
+from deebot_client.events.water_info import WaterCustomAmountEvent
+from deebot_client.events.xwk78e import (
+    AutoEmptyEventT80,
+    AutoEmptyIntensity,
+    TrueDetectLevel,
+    TrueDetectLevelEvent,
+    WashMode,
+    WashModeEvent,
+)
+from deebot_client.message import HandlingResult
+from deebot_client.messages.json.xwk78e import (
+    OnAutoEmptyT80,
+    OnWashInfoT80,
+    OnWorkStateT80,
+)
+from deebot_client.models import CleanAction, CleanMode, State
+from deebot_client.util import get_enum
+
+if TYPE_CHECKING:
+    from deebot_client.authentication import Authenticator
+    from deebot_client.commands import StationAction as StationActionType
+    from deebot_client.event_bus import EventBus
+    from deebot_client.models import ApiDeviceInfo
+
+
+class SetAutoEmptyV2(SetAutoEmpty):
+    """China T80 auto-empty command."""
+
+    def __init__(
+        self,
+        enable: bool | None = None,
+        frequency: Frequency | str | None = None,
+        intensity: AutoEmptyIntensity | int | str | None = None,
+    ) -> None:
+        if isinstance(frequency, str):
+            frequency = get_enum(Frequency, frequency)
+        if isinstance(intensity, str):
+            intensity = get_enum(AutoEmptyIntensity, intensity)
+        if intensity is not None:
+            intensity = AutoEmptyIntensity(intensity)
+        self._requested_frequency = frequency
+        self._requested_intensity = intensity
+        ExecuteCommand.__init__(
+            self,
+            {
+                "enable": int(enable) if enable is not None else 1,
+                "frequency": frequency.value if frequency else Frequency.SMART.value,
+                "intensity": int(intensity) if intensity is not None else 1,
+            },
+        )
+
+    async def _execute(
+        self,
+        authenticator: Authenticator,
+        device_info: ApiDeviceInfo,
+        event_bus: EventBus,
+    ) -> tuple[Any, dict[str, Any]]:
+        event = event_bus.get_last_event(AutoEmptyEventT80)
+        if isinstance(event, AutoEmptyEventT80):
+            if self._requested_frequency is None and event.frequency:
+                self._args["frequency"] = event.frequency.value
+            if self._requested_intensity is None and event.intensity is not None:
+                self._args["intensity"] = int(event.intensity)
+        return await super()._execute(authenticator, device_info, event_bus)
+
+
+class GetAutoEmptyT80(OnAutoEmptyT80, JsonCommandWithMessageHandling):
+    """Get T80 auto-empty state and suction intensity."""
+
+    NAME = "getAutoEmpty"
+
+
+class SetWashInfoT80(JsonSetCommand):
+    """Set T80 station mop-washing mode."""
+
+    NAME = "setWashInfo"
+    _mqtt_params = MappingProxyType(
+        {
+            "mode": InitParam(int),
+            "interval": InitParam(int, optional=True),
+        }
+    )
+
+    @property
+    def get_command(self) -> type[GetWashInfoT80]:
+        """Return the T80 wash-info query command."""
+        return GetWashInfoT80
+
+    def __init__(self, mode: WashMode | int | str, interval: int = 15) -> None:
+        if isinstance(mode, str):
+            mode = get_enum(WashMode, mode)
+        self._requested_interval = interval
+        super().__init__({"mode": int(mode), "interval": interval})
+
+    async def _execute(
+        self,
+        authenticator: Authenticator,
+        device_info: ApiDeviceInfo,
+        event_bus: EventBus,
+    ) -> tuple[Any, dict[str, Any]]:
+        event = event_bus.get_last_event(WashModeEvent)
+        if isinstance(event, WashModeEvent) and event.interval is not None:
+            self._args["interval"] = event.interval
+        return await super()._execute(authenticator, device_info, event_bus)
+
+
+class GetWashInfoT80(OnWashInfoT80, JsonGetCommand):
+    """Get T80 station mop-washing mode."""
+
+    NAME = "getWashInfo"
+
+
+class GetTrueDetectT80(JsonGetCommand):
+    """Get T80 obstacle detection state and sensitivity."""
+
+    NAME = "getTrueDetect"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        try:
+            level = TrueDetectLevel(data["level"])
+        except (KeyError, ValueError):
+            return HandlingResult.analyse()
+        event_bus.notify(TrueDetectEvent(bool(data["enable"])))
+        event_bus.notify(TrueDetectLevelEvent(level))
+        return HandlingResult.success()
+
+
+class SetTrueDetectV2(JsonSetCommand):
+    """China T80 AIVI 3D setting command."""
+
+    NAME = "setTrueDetect"
+
+    _mqtt_params = MappingProxyType(
+        {
+            "enable": InitParam(bool),
+            "level": InitParam(int),
+        }
+    )
+
+    def __init__(self, enable: bool, level: int = 1) -> None:
+        JsonSetCommand.__init__(self, {"enable": int(enable), "level": level})
+
+    @property
+    def get_command(self) -> type[GetTrueDetectT80]:
+        """Return the T80 true-detect query command."""
+        return GetTrueDetectT80
+
+
+class SetTrueDetectLevelT80(JsonSetCommand):
+    """Set only the T80 obstacle detection sensitivity."""
+
+    NAME = "setTrueDetect"
+    _mqtt_params = MappingProxyType(
+        {
+            "enable": InitParam(bool),
+            "level": InitParam(int),
+        }
+    )
+
+    def __init__(
+        self, level: TrueDetectLevel | int | str, enable: bool | None = None
+    ) -> None:
+        if isinstance(level, str):
+            level = get_enum(TrueDetectLevel, level)
+        self._requested_level = TrueDetectLevel(level)
+        super().__init__(
+            {
+                "enable": int(enable) if enable is not None else 1,
+                "level": int(self._requested_level),
+            }
+        )
+
+    @property
+    def get_command(self) -> type[GetTrueDetectT80]:
+        """Return the T80 true-detect query command."""
+        return GetTrueDetectT80
+
+    async def _execute(
+        self,
+        authenticator: Authenticator,
+        device_info: ApiDeviceInfo,
+        event_bus: EventBus,
+    ) -> tuple[Any, dict[str, Any]]:
+        event = event_bus.get_last_event(TrueDetectEvent)
+        if isinstance(event, TrueDetectEvent):
+            self._args["enable"] = int(event.enabled)
+        return await super()._execute(authenticator, device_info, event_bus)
+
+
+class StationActionT80(StationAction):
+    """China T80 station action with explicit action verb."""
+
+    def __init__(self, action: StationActionType, *, act: int = 1) -> None:
+        ExecuteCommand.__init__(self, {"act": act, "type": action.value})
+
+
+class ChargeT80(Charge):
+    """T80 charge command preserving docked state on duplicate charge."""
+
+    @classmethod
+    def _handle_body(
+        cls, event_bus: EventBus, body: dict[str, Any]
+    ) -> Any:
+        if int(body.get("code", -1)) == 0:
+            state = event_bus.get_last_event(StateEvent)
+            if state and state.state == State.DOCKED:
+                event_bus.notify(StateEvent(State.DOCKED))
+            else:
+                event_bus.notify(StateEvent(State.RETURNING))
+            return HandlingResult.success()
+        return super()._handle_body(event_bus, body)
+
+
+class GetWorkStateT80(OnWorkStateT80, JsonCommandWithMessageHandling):
+    """T80 work-state refresh command."""
+
+    NAME = "getWorkState"
+
+
+class CleanAreaV2FreeClean(CleanV2):
+    """T80 room-cleaning command using the freeClean payload."""
+
+    def __init__(
+        self, mode: CleanMode, area: list[int | float], cleanings: int = 1
+    ) -> None:
+        del mode
+        self._room_ids = [int(room_id) for room_id in area]
+        self._cleanings = cleanings
+        self._additional_content = {
+            "type": CleanMode.FREE_CLEAN.value,
+            "value": ";".join(
+                self._room_value(
+                    room_id,
+                    {
+                        "cleanings": cleanings,
+                        "fan_speed": 0,
+                        "water_amount": 30,
+                        "work_mode": 0,
+                    },
+                )
+                for room_id in self._room_ids
+            ),
+        }
+        super().__init__(CleanAction.START)
+
+    async def _execute(
+        self,
+        authenticator: Authenticator,
+        device_info: ApiDeviceInfo,
+        event_bus: EventBus,
+    ) -> tuple[Any, dict[str, Any]]:
+        """Use the current T80 cleaning settings in the room payload."""
+        fan_speed = event_bus.get_last_event(FanSpeedEvent)
+        water_amount = event_bus.get_last_event(WaterCustomAmountEvent)
+        work_mode = event_bus.get_last_event(WorkModeEvent)
+        clean_count = event_bus.get_last_event(CleanCountEvent)
+        if not isinstance(fan_speed, FanSpeedEvent):
+            fan_speed = None
+        if not isinstance(water_amount, WaterCustomAmountEvent):
+            water_amount = None
+        if not isinstance(work_mode, WorkModeEvent):
+            work_mode = None
+        if not isinstance(clean_count, CleanCountEvent):
+            clean_count = None
+        if fan_speed or water_amount or work_mode or clean_count:
+            settings = {
+                "fan_speed": fan_speed.speed if fan_speed else 0,
+                "water_amount": self._water_value(water_amount.value)
+                if water_amount
+                else 30,
+                "work_mode": work_mode.mode if work_mode else 0,
+                "cleanings": clean_count.count if clean_count else self._cleanings,
+            }
+            self._additional_content["value"] = ";".join(
+                self._room_value(room_id, settings) for room_id in self._room_ids
+            )
+        self._args = self._get_args(CleanAction.START)
+        return await super()._execute(authenticator, device_info, event_bus)
+
+    @staticmethod
+    def _water_value(custom_amount: int) -> int:
+        """Convert T80 custom water percent to the freeClean scale."""
+        return custom_amount * 2
+
+    @staticmethod
+    def _room_value(room_id: int, settings: dict[str, Any]) -> str:
+        return (
+            f"1,{room_id},,{settings['cleanings']},{settings['fan_speed']}"
+            f",{settings['water_amount']},{settings['work_mode']},1,0"
+        )
+
+    def _get_args(self, action: CleanAction) -> dict[str, Any]:
+        args = super()._get_args(action)
+        if action == CleanAction.START:
+            args["content"].update(self._additional_content)
+        return args
+
+
+class GetCleanPreferenceT80(GetCleanPreference):
+    """T80 clean-preference read, whose device service is unavailable."""
+
+    @classmethod
+    def _handle_body(
+        cls, event_bus: EventBus, body: dict[str, Any]
+    ) -> Any:
+        if body.get("code") == 20005:
+            return HandlingResult.success()
+        return super()._handle_body(event_bus, body)
+
+
+class SetCleanPreferenceT80(SetCleanPreference):
+    """T80 clean-preference setter linked to the T80 read command."""
+
+    get_command = GetCleanPreferenceT80

--- a/deebot_client/events/xwk78e.py
+++ b/deebot_client/events/xwk78e.py
@@ -1,0 +1,57 @@
+"""China T80 station setting events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum, unique
+
+from deebot_client.events.auto_empty import AutoEmptyEvent
+from deebot_client.events.base import Event
+
+
+@unique
+class AutoEmptyIntensity(IntEnum):
+    """T80 station suction intensity values."""
+
+    STANDARD = 1
+    SILENT = 0
+
+
+@dataclass(frozen=True)
+class AutoEmptyEventT80(AutoEmptyEvent):
+    """T80 auto-empty state including station suction intensity."""
+
+    intensity: AutoEmptyIntensity | None = None
+
+
+@unique
+class TrueDetectLevel(IntEnum):
+    """T80 obstacle detection sensitivity values."""
+
+    HIGH_SENSITIVITY = 0
+    STANDARD = 1
+
+
+@dataclass(frozen=True)
+class TrueDetectLevelEvent(Event):
+    """T80 obstacle detection sensitivity state."""
+
+    level: TrueDetectLevel
+
+
+@unique
+class WashMode(IntEnum):
+    """T80 station mop-washing modes."""
+
+    SMART_TEMPERATURE = 3
+    ENERGY_SAVING = 0
+    HOT_WATER_STANDARD = 1
+    HOT_WATER_DEEP = 2
+
+
+@dataclass(frozen=True)
+class WashModeEvent(Event):
+    """T80 station mop-washing mode state."""
+
+    mode: WashMode
+    interval: int | None = None

--- a/deebot_client/hardware/xwk78e.py
+++ b/deebot_client/hardware/xwk78e.py
@@ -1,0 +1,176 @@
+"""Deebot DEEBOT T80 China capabilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+from deebot_client.capabilities import (
+    CapabilityEvent,
+    CapabilitySettings,
+    CapabilitySetTypes,
+    CapabilityStation,
+)
+from deebot_client.commands import StationAction
+from deebot_client.commands.json.charge_state import GetChargeState
+from deebot_client.commands.json.clean import GetCleanInfoV2
+from deebot_client.commands.json.life_span import GetLifeSpan
+from deebot_client.commands.json.xwk78e import (
+    ChargeT80,
+    CleanAreaV2FreeClean,
+    GetAutoEmptyT80,
+    GetCleanPreferenceT80,
+    GetTrueDetectT80,
+    GetWashInfoT80,
+    GetWorkStateT80,
+    SetAutoEmptyV2,
+    SetCleanPreferenceT80,
+    SetTrueDetectLevelT80,
+    SetTrueDetectV2,
+    SetWashInfoT80,
+    StationActionT80,
+)
+from deebot_client.events import LifeSpan, LifeSpanEvent, StateEvent
+from deebot_client.events.xwk78e import (
+    AutoEmptyEventT80,
+    TrueDetectLevel,
+    TrueDetectLevelEvent,
+    WashMode,
+    WashModeEvent,
+)
+
+if TYPE_CHECKING:
+    from deebot_client.models import StaticDeviceInfo
+
+
+_base_get_device_info = import_module("deebot_client.hardware.9eamof").get_device_info
+
+
+@dataclass(frozen=True, kw_only=True)
+class CapabilityStationT80(CapabilityStation):
+    """T80 station capabilities with wash-mode settings."""
+
+    wash_mode: CapabilitySetTypes[WashModeEvent, [WashMode | str], WashMode]
+
+
+@dataclass(frozen=True, kw_only=True)
+class CapabilitySettingsT80(CapabilitySettings):
+    """T80 settings with obstacle sensitivity selection."""
+
+    true_detect_level: CapabilitySetTypes[
+        TrueDetectLevelEvent, [TrueDetectLevel | str], TrueDetectLevel
+    ] | None = None
+
+
+def get_device_info() -> StaticDeviceInfo:
+    """Get China T80 capabilities without changing shared profiles."""
+    info = _base_get_device_info()
+    capabilities = info.capabilities
+
+    charge = replace(capabilities.charge, execute=ChargeT80)
+
+    clean = replace(
+        capabilities.clean,
+        action=replace(
+            capabilities.clean.action,
+            area=CleanAreaV2FreeClean,
+        ),
+        preference=replace(
+            capabilities.clean.preference,
+            get=[GetCleanPreferenceT80()],
+            set=SetCleanPreferenceT80,
+        ),
+    )
+
+    life_span_types = (
+        LifeSpan.BRUSH,
+        LifeSpan.FILTER,
+        LifeSpan.SIDE_BRUSH,
+        LifeSpan.UNIT_CARE,
+        LifeSpan.CLEANING_SOLUTION,
+        LifeSpan.SEWAGE_BOX,
+        LifeSpan.DUST_BAG,
+        LifeSpan.ROUND_MOP,
+        LifeSpan.WATER_SINK,
+    )
+    life_span = replace(
+        capabilities.life_span,
+        types=life_span_types,
+        event=LifeSpanEvent,
+        get=[GetLifeSpan(list(life_span_types))],
+    )
+
+    base_settings = capabilities.settings
+    settings = CapabilitySettingsT80(
+        advanced_mode=base_settings.advanced_mode,
+        carpet_auto_fan_boost=base_settings.carpet_auto_fan_boost,
+        efficiency_mode=base_settings.efficiency_mode,
+        border_spin=base_settings.border_spin,
+        border_switch=base_settings.border_switch,
+        child_lock=base_settings.child_lock,
+        cut_direction=base_settings.cut_direction,
+        mop_auto_wash_frequency=base_settings.mop_auto_wash_frequency,
+        moveup_warning=base_settings.moveup_warning,
+        cross_map_border_warning=base_settings.cross_map_border_warning,
+        safe_protect=base_settings.safe_protect,
+        ota=base_settings.ota,
+        sweep_mode=base_settings.sweep_mode,
+        true_detect=replace(
+            base_settings.true_detect,
+            get=[GetTrueDetectT80()],
+            set=SetTrueDetectV2,
+        ),
+        true_detect_level=CapabilitySetTypes(
+            event=TrueDetectLevelEvent,
+            get=[GetTrueDetectT80()],
+            set=SetTrueDetectLevelT80,
+            types=tuple(TrueDetectLevel),
+        ),
+        voice_assistant=base_settings.voice_assistant,
+        volume=base_settings.volume,
+    )
+
+    state = CapabilityEvent(
+        StateEvent,
+        [GetChargeState(), GetCleanInfoV2(), GetWorkStateT80()],
+    )
+
+    station = CapabilityStationT80(
+        action=replace(
+            capabilities.station.action,
+            execute=StationActionT80,
+            types=(
+                StationAction.EMPTY_DUSTBIN,
+                StationAction.DRY_MOP,
+                StationAction.CLEAN_BASE,
+                StationAction.WASH_MOP,
+            ),
+        ),
+        auto_empty=replace(
+            capabilities.station.auto_empty,
+            event=AutoEmptyEventT80,
+            get=[GetAutoEmptyT80()],
+            set=SetAutoEmptyV2,
+        ),
+        state=capabilities.station.state,
+        wash_mode=CapabilitySetTypes(
+            event=WashModeEvent,
+            get=[GetWashInfoT80()],
+            set=SetWashInfoT80,
+            types=tuple(WashMode),
+        ),
+    )
+
+    return replace(
+        info,
+        capabilities=replace(
+            capabilities,
+            charge=charge,
+            clean=clean,
+            life_span=life_span,
+            settings=settings,
+            state=state,
+            station=station,
+        ),
+    )

--- a/deebot_client/messages/__init__.py
+++ b/deebot_client/messages/__init__.py
@@ -8,6 +8,7 @@ from deebot_client.const import DataType
 from deebot_client.logging_filter import get_logger
 
 from .json import MESSAGES as JSON_MESSAGES, get_legacy_message
+from .json.xwk78e import OnAutoEmptyT80, OnWashInfoT80
 from .xml import MESSAGES as XML_MESSAGES
 
 if TYPE_CHECKING:
@@ -34,6 +35,14 @@ def get_message(
     if messages is None:
         _LOGGER.warning("Datatype %s is not supported.", static.data_type)
         return None
+
+    if static.data_type == DataType.JSON and (
+        station := static.capabilities.station
+    ) is not None and getattr(station, "wash_mode", None) is not None:
+        messages = messages | {
+            "onAutoEmpty": OnAutoEmptyT80,
+            "onWashInfo": OnWashInfoT80,
+        }
 
     if message_type := messages.get(message_name, None):
         return message_type

--- a/deebot_client/messages/json/xwk78e.py
+++ b/deebot_client/messages/json/xwk78e.py
@@ -1,0 +1,102 @@
+"""China T80-specific work-state message handling."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from deebot_client.events import StateEvent
+from deebot_client.events.auto_empty import Frequency
+from deebot_client.events.station import StationEvent
+from deebot_client.events.xwk78e import (
+    AutoEmptyEventT80,
+    AutoEmptyIntensity,
+    WashMode,
+    WashModeEvent,
+)
+from deebot_client.message import HandlingResult, MessageBodyDataDict
+from deebot_client.messages.json.work_state import _WORK_STATE_2_EVENTS
+from deebot_client.models import State as RobotState
+
+if TYPE_CHECKING:
+    from deebot_client.event_bus import EventBus
+
+
+class OnWorkStateT80(MessageBodyDataDict):
+    """Handle T80's stale paused payloads without changing other models."""
+
+    NAME = "onWorkState"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        robot_state = data.get("robotState", {}).get("state")
+        station_state = data.get("stationState", {}).get("state")
+        robot_status, station_status = _WORK_STATE_2_EVENTS.get(robot_state, {}).get(
+            station_state, (None, None)
+        )
+
+        if (robot_status, station_status) == (None, None):
+            return HandlingResult.analyse()
+
+        if data.get("paused") == 1:
+            robot_data = data.get("robotState", {})
+            voice_charging = (
+                robot_data.get("state") == "cleaning"
+                and robot_data.get("trigger") == "voice"
+                and station_state == "idle"
+            )
+            last_state = event_bus.get_last_event(StateEvent)
+            if voice_charging or (
+                last_state and last_state.state == RobotState.DOCKED
+            ):
+                robot_status = None
+            else:
+                robot_status = RobotState.PAUSED
+
+        if robot_status is not None:
+            event_bus.notify(StateEvent(robot_status))
+        if station_status is not None:
+            event_bus.notify(StationEvent(station_status))
+
+        return HandlingResult.success()
+
+
+class OnAutoEmptyT80(MessageBodyDataDict):
+    """Parse T80 auto-empty state including suction intensity."""
+
+    NAME = "onAutoEmpty"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        frequency = None
+        if frequency_value := data.get("frequency"):
+            frequency = Frequency(frequency_value)
+        intensity = data.get("intensity")
+        event_bus.notify(
+            AutoEmptyEventT80(
+                bool(data["enable"]),
+                frequency,
+                AutoEmptyIntensity(intensity) if intensity is not None else None,
+            )
+        )
+        return HandlingResult.success()
+
+
+class OnWashInfoT80(MessageBodyDataDict):
+    """Parse T80 station mop-washing mode state."""
+
+    NAME = "onWashInfo"
+
+    @classmethod
+    def _handle_body_data_dict(
+        cls, event_bus: EventBus, data: dict[str, Any]
+    ) -> HandlingResult:
+        try:
+            mode = WashMode(data["mode"])
+        except (KeyError, ValueError):
+            return HandlingResult.analyse()
+        event_bus.notify(WashModeEvent(mode, data.get("interval")))
+        return HandlingResult.success()

--- a/deebot_client/mqtt_client.py
+++ b/deebot_client/mqtt_client.py
@@ -17,6 +17,7 @@ from deebot_client.const import UNDEFINED, DataType, UndefinedType
 from deebot_client.exceptions import AuthenticationError, MqttError
 
 from .commands import COMMANDS_WITH_MQTT_P2P_HANDLING
+from .commands.json.xwk78e import SetTrueDetectV2, SetWashInfoT80
 from .logging_filter import get_logger
 from .util.continents import get_continent_url_postfix
 
@@ -294,6 +295,14 @@ class MqttClient:
             command_type = COMMANDS_WITH_MQTT_P2P_HANDLING.get(data_type, {}).get(
                 command_name, None
             )
+            device_did = topic_split[3] if topic_split[9] == "p" else topic_split[6]
+            if sub_info := self._subscriptions.get(device_did):
+                station = sub_info.device_info.static.capabilities.station
+                if station is not None and getattr(station, "wash_mode", None) is not None:
+                    if command_name == "setTrueDetect":
+                        command_type = SetTrueDetectV2
+                    elif command_name == "setWashInfo":
+                        command_type = SetWashInfoT80
             if command_type is None:
                 _LOGGER.debug(
                     "Command %s does not support p2p handling (yet)", command_name

--- a/tests/commands/json/test_auto_empty.py
+++ b/tests/commands/json/test_auto_empty.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from deebot_client.commands.json.auto_empty import GetAutoEmpty, SetAutoEmpty
+from deebot_client.commands.json.xwk78e import SetAutoEmptyV2
 from deebot_client.events.auto_empty import AutoEmptyEvent, Frequency
 from tests.helpers import (
     get_request_json,
@@ -118,4 +119,32 @@ async def test_SetAutoEmpty(
 ) -> None:
     """Test SetAutoEmpty."""
     command = SetAutoEmpty(enabled, frequency)
+    await assert_execute_command(command, args)
+
+
+@pytest.mark.parametrize(
+    ("enabled", "frequency", "args"),
+    [
+        (
+            True,
+            Frequency.SMART,
+            {"enable": 1, "frequency": "smart", "intensity": 1},
+        ),
+        (
+            True,
+            Frequency.AUTO,
+            {"enable": 1, "frequency": "auto", "intensity": 1},
+        ),
+        (
+            None,
+            Frequency.AUTO,
+            {"enable": 1, "frequency": "auto", "intensity": 1},
+        ),
+    ],
+)
+async def test_SetAutoEmptyV2(
+    enabled: bool, frequency: Frequency, args: dict[str, Any]
+) -> None:
+    """Test the China T80 auto-empty command payload."""
+    command = SetAutoEmptyV2(enabled, frequency)
     await assert_execute_command(command, args)

--- a/tests/commands/json/test_charge.py
+++ b/tests/commands/json/test_charge.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
 from deebot_client.commands.json import Charge
+from deebot_client.commands.json.xwk78e import ChargeT80
 from deebot_client.events import FirmwareEvent, StateEvent
 from deebot_client.message import HandlingResult, HandlingState
 from deebot_client.models import State
@@ -37,6 +39,17 @@ async def test_Charge(
 ) -> None:
     json, firmware_event = data
     await assert_command(Charge(), json, (firmware_event, expected))
+
+
+async def test_Charge_when_already_docked() -> None:
+    event_bus = Mock()
+    event_bus.get_last_event.return_value = StateEvent(State.DOCKED)
+
+    json, _ = _prepare_json(0)
+    result = ChargeT80._handle_body(event_bus, json["resp"]["body"])
+
+    assert result == HandlingResult.success()
+    event_bus.notify.assert_called_once_with(StateEvent(State.DOCKED))
 
 
 async def test_Charge_failed(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/commands/json/test_clean.py
+++ b/tests/commands/json/test_clean.py
@@ -13,8 +13,18 @@ from deebot_client.commands.json.clean import (
     CleanV2,
     GetCleanInfoV2,
 )
+from deebot_client.commands.json.xwk78e import CleanAreaV2FreeClean
 from deebot_client.event_bus import EventBus
-from deebot_client.events import FirmwareEvent, StateEvent
+from deebot_client.events import (
+    CleanCountEvent,
+    FanSpeedEvent,
+    FanSpeedLevel,
+    FirmwareEvent,
+    StateEvent,
+    WorkMode,
+    WorkModeEvent,
+)
+from deebot_client.events.water_info import WaterCustomAmountEvent
 from deebot_client.models import ApiDeviceInfo, CleanAction, CleanMode, State
 from tests.helpers import get_request_json, get_success_body
 
@@ -150,6 +160,16 @@ async def test_Clean_act(
                 "content": {"type": "freeClean", "value": "2,0"},
             },
         ),
+        (
+            CleanAreaV2FreeClean(CleanMode.SPOT_AREA, [5, 8]),
+            {
+                "act": "start",
+                "content": {
+                    "type": "freeClean",
+                    "value": "1,5,,1,0,30,0,1,0;1,8,,1,0,30,0,1,0",
+                },
+            },
+        ),
     ],
     ids=[
         "Rooms",
@@ -158,9 +178,35 @@ async def test_Clean_act(
         "Coordinates V2",
         "FreeClean",
         "FreeClean single room 2x",
+        "T80 freeClean room list",
     ],
 )
 async def test_CleanArea(
     command: CleanArea | CleanAreaV2, args: dict[str, str]
 ) -> None:
     await assert_execute_command(command, args)
+
+
+async def test_CleanArea_uses_current_t80_settings(
+    authenticator: Authenticator,
+    api_device_info: ApiDeviceInfo,
+) -> None:
+    event_bus = Mock(spec_set=EventBus)
+    events = {
+        FanSpeedEvent: FanSpeedEvent(FanSpeedLevel.MAX),
+        WaterCustomAmountEvent: WaterCustomAmountEvent(15),
+        WorkModeEvent: WorkModeEvent(WorkMode.MOP_AFTER_VACUUM),
+        CleanCountEvent: CleanCountEvent(2),
+    }
+    event_bus.get_last_event.side_effect = events.get
+    command = CleanAreaV2FreeClean(CleanMode.SPOT_AREA, [5, 8])
+
+    await command.execute(authenticator, api_device_info, event_bus)
+
+    assert command._args == {
+        "act": "start",
+        "content": {
+            "type": "freeClean",
+            "value": "1,5,,2,1,30,3,1,0;1,8,,2,1,30,3,1,0",
+        },
+    }

--- a/tests/commands/json/test_clean_preference.py
+++ b/tests/commands/json/test_clean_preference.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 
 from deebot_client.commands.json import GetCleanPreference, SetCleanPreference
+from deebot_client.commands.json.xwk78e import GetCleanPreferenceT80
 from deebot_client.events import CleanPreferenceEvent
+from deebot_client.message import HandlingResult
 from tests.helpers import get_request_json, get_success_body
 
 from . import assert_command, assert_set_enable_command
@@ -17,6 +21,14 @@ async def test_GetCleanPreference(*, value: bool) -> None:
     await assert_command(
         GetCleanPreference(), json, (firmware_event, CleanPreferenceEvent(value))
     )
+
+
+async def test_GetCleanPreference_unsupported_read_service() -> None:
+    result = GetCleanPreferenceT80._handle_body(
+        Mock(), {"code": 20005, "msg": "call setting service empty"}
+    )
+
+    assert result == HandlingResult.success()
 
 
 @pytest.mark.parametrize("value", [False, True])

--- a/tests/commands/json/test_station_action.py
+++ b/tests/commands/json/test_station_action.py
@@ -1,4 +1,4 @@
-"""Auto empty tests."""
+"""Station action tests."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import pytest
 
 from deebot_client.commands import StationAction
 from deebot_client.commands.json import station_action
+from deebot_client.commands.json.xwk78e import StationActionT80
 
 from . import assert_execute_command
 
@@ -33,6 +34,14 @@ async def test_StationAction(
     action: StationAction,
     args: dict[str, Any],
 ) -> None:
-    """Test StationAction."""
-    command = station_action.StationAction(action)
-    await assert_execute_command(command, args)
+    """Test the shared station action command."""
+    await assert_execute_command(station_action.StationAction(action), args)
+
+
+@pytest.mark.parametrize("act", [1, 2, 3, 4])
+async def test_StationActionT80(act: int) -> None:
+    """Test T80 station actions with explicit action verbs."""
+    await assert_execute_command(
+        StationActionT80(StationAction.WASH_MOP, act=act),
+        {"act": act, "type": 4},
+    )

--- a/tests/commands/json/test_true_detect.py
+++ b/tests/commands/json/test_true_detect.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import pytest
 
 from deebot_client.commands.json import GetTrueDetect, SetTrueDetect
+from deebot_client.commands.json.xwk78e import SetTrueDetectV2
 from deebot_client.events import TrueDetectEvent
+from deebot_client.events.xwk78e import TrueDetectLevel, TrueDetectLevelEvent
 from tests.helpers import get_request_json, get_success_body
 
-from . import assert_command, assert_set_enable_command
+from . import assert_command, assert_set_command, assert_set_enable_command
 
 
 @pytest.mark.parametrize("value", [False, True])
@@ -23,4 +25,27 @@ async def test_GetTrueDetect(*, value: bool) -> None:
 async def test_SetTrueDetect(*, value: bool) -> None:
     await assert_set_enable_command(
         SetTrueDetect(value), TrueDetectEvent, enabled=value
+    )
+
+
+@pytest.mark.parametrize("value", [False, True])
+async def test_SetTrueDetectV2_default_level(*, value: bool) -> None:
+    command = SetTrueDetectV2(value)
+    await assert_set_command(
+        command,
+        {"enable": 1 if value else 0, "level": 1},
+        (TrueDetectEvent(value), TrueDetectLevelEvent(TrueDetectLevel.STANDARD)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "level"),
+    [(False, 0), (True, 0), (True, 1)],
+)
+async def test_SetTrueDetectV2(*, value: bool, level: int) -> None:
+    command = SetTrueDetectV2(value, level)
+    await assert_set_command(
+        command,
+        {"enable": 1 if value else 0, "level": level},
+        (TrueDetectEvent(value), TrueDetectLevelEvent(TrueDetectLevel(level))),
     )

--- a/tests/commands/json/test_work_state.py
+++ b/tests/commands/json/test_work_state.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from unittest.mock import Mock
 
 import pytest
 
 from deebot_client.commands.json.work_state import GetWorkState
+from deebot_client.commands.json.xwk78e import GetWorkStateT80
 from deebot_client.events import StateEvent
 from deebot_client.events.station import State as StationState, StationEvent
 from deebot_client.message import HandlingResult, HandlingState
@@ -26,6 +28,13 @@ if TYPE_CHECKING:
             {},
             "idle",
             [StationEvent(StationState.IDLE)],
+        ),
+        (
+            1,
+            "idle",
+            {},
+            "idle",
+            [StateEvent(RobotState.PAUSED), StationEvent(StationState.IDLE)],
         ),
         (
             0,
@@ -133,6 +142,23 @@ async def test_GetWorkState(
         )
     )
     await assert_command(GetWorkState(), json, (firmware_event, *expected))
+
+
+async def test_GetWorkState_does_not_override_docked_with_stale_pause() -> None:
+    event_bus = Mock()
+    event_bus.get_last_event.return_value = StateEvent(RobotState.IDLE)
+
+    result = GetWorkStateT80._handle_body_data_dict(
+        event_bus,
+        {
+            "paused": 1,
+            "robotState": {"state": "cleaning", "trigger": "voice"},
+            "stationState": {"state": "idle"},
+        },
+    )
+
+    assert result == HandlingResult.success()
+    event_bus.notify.assert_called_once_with(StationEvent(StationState.IDLE))
 
 
 @pytest.mark.parametrize(

--- a/tests/commands/json/test_xwk78e.py
+++ b/tests/commands/json/test_xwk78e.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from deebot_client.commands.json.xwk78e import (
+    GetAutoEmptyT80,
+    GetTrueDetectT80,
+    GetWashInfoT80,
+    SetTrueDetectLevelT80,
+    SetTrueDetectV2,
+    SetWashInfoT80,
+)
+from deebot_client.events import TrueDetectEvent
+from deebot_client.events.auto_empty import Frequency
+from deebot_client.events.xwk78e import (
+    AutoEmptyEventT80,
+    TrueDetectLevel,
+    TrueDetectLevelEvent,
+    WashMode,
+    WashModeEvent,
+)
+from tests.helpers import get_request_json, get_success_body
+
+from . import assert_command, assert_execute_command, assert_set_command
+
+
+@pytest.mark.parametrize("enable", [False, True])
+@pytest.mark.parametrize("level", list(TrueDetectLevel))
+async def test_GetTrueDetectT80(enable: bool, level: TrueDetectLevel) -> None:
+    json, firmware_event = get_request_json(
+        get_success_body({"enable": int(enable), "level": int(level)})
+    )
+    await assert_command(
+        GetTrueDetectT80(),
+        json,
+        (firmware_event, TrueDetectEvent(enable), TrueDetectLevelEvent(level)),
+    )
+
+
+@pytest.mark.parametrize("enable", [False, True])
+@pytest.mark.parametrize("level", list(TrueDetectLevel))
+async def test_SetTrueDetectV2(enable: bool, level: TrueDetectLevel) -> None:
+    await assert_set_command(
+        SetTrueDetectV2(enable, level),
+        {"enable": int(enable), "level": int(level)},
+        (TrueDetectEvent(enable), TrueDetectLevelEvent(level)),
+    )
+
+
+@pytest.mark.parametrize("level", list(TrueDetectLevel))
+async def test_SetTrueDetectLevelT80(level: TrueDetectLevel) -> None:
+    await assert_set_command(
+        SetTrueDetectLevelT80(level),
+        {"enable": 1, "level": int(level)},
+        (TrueDetectEvent(True), TrueDetectLevelEvent(level)),
+    )
+
+
+@pytest.mark.parametrize("intensity", [0, 1])
+async def test_GetAutoEmptyT80(intensity: int) -> None:
+    json, firmware_event = get_request_json(
+        get_success_body(
+            {"enable": 1, "frequency": "smart", "intensity": intensity}
+        )
+    )
+    await assert_command(
+        GetAutoEmptyT80(),
+        json,
+        (firmware_event, AutoEmptyEventT80(True, Frequency.SMART, intensity)),
+    )
+
+
+@pytest.mark.parametrize("mode", list(WashMode))
+async def test_SetWashInfoT80(mode: WashMode) -> None:
+    await assert_execute_command(
+        SetWashInfoT80(mode), {"mode": int(mode), "interval": 15}
+    )
+
+
+@pytest.mark.parametrize("mode", list(WashMode))
+async def test_GetWashInfoT80(mode: WashMode) -> None:
+    json, firmware_event = get_request_json(get_success_body({"mode": int(mode)}))
+    await assert_command(
+        GetWashInfoT80(), json, (firmware_event, WashModeEvent(mode))
+    )

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -9,6 +10,7 @@ from unittest import mock
 import pytest
 
 from deebot_client import hardware
+from deebot_client.commands import StationAction
 from deebot_client.commands.json import GetCutDirection
 from deebot_client.commands.json.advanced_mode import GetAdvancedMode
 from deebot_client.commands.json.auto_empty import GetAutoEmpty
@@ -17,7 +19,12 @@ from deebot_client.commands.json.border_switch import GetBorderSwitch
 from deebot_client.commands.json.carpet import GetCarpetAutoFanBoost
 from deebot_client.commands.json.charge_state import GetChargeState
 from deebot_client.commands.json.child_lock import GetChildLock
-from deebot_client.commands.json.clean import GetCleanInfo, GetCleanInfoV2
+from deebot_client.commands.json.clean import (
+    CleanAreaV2,
+    CleanV2,
+    GetCleanInfo,
+    GetCleanInfoV2,
+)
 from deebot_client.commands.json.clean_count import GetCleanCount
 from deebot_client.commands.json.clean_logs import GetCleanLogs
 from deebot_client.commands.json.clean_preference import GetCleanPreference
@@ -42,6 +49,19 @@ from deebot_client.commands.json.true_detect import GetTrueDetect
 from deebot_client.commands.json.voice_assistant_state import GetVoiceAssistantState
 from deebot_client.commands.json.volume import GetVolume
 from deebot_client.commands.json.water_info import GetWaterInfo
+from deebot_client.commands.json.xwk78e import (
+    ChargeT80,
+    CleanAreaV2FreeClean,
+    GetAutoEmptyT80,
+    GetCleanPreferenceT80,
+    GetWashInfoT80,
+    GetWorkStateT80,
+    SetAutoEmptyV2,
+    SetCleanPreferenceT80,
+    SetTrueDetectV2,
+    SetWashInfoT80,
+    StationActionT80,
+)
 from deebot_client.events import (
     AdvancedModeEvent,
     AutoEmptyEvent,
@@ -85,6 +105,7 @@ from deebot_client.events.map import (
 )
 from deebot_client.events.network import NetworkInfoEvent
 from deebot_client.events.water_info import MopAttachedEvent, WaterAmountEvent
+from deebot_client.events.xwk78e import AutoEmptyEventT80, WashMode
 from deebot_client.hardware.yna5xi import get_device_info as get_yna5xi_info
 from deebot_client.models import StaticDeviceInfo
 
@@ -112,6 +133,77 @@ async def test_get_static_device_info(
         static_device_info_cached = await hardware.get_static_device_info(class_)
         assert static_device_info_cached == expected
         mock_import.assert_not_called()
+
+
+async def test_xwk78e_uses_t80_capabilities() -> None:
+    """Test that the China T80 class resolves to the T80 capability profile."""
+    static_device_info = await hardware.get_static_device_info("xwk78e")
+
+    assert static_device_info is not None
+    assert static_device_info.capabilities.clean is not None
+    assert static_device_info.capabilities.clean.action.command is CleanV2
+    assert static_device_info.capabilities.clean.action.area is CleanAreaV2FreeClean
+    assert static_device_info.capabilities.clean.preference.get == [
+        GetCleanPreferenceT80()
+    ]
+    assert static_device_info.capabilities.clean.preference.set is SetCleanPreferenceT80
+    assert static_device_info.capabilities.charge.execute is ChargeT80
+    assert static_device_info.capabilities.life_span is not None
+    assert static_device_info.capabilities.life_span.get[0] == GetLifeSpan(
+        [
+            LifeSpan.BRUSH,
+            LifeSpan.FILTER,
+            LifeSpan.SIDE_BRUSH,
+            LifeSpan.UNIT_CARE,
+            LifeSpan.CLEANING_SOLUTION,
+            LifeSpan.SEWAGE_BOX,
+            LifeSpan.DUST_BAG,
+            LifeSpan.ROUND_MOP,
+            LifeSpan.WATER_SINK,
+        ]
+    )
+    assert static_device_info.capabilities.station is not None
+    assert static_device_info.capabilities.station.auto_empty is not None
+    assert static_device_info.capabilities.station.auto_empty.set is SetAutoEmptyV2
+    assert static_device_info.capabilities.station.auto_empty.event is AutoEmptyEventT80
+    assert static_device_info.capabilities.station.auto_empty.get == [GetAutoEmptyT80()]
+    assert static_device_info.capabilities.station.wash_mode.types == tuple(WashMode)
+    assert static_device_info.capabilities.station.wash_mode.set is SetWashInfoT80
+    assert static_device_info.capabilities.station.wash_mode.get == [GetWashInfoT80()]
+    assert static_device_info.capabilities.station.action.execute is StationActionT80
+    assert static_device_info.capabilities.station.action.types == (
+        StationAction.EMPTY_DUSTBIN,
+        StationAction.DRY_MOP,
+        StationAction.CLEAN_BASE,
+        StationAction.WASH_MOP,
+    )
+    assert static_device_info.capabilities.settings is not None
+    assert static_device_info.capabilities.settings.true_detect is not None
+    assert static_device_info.capabilities.settings.true_detect.set is SetTrueDetectV2
+    assert static_device_info.capabilities.get_refresh_commands(StateEvent) == [
+        GetChargeState(),
+        GetCleanInfoV2(),
+        GetWorkStateT80(),
+    ]
+
+
+async def test_xwk78e_does_not_modify_shared_t80_profile() -> None:
+    """Ensure the shared T80 profile keeps upstream capabilities."""
+    shared = import_module("deebot_client.hardware.9eamof").get_device_info()
+
+    assert shared.capabilities.clean.action.command is CleanV2
+    assert shared.capabilities.clean.action.area is CleanAreaV2
+    assert shared.capabilities.clean.preference.get == [GetCleanPreference()]
+    assert shared.capabilities.station.action.types == (StationAction.EMPTY_DUSTBIN,)
+    assert shared.capabilities.state is not None
+    assert shared.capabilities.get_refresh_commands(StateEvent) == [
+        GetChargeState(),
+        GetCleanInfoV2(),
+    ]
+    assert shared.capabilities.life_span is not None
+    assert LifeSpan.DUST_BAG not in shared.capabilities.life_span.types
+    assert LifeSpan.ROUND_MOP not in shared.capabilities.life_span.types
+    assert LifeSpan.WATER_SINK not in shared.capabilities.life_span.types
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Add support for the China-region Ecovacs DEEBOT T80 OMNI identified by hardware class `xwk78e`.

This device is different from the existing T80 OMNI profile represented by `9eamof`. The two devices must remain separate profiles: they have different hardware classes and different protocol behavior. This PR adds support for `xwk78e` without replacing or changing the existing `9eamof` implementation.

The implementation keeps T80-specific protocol behavior in dedicated modules and uses capability-gated routing for the small changes required in shared message and MQTT entry points.

## Device information

- Device: Ecovacs DEEBOT T80 OMNI
- Region: China (`CN`)
- Company: `eco-ng`
- Hardware class: `xwk78e`
- Model: `KEPLER_SE_WHITE`
- Firmware tested: `1.69.0`

## Important distinction from the existing `9eamof` profile

- `xwk78e` is the China-region T80 OMNI device covered by this PR.
- `9eamof` is an existing, different device profile in the repository.
- This PR does not modify `deebot_client/hardware/9eamof.py`.
- T80-specific consumables, state semantics, command payloads, and settings are not added to `9eamof`.
- The `xwk78e` profile is loaded only when the device discovery result contains `class=xwk78e`.
- The existing `9eamof` profile continues to use its original commands, events, capabilities, and consumable list.

## Implementation details

### Dedicated hardware profile

`deebot_client/hardware/xwk78e.py` derives the base structure from the original `9eamof` profile and applies T80-only replacements using `dataclasses.replace` and T80-specific capability classes.

The profile provides:

- T80-specific cleaning action and room-cleaning command;
- T80-specific charging and work-state commands;
- T80-specific station action types;
- T80-specific auto-empty event and command;
- T80-specific wash-mop capability;
- T80-specific obstacle sensitivity capability;
- T80-specific nine-item consumable list.

### T80 commands

`deebot_client/commands/json/xwk78e.py` adds:

- `SetAutoEmptyV2` and `GetAutoEmptyT80`;
- `SetWashInfoT80` and `GetWashInfoT80`;
- `GetTrueDetectT80`;
- `SetTrueDetectV2`;
- `SetTrueDetectLevelT80`;
- `StationActionT80`;
- `ChargeT80`;
- `GetWorkStateT80`;
- `CleanAreaV2FreeClean`;
- `GetCleanPreferenceT80` and `SetCleanPreferenceT80`.

### T80 events

`deebot_client/events/xwk78e.py` adds:

- `AutoEmptyIntensity`:
  - `STANDARD = 1`;
  - `SILENT = 0`;
- `AutoEmptyEventT80`;
- `WashMode`:
  - `SMART_TEMPERATURE = 3`;
  - `ENERGY_SAVING = 0`;
  - `HOT_WATER_STANDARD = 1`;
  - `HOT_WATER_DEEP = 2`;
- `WashModeEvent`;
- `TrueDetectLevel`:
  - `HIGH_SENSITIVITY = 0`;
  - `STANDARD = 1`;
- `TrueDetectLevelEvent`.

### T80 messages

`deebot_client/messages/json/xwk78e.py` adds T80-specific parsing for:

- `onWorkState`;
- `onAutoEmpty`;
- `onWashInfo`.

The T80 work-state parser handles stale paused payloads reported during voice-triggered charging and preserves a docked state when appropriate.

### Cleaning

- Use `clean_V2` instead of the unsupported generic `clean` command.
- Add T80 `freeClean` room-cleaning payloads.
- Support multiple room IDs.
- Preserve the current cleaning settings in room-cleaning payloads:
  - Cleaning mode;
  - Fan speed;
  - Water amount;
  - Cleaning count.
- Convert the T80 custom water amount to the `freeClean` protocol scale.

The room payload uses the T80 format:

```text
1,<room_id>,,<count>,<fan>,<water>,<mode>,1,0
```

Multiple rooms are joined with semicolons.

### Station and cleaning settings

- Add T80 auto-empty handling with suction intensity.
- Support T80 station actions:
  - Empty dustbin;
  - Dry mop;
  - Clean base;
  - Wash mop.
- Support wash-mop actions with explicit start, pause, resume, and cancel verbs.
- Add T80 mop-washing modes:
  - Smart temperature;
  - Energy saving;
  - Hot water standard;
  - Hot water deep.

### AIVI 3D obstacle detection

- Preserve the obstacle-detection enable/disable state when changing sensitivity.
- Add T80 obstacle-detection sensitivity:
  - Standard (`level=1`);
  - High sensitivity (`level=0`).
- Parse and publish both the enable state and sensitivity level.
- Use the same T80 `getTrueDetect` response to update both events.

### Consumables and state handling

- Add the nine consumable types reported by the China-region T80 OMNI.
- Preserve docked state when the robot is already docked and a duplicate charge command is received.
- Add T80 work-state refresh handling after the robot leaves the dock.
- Treat the T80 unsupported clean-preference read response as a handled device limitation instead of a false error.

## Shared entry-point changes and isolation

Two existing shared production files are changed because device discovery and MQTT message handling enter through these modules:

### `deebot_client/messages/__init__.py`

- Add conditional routing for T80 `onAutoEmpty` and `onWashInfo` messages.
- The T80 parser is selected only when the device has the T80-specific `wash_mode` capability.
- Other hardware profiles continue to use the existing message mapping.

### `deebot_client/mqtt_client.py`

- Add conditional routing for T80 `setTrueDetect` and `setWashInfo` MQTT P2P commands.
- The routing is selected only for devices with the T80-specific `wash_mode` capability.
- T80 `get*` queries are not forced through MQTT P2P command parsing because the regular JSON get commands do not implement `create_from_mqtt`.

No other shared runtime files were changed.

## Complete production file list

### New files

```text
deebot_client/commands/json/xwk78e.py
deebot_client/events/xwk78e.py
deebot_client/hardware/xwk78e.py
deebot_client/messages/json/xwk78e.py
```

### Existing production files changed

```text
deebot_client/messages/__init__.py
deebot_client/mqtt_client.py
```

### Existing production files intentionally not changed

```text
deebot_client/hardware/9eamof.py
deebot_client/commands/json/auto_empty.py
deebot_client/commands/json/clean.py
deebot_client/commands/json/station_action.py
deebot_client/events/*
deebot_client/messages/json/*
```

The last two wildcard entries mean that no existing generic event or message implementation was modified; the new T80 implementations are in the dedicated `xwk78e.py` modules.

## Test file list

### New test file

```text
tests/commands/json/test_xwk78e.py
```

### Existing test files extended

```text
tests/commands/json/test_auto_empty.py
tests/commands/json/test_charge.py
tests/commands/json/test_clean.py
tests/commands/json/test_clean_preference.py
tests/commands/json/test_station_action.py
tests/commands/json/test_true_detect.py
tests/commands/json/test_work_state.py
tests/hardware/test_init.py
```

The hardware tests explicitly verify that the new `xwk78e` profile does not modify the original `9eamof` profile.

## Isolation and compatibility

- Existing hardware profiles were not modified.
- In particular, `deebot_client/hardware/9eamof.py` remains unchanged.
- T80-specific code is contained in new `xwk78e` modules.
- Shared message and MQTT routing changes are guarded by the T80-specific capability.
- No Home Assistant integration files are included in this PR.
- Existing non-T80 command and capability behavior is preserved.

## Testing

- Added T80 command, message, capability, and profile-isolation tests.
- T80-related test result:
  - `142 passed`;
  - `5 deselected`.
- Ruff checks passed for all changed files.
- The T80 profile was installed from a Linux `musllinux` wheel in a Home Assistant Docker environment and loaded successfully.
- The installed wheel exposed the expected T80 cleaning, wash-mode, and obstacle-sensitivity capabilities.

The complete test suite on the Windows development environment currently has unrelated collection limitations:

- Windows Git symlink files are checked out as plain text for some numeric hardware module names.
- `pycountry` is unavailable in the local virtual environment.
- Existing benchmark and timeout marker warnings are reported by the local environment.

## Breaking changes

None intended.