### PR TITLE
Ignore unknown life span component types

### DIFF
--- a/deebot_client/commands/json/life_span.py
+++ b/deebot_client/commands/json/life_span.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from deebot_client.command import InitParam
 from deebot_client.events import LifeSpan, LifeSpanEvent
+from deebot_client.logging_filter import get_logger
 from deebot_client.message import HandlingResult, HandlingState, MessageBodyDataList
 
 from .common import ExecuteCommand, JsonCommandMqttP2P, JsonCommandWithMessageHandling
@@ -14,6 +15,8 @@ from .common import ExecuteCommand, JsonCommandMqttP2P, JsonCommandWithMessageHa
 if TYPE_CHECKING:
     from deebot_client.event_bus import EventBus
     from deebot_client.util import LST
+
+_LOGGER = get_logger(__name__)
 
 
 class GetLifeSpan(JsonCommandWithMessageHandling, MessageBodyDataList):
@@ -27,16 +30,22 @@ class GetLifeSpan(JsonCommandWithMessageHandling, MessageBodyDataList):
 
     @classmethod
     def _handle_body_data_list(
-        cls, event_bus: EventBus, data: list[dict[str, Any]]
+        cls, event_bus: EventBus, data: list[Any]
     ) -> HandlingResult:
         """Handle message->body->data and notify the correct event subscribers.
 
         :return: A message response
         """
         for component in data:
-            component_type = LifeSpan(component["type"])
-            left = int(component["left"])
-            total = int(component["total"])
+            try:
+                component_type = LifeSpan(component["type"])
+                left = int(component["left"])
+                total = int(component["total"])
+            except (KeyError, TypeError, ValueError):
+                # A missing, unknown or malformed component must not discard
+                # the whole batch.
+                _LOGGER.warning("Skipping life span component: %s", component)
+                continue
 
             if total <= 0:
                 raise ValueError("total not positive!")

--- a/tests/commands/json/test_life_span.py
+++ b/tests/commands/json/test_life_span.py
@@ -7,6 +7,7 @@ import pytest
 from deebot_client.commands.json import GetLifeSpan
 from deebot_client.commands.json.life_span import ResetLifeSpan
 from deebot_client.events import FirmwareEvent, LifeSpan, LifeSpanEvent
+from deebot_client.message import HandlingResult, HandlingState
 from tests.helpers import get_request_json, get_success_body
 
 from . import assert_command, assert_execute_command
@@ -195,6 +196,54 @@ from . import assert_command, assert_execute_command
             ),
             (LifeSpanEvent(LifeSpan.SEWAGE_BOX, 100.0, 3600),),
         ),
+        (
+            GetLifeSpan({LifeSpan.BRUSH}),
+            get_request_json(
+                get_success_body(
+                    [
+                        {"type": "brandNewComponent", "left": 1, "total": 2},
+                        {"type": "brush", "left": 17979, "total": 18000},
+                    ]
+                )
+            ),
+            (LifeSpanEvent(LifeSpan.BRUSH, 99.88, 17979),),
+        ),
+        (
+            GetLifeSpan({LifeSpan.BRUSH}),
+            get_request_json(
+                get_success_body(
+                    [
+                        {"left": 1, "total": 2},
+                        {"type": "brush", "left": 17979, "total": 18000},
+                    ]
+                )
+            ),
+            (LifeSpanEvent(LifeSpan.BRUSH, 99.88, 17979),),
+        ),
+        (
+            GetLifeSpan({LifeSpan.BRUSH}),
+            get_request_json(
+                get_success_body(
+                    [
+                        "not-a-dict",
+                        {"type": "brush", "left": 17979, "total": 18000},
+                    ]
+                )
+            ),
+            (LifeSpanEvent(LifeSpan.BRUSH, 99.88, 17979),),
+        ),
+        (
+            GetLifeSpan({LifeSpan.BRUSH}),
+            get_request_json(
+                get_success_body(
+                    [
+                        {"type": "brush", "left": 1},
+                        {"type": "brush", "left": 17979, "total": 18000},
+                    ]
+                )
+            ),
+            (LifeSpanEvent(LifeSpan.BRUSH, 99.88, 17979),),
+        ),
     ],
 )
 async def test_GetLifeSpan(
@@ -204,6 +253,20 @@ async def test_GetLifeSpan(
 ) -> None:
     json, firmware_event = data
     await assert_command(command, json, (firmware_event, *expected))
+
+
+async def test_GetLifeSpan_total_not_positive() -> None:
+    """A non-positive total is still reported as an error, not silently skipped."""
+    command = GetLifeSpan({LifeSpan.BRUSH})
+    json, firmware_event = get_request_json(
+        get_success_body([{"type": "brush", "left": 10, "total": 0}])
+    )
+    await assert_command(
+        command,
+        json,
+        (firmware_event,),
+        handling_result=HandlingResult(HandlingState.ERROR),
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`GetLifeSpan._handle_body_data_list` raises as soon as it meets a component it
cannot parse (most commonly a `type` that is not in the `LifeSpan` enum). The
exception is caught by `MessageBodyData` and becomes `HandlingState.ERROR`,
which discards the **entire** response — so one unrecognised component hides
every life-span value in that batch.

## Observed

`getLifeSpan` for the full component set on a DEEBOT X1 (class `1vxt52`) returns:

    {"code": 0, "msg": "ok", "data": [
      {"type": "sideBrush", "left": 5292,  "total": 9000},
      {"type": "brush",     "left": 14703, "total": 18000},
      {"type": "heap",      "left": 3851,  "total": 7200},
      {"type": "unitCare",  "left": 0,     "total": 1800},
      {"type": "dModule",   "left": 3600,  "total": 3600},
      {"type": "roundMop",  "left": 5668,  "total": 9000},
      {"type": "dustBag",   "left": 1186,  "total": 1500},
      {"type": "silverIon", "left": 7200,  "total": 7200},
      {"type": "doorSill",  "left": 7200,  "total": 7200},
      {"type": "strainer",  "left": 1800,  "total": 1800}]}

`silverIon` and `doorSill` are not members of `LifeSpan`, and parsing aborts:

    ValueError: 'silverIon' is not a valid LifeSpan

The same happens for any device that reports a component the library does not
model, without waiting for a new library release.

## Change

- In `GetLifeSpan._handle_body_data_list`, skip a component that cannot be
  parsed — unknown or missing `type`, a non-dict entry, or malformed
  `left`/`total` — logging a warning, instead of aborting the whole batch.
  This mirrors the existing "skip a bad entry" pattern in `GetCleanLogs`
  (`commands/json/clean_logs.py`).
- The existing `total <= 0` validation is deliberately left **outside** the
  skip: it still produces `HandlingState.ERROR` and is not treated as
  unknown/malformed.
- No new enum members here: `silverIon`/`doorSill` (and their XML names) cannot
  be verified from a JSON device, so they are skipped like any other unknown
  type and can be added to `LifeSpan` separately once confirmed.

## Verification

Ran against the live device through the same cloud/MQTT path the Home Assistant
integration uses, patched vs unpatched library, identical call:

- unpatched: `ValueError: 'silverIon' is not a valid LifeSpan`, **0** life-span
  events emitted for the batch
- patched: **8** life-span events emitted; `silverIon`/`doorSill` skipped with a
  warning

## Tests

- Parametrised cases — an unknown type, a missing `type`, a non-dict entry, and
  a malformed `left`/`total` (each placed *first*) are skipped while a following
  known component is still emitted (also distinguishes `continue` from `break`).
- `test_GetLifeSpan_total_not_positive`: pins that a non-positive `total` still
  yields `HandlingState.ERROR` (regression guard for the preserved path).
- `pytest tests/commands/json/test_life_span.py tests/events` → 82 passed.
- `ruff check` / `ruff format --check` clean.

## Notes

- The skip is logged at WARNING (consistent with `clean_logs.py`); `exc_info`
  is intentionally omitted, since an unrecognised component is expected input
  (a newer device) rather than corrupt data.
- The only remaining whole-batch failure is `total <= 0`, which is the existing
  intended behaviour.
