### PR TITLE
Add station water tank capability for T50 Max Pro Omni

### DIFF
--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -231,11 +231,6 @@ class CapabilitySettings:
     volume: CapabilitySet[VolumeEvent, [int]] | None = None
 
 
-@dataclass(frozen=True)
-class CapabilityStationWaterTank:
-    """Capabilities for station water tanks."""
-
-
 @dataclass(frozen=True, kw_only=True)
 class CapabilityStation:
     """Capabilities for the station."""
@@ -247,7 +242,7 @@ class CapabilityStation:
         auto_empty.Frequency,
     ]
     state: CapabilityEvent[StationEvent]
-    water_tank: CapabilityStationWaterTank | None = None
+    water_tank: CapabilityEvent[ErrorEvent] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/deebot_client/capabilities.py
+++ b/deebot_client/capabilities.py
@@ -231,6 +231,11 @@ class CapabilitySettings:
     volume: CapabilitySet[VolumeEvent, [int]] | None = None
 
 
+@dataclass(frozen=True)
+class CapabilityStationWaterTank:
+    """Capabilities for station water tanks."""
+
+
 @dataclass(frozen=True, kw_only=True)
 class CapabilityStation:
     """Capabilities for the station."""
@@ -242,6 +247,7 @@ class CapabilityStation:
         auto_empty.Frequency,
     ]
     state: CapabilityEvent[StationEvent]
+    water_tank: CapabilityStationWaterTank | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/deebot_client/hardware/c8rj4y.py
+++ b/deebot_client/hardware/c8rj4y.py
@@ -18,7 +18,6 @@ from deebot_client.capabilities import (
     CapabilitySettings,
     CapabilitySetTypes,
     CapabilityStation,
-    CapabilityStationWaterTank,
     CapabilityStats,
     CapabilityWater,
     DeviceType,
@@ -268,7 +267,7 @@ def get_device_info() -> StaticDeviceInfo:
                     ),
                 ),
                 state=CapabilityEvent(StationEvent, [GetWorkState()]),
-                water_tank=CapabilityStationWaterTank(),
+                water_tank=CapabilityEvent(ErrorEvent, [GetError()]),
             ),
             stats=CapabilityStats(
                 clean=CapabilityEvent(StatsEvent, [GetStats()]),

--- a/deebot_client/hardware/c8rj4y.py
+++ b/deebot_client/hardware/c8rj4y.py
@@ -18,6 +18,7 @@ from deebot_client.capabilities import (
     CapabilitySettings,
     CapabilitySetTypes,
     CapabilityStation,
+    CapabilityStationWaterTank,
     CapabilityStats,
     CapabilityWater,
     DeviceType,
@@ -267,6 +268,7 @@ def get_device_info() -> StaticDeviceInfo:
                     ),
                 ),
                 state=CapabilityEvent(StationEvent, [GetWorkState()]),
+                water_tank=CapabilityStationWaterTank(),
             ),
             stats=CapabilityStats(
                 clean=CapabilityEvent(StatsEvent, [GetStats()]),

--- a/tests/hardware/test_init.py
+++ b/tests/hardware/test_init.py
@@ -260,6 +260,26 @@ async def test_capabilities_event_extraction(
         )
 
 
+@pytest.mark.parametrize(
+    ("class_", "supported"),
+    [
+        ("cuoipb", True),
+        ("qhe2o2", False),
+        ("yna5xi", False),
+        ("5xu9h3", False),
+    ],
+)
+async def test_station_water_tank_capability(class_: str, supported: bool) -> None:
+    """Test station water tank support without changing error refresh commands."""
+    info = await hardware.get_static_device_info(class_)
+    assert info is not None
+    capabilities = info.capabilities
+
+    station = capabilities.station
+    assert (station is not None and station.water_tank is not None) is supported
+    assert capabilities.get_refresh_commands(ErrorEvent) == [GetError()]
+
+
 async def test_all_models_loaded() -> None:
     """Test that all models can be loaded."""
     folder = Path(hardware.__file__).parent


### PR DESCRIPTION
## Proposed change

Add an explicit station water-tank capability so integrations can distinguish docks with known water-tank fault support from auto-empty-only stations.

The new optional `CapabilityStationWaterTank` marker is exposed through `CapabilityStation.water_tank`. It is enabled for the shared T50 Max Pro Omni hardware definition used by `cuoipb`, where clean-water and dirty-water tank faults have been verified.

The existing `ErrorEvent` capability and refresh commands remain unchanged. This is a support marker only; it does not introduce a new event source or guarantee continuous tank-level reporting.

## Motivation

Home Assistant PR home-assistant/core#181667 adds actionable binary sensors for dock water-tank faults. The initial implementation exposed those sensors on devices that have generic error, station, and robot water capabilities but lack clean/dirty dock tanks.

An explicit capability allows Home Assistant to gate the sensors correctly without maintaining model allow-lists or inferring tank support from unrelated capabilities.

## Verification

* Verified on T50 Max Pro Omni hardware class `cuoipb`:

  * Error `322`: clean-water tank empty or not installed.
  * Error `323`: dirty-water tank full or not installed.
* Added tests confirming the marker is present for `cuoipb` and absent for `qhe2o2`, `yna5xi`, and `5xu9h3`.
* Confirmed `ErrorEvent` refresh commands remain `[GetError()]`.
* Full hardware test file: 11 passed.
* Pre-commit checks, including Ruff and mypy, passed.

## Related PR

* Home Assistant Core: https://github.com/home-assistant/core/pull/181667
